### PR TITLE
Change student icon check in scoreboard.py

### DIFF
--- a/dojo_plugin/api/v1/scoreboard.py
+++ b/dojo_plugin/api/v1/scoreboard.py
@@ -23,7 +23,7 @@ scoreboard_namespace = Namespace("scoreboard")
 def email_symbol_asset(email):
     if email.endswith("@asu.edu"):
         group = "fork.png"
-    elif email.endswith(".edu"):
+    elif ".edu" in email.split("@")[1]:
         group = "student.png"
     else:
         group = "hacker.png"


### PR DESCRIPTION
If an email has the format: `<name>@student.edu.<country>` or any other format where `.edu` is not at the end, then the email is not recognized as a student email. Probably broad but this is a simple fix.