### PR TITLE
Grades page - round course grade % to 4 digits in calculation

### DIFF
--- a/dojo_plugin/pages/course.py
+++ b/dojo_plugin/pages/course.py
@@ -176,6 +176,7 @@ def grade(dojo, users_query, *, ignore_pending=False):
             sum(grade["credit"] for grade in grades if "weight" not in grade)
         )
         overall_grade += extra_credit
+        overall_grade = round(overall_grade, 4)
         letter_grade = get_letter_grade(dojo, overall_grade)
 
         return dict(user_id=user_id,


### PR DESCRIPTION
Overall grades stored as unrounded floats in calculation can result in incorrect letter grade / percent combination displaying.  The displayed overall course percentage can round up (to four digits), but the grade cutoff comparisons will not.  Rounding the number prior to grade cutoff comparisons addresses this, assuming the value can be accurately stored as float.