### PR TITLE
challenge-full copy tools-apt last

### DIFF
--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -513,9 +513,9 @@ COPY --link --from=builder-busybox / /
 COPY --link --from=builder-glow / /
 COPY --link --from=builder-desktop-xfce / /
 COPY --link --from=builder-desktop-reversing-tools / /
-COPY --link --from=builder-tools-apt / /
 COPY --link --from=builder-gdb / /
 COPY --link --from=builder-tools-pip / /
+COPY --link --from=builder-tools-apt / /
 
 RUN cat >> /etc/ssh/ssh_config <<EOF
     StrictHostKeyChecking no


### PR DESCRIPTION
challenge COPY order overwrites /etc/alternatives resulting in unexpected defaults.  Copying builder-tools-apt last ensures /etc/alternatives from layer that installs expected defaults prevails.

Closes #218