### PR TITLE
Allow KPTI to be disabled for vm challenges

### DIFF
--- a/challenge/vm/vm
+++ b/challenge/vm/vm
@@ -45,9 +45,17 @@ def extra_boot_flags():
     if args.nokaslr is not None:
         nokaslr = args.nokaslr
 
+    nopti = False
+    if os.path.exists("/challenge/.nopti"):
+        nopti = True
+
     result = []
     if nokaslr:
         result.append("nokaslr")
+
+    if nopti:
+        result.append("nopti")
+
     return result
 
 


### PR DESCRIPTION
KPTI is the Linux kernel's mitigation for meltdown, support configuring it for vm challenges in a similar way to KASLR to make meltdown challenges possible.