### PR TITLE
Support user-selectable ssh port (via env var) in run.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ git -C /opt/dojo submodule update --init --recursive
 ```
 
 Assuming you already have ssh running on port 22, you will want to change that so that users may ssh via port 22.
+Alternatively, you can set the `SSH_PORT` environment variable before running `run.sh` below.
 
 Change the line in `/etc/ssh/sshd_config` that says `Port 22` to `Port 2222`, and then restart ssh:
 ```sh

--- a/run.sh
+++ b/run.sh
@@ -17,7 +17,7 @@ docker run \
        --rm \
        --volume $PWD/data/docker:/var/lib/docker \
        --volume $PWD/data:/opt/pwn.college/data \
-       --publish 22:22 \
+       --publish ${SSH_PORT:-22}:22 \
        --publish 80:80 \
        --publish 443:443 \
        --env SETUP_HOSTNAME="$SETUP_HOSTNAME" \


### PR DESCRIPTION
This makes it easier to dev the dojo if you don't want to move ssh to a different port :-)