### PR TITLE
make belts great again

### DIFF
--- a/dojo_plugin/api/v1/belts.py
+++ b/dojo_plugin/api/v1/belts.py
@@ -23,9 +23,9 @@ def get_belts():
         belted_users = (
             db.session.query(Users.id, Users.name, db.func.max(Solves.date))
             .join(Solves, Users.id == Solves.user_id)
-            .filter(Solves.challenge_id.in_(challenges.subquery()))
+            .filter(Solves.challenge_id.in_(challenges))
             .group_by(Users.id)
-            .having(db.func.count() == challenges.count())
+            .having(db.func.count() == len(challenges))
             .order_by(db.func.max(Solves.date))
         )
 
@@ -36,13 +36,14 @@ def get_belts():
                 "color": color,
             }
 
+    # Belt deadlines should just be changed with the next iteration of the course
     # TODO: support belt deadlines
-    for user_id, belt in list(result["users"].items()):
-        if belt["color"] == "yellow":
-            received = datetime.datetime.fromisoformat(result["dates"]["yellow"][user_id])
-            if received > datetime.datetime.fromisoformat("2022-10-01"):
-                del result["users"][user_id]
-                del result["dates"]["yellow"][user_id]
+    # for user_id, belt in list(result["users"].items()):
+    #     if belt["color"] == "yellow":
+    #         received = datetime.datetime.fromisoformat(result["dates"]["yellow"][user_id])
+    #         if received > datetime.datetime.fromisoformat("2022-10-01"):
+    #             del result["users"][user_id]
+    #             del result["dates"]["yellow"][user_id]
 
     return result
 

--- a/dojo_plugin/api/v1/scoreboard.py
+++ b/dojo_plugin/api/v1/scoreboard.py
@@ -37,6 +37,8 @@ def belt_asset(color):
         belt = "blue.svg"
     elif color == "yellow":
         belt = "yellow.svg"
+    elif color == "orange":
+        belt = "orange.svg"
     else:
         belt = "white.svg"
     return url_for("views.themes", path=f"img/dojo/{belt}")

--- a/dojo_plugin/pages/users.py
+++ b/dojo_plugin/pages/users.py
@@ -12,7 +12,8 @@ from CTFd.cache import cache
 
 from ..models import Dojos, DojoModules, DojoChallenges
 from ..utils import DATA_DIR
-
+from ..api.v1.belts import get_belts
+from ..api.v1.scoreboard import belt_asset
 
 users = Blueprint("pwncollege_users", __name__)
 
@@ -29,7 +30,9 @@ def view_hacker(user):
         max_rank = len(rankings)
         return user_rank, max_rank
 
-    return render_template("hacker.html", dojos=dojos, user=user, ranking=ranking)
+    info = get_belts()["users"].get(user.id)
+    belt = belt_asset(info["color"] if info else "white")
+    return render_template("hacker.html", dojos=dojos, user=user, ranking=ranking, belt=belt)
 
 @users.route("/hacker/<int:user_id>")
 def view_other(user_id):

--- a/dojo_plugin/utils/__init__.py
+++ b/dojo_plugin/utils/__init__.py
@@ -365,40 +365,17 @@ def daily_solve_counts():
 def belt_challenges():
     # TODO: move this concept into dojo yml
 
-    yellow_categories = [
-        "embryoio",
-        "babysuid",
-        "embryoasm",
-        "babyshell",
-        "babyjail",
-        "embryogdb",
-        "babyrev",
-        "babymem",
-        "toddlerone",
-    ]
-
-    blue_categories = [
-        *yellow_categories,
-        "babyrop",
-        "babyheap",
-        "babyrace",
-        "babykernel",
-        "toddlertwo",
-    ]
-
-    color_categories = {
-        "yellow": yellow_categories,
-        "blue": blue_categories,
-    }
-
+    orange_challenges = {challenge.challenge_id for challenge in Dojos.query.filter_by(name="CSE 365 - Spring 2023").first().challenges}
+    yellow_challenges = {challenge.challenge_id for challenge in Dojos.query.filter_by(name="CSE 466 - Fall 2022").first().challenges}
+    blue_challenges = {challenge.challenge_id for challenge in Dojos.query.filter_by(name="CSE 494 - Spring 2023").first().challenges}
+    
     return {
-        color: db.session.query(Challenges.id).filter(
-            Challenges.state == "visible",
-            Challenges.value > 0,
-            Challenges.id < 1000,
-            Challenges.category.in_(categories),
-        )
-        for color, categories in color_categories.items()
+        "orange":
+        orange_challenges,
+        "yellow":
+        orange_challenges + yellow_challenges,
+        "blue":
+        orange_challenges + yellow_challenges + blue_challenges,
     }
 
 # based on https://stackoverflow.com/questions/36408496/python-logging-handler-to-append-to-list

--- a/dojo_plugin/utils/__init__.py
+++ b/dojo_plugin/utils/__init__.py
@@ -373,9 +373,9 @@ def belt_challenges():
         "orange":
         orange_challenges,
         "yellow":
-        orange_challenges + yellow_challenges,
+        orange_challenges | yellow_challenges,
         "blue":
-        orange_challenges + yellow_challenges + blue_challenges,
+        orange_challenges | yellow_challenges | blue_challenges,
     }
 
 # based on https://stackoverflow.com/questions/36408496/python-logging-handler-to-append-to-list


### PR DESCRIPTION
I can't test the inner workings in detail so there might be some bugs but this *should* allow belts to be shown on profiles. The challenges are pulled in one go from the course dojos which made more sense to me rather than lists of "required belt modules". That way:
- 365->orange
- 365+466->yellow
- 365+466+494->blue
is more clear.