### PR TITLE
install expect (specifically for unbuffer)

### DIFF
--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -88,7 +88,8 @@ RUN apt-get update && \
                        libc6:i386 \
                        libc6-dev-i386 \
                        libstdc++6:i386 \
-                       libncurses5:i386
+                       libncurses5:i386 \
+                       expect
 
 RUN yes | unminimize
 


### PR DESCRIPTION
unbuffer is a simple tool used for unbuffering piped messages, so a process can read a challenge output, parse it, and respond accordingly before the challenge terminates.