### PR TITLE
rp++ 2.0 Beta is gone

### DIFF
--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -169,7 +169,7 @@ RUN git clone https://github.com/aquynh/capstone /opt/capstone && cd /opt/capsto
 RUN git clone --branch=5.1.0 --depth=1 https://github.com/radareorg/radare2 /opt/radare2 && cd /opt/radare2 && sys/install.sh
 RUN git clone https://github.com/aflplusplus/aflplusplus /opt/aflplusplus && cd /opt/aflplusplus && make distrib && make install
 RUN git clone https://github.com/yrp604/rappel /opt/rappel && cd /opt/rappel && make && cp bin/rappel /usr/bin/rappel
-RUN wget https://github.com/0vercl0k/rp/releases/download/v2-beta/rp-lin-x64 -O /usr/bin/rp++ && chmod +x /usr/bin/rp++
+RUN wget https://github.com/0vercl0k/rp/releases/download/v2.0.2/rp-lin-x64 -O /usr/bin/rp++ && chmod +x /usr/bin/rp++
 
 RUN pip install git+git://github.com/Gallopsled/pwntools.git#egg=pwntools jupyter angr r2pipe asteval psutil
 


### PR DESCRIPTION
rp++ v2.0.2 is released, which means the beta versions go away:
https://github.com/0vercl0k/rp/releases