### PR TITLE
Make start and restart do the same thing.

### DIFF
--- a/challenge/vm/vm
+++ b/challenge/vm/vm
@@ -200,7 +200,7 @@ def main():
     commands = {
         "connect": lambda: (start(), connect()),
         "exec": lambda: (start(), exec_(args.exec_command, *args.exec_command_args)),
-        "start": lambda: start(),
+        "start": lambda: (stop(), start()),
         "stop": lambda: stop(),
         "restart": lambda: (stop(), start()),
         "debug": lambda: debug(),


### PR DESCRIPTION
As discussed, our usecase seems to need `start` to actually restart the VM...