### PR TITLE
Display per-dojo solve count on dojos page

### DIFF
--- a/discord_bot/Dockerfile
+++ b/discord_bot/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-buster
+FROM python:3.10-slim-buster
 
 RUN pip install discord-py sqlalchemy pandas PyMySQL
 

--- a/discord_bot/bot.py
+++ b/discord_bot/bot.py
@@ -74,6 +74,8 @@ async def on_ready():
                                           if channel.category and channel.category.name.lower() == "logs" and channel.name == "liked-memes")
     client.attendance_log_channel = next(channel for channel in client.guild.channels
                                          if channel.category and channel.category.name.lower() == "logs" and channel.name == "attendance")
+    client.belting_ceremony_channel = next(channel for channel in client.guild.channels
+                                         if channel.category and channel.category.name.lower() == "the dojo" and channel.name == "belting-ceremony")
     client.voice_state_history = collections.defaultdict(list)
     run_daily(daily_attendance, "17:20:00-07:00")
     run_daily(check_belts, "18:00:00-07:00")
@@ -285,6 +287,9 @@ class Belt(Enum):
             case _:
                 return 0
 
+async def announce_belting(member, belt: Belt):
+    belt_message = await client.belting_ceremony_channel.send(content=f"{member.mention} has earned their {belt.get_role()}! :tada:")
+    return belt_message
 
 async def check_belts():
     now = datetime.datetime.now()
@@ -324,6 +329,7 @@ async def check_belts():
                 now = datetime.datetime.now()
                 print(f"Awarding {belt.get_role()} to {member.display_name} @ {now}")
                 await member.add_roles(role)
+                await announce_belting(member, belt)
 
     await check_belt(Belt.ORANGE)
     await check_belt(Belt.YELLOW)

--- a/dojo_theme/templates/dojos.html
+++ b/dojo_theme/templates/dojos.html
@@ -12,7 +12,7 @@
     <h2>{{ type | title }}</h2>
     <ul class="card-list">
       {% for dojo in dojos %}
-        {{ card(url_for("pwncollege_dojos.view_dojo", dojo=dojo.reference_id), dojo.name, "{} Modules".format(dojo.modules | length)) }}
+      {{ card(url_for("pwncollege_dojos.view_dojo", dojo=dojo.reference_id), dojo.name, "{} Modules : ".format(dojo.modules | length) + "{} / {}".format(dojo.solves(user=user, ignore_visibility=True, ignore_admins=False).count(), dojo.challenges | length)) }}
       {% endfor %}
 
       {% if type == "More" %}


### PR DESCRIPTION
Users should be able to tell which dojos contain unsolved challenges at a glance.  This isn't necessarily the prettiest, but it  displays this information.