### PR TITLE
Add per-dojo solve count to dojos page

### DIFF
--- a/dojo_theme/templates/dojos.html
+++ b/dojo_theme/templates/dojos.html
@@ -12,7 +12,7 @@
     <h2>{{ type | title }}</h2>
     <ul class="card-list">
       {% for dojo in dojos %}
-        {{ card(url_for("pwncollege_dojos.view_dojo", dojo=dojo.reference_id), dojo.name, "{} Modules".format(dojo.modules | length)) }}
+      {{ card(url_for("pwncollege_dojos.view_dojo", dojo=dojo.reference_id), dojo.name, "{} Modules : ".format(dojo.modules | length) + "{} / {}".format(dojo.solves(user=user, ignore_visibility=True, ignore_admins=False).count(), dojo.challenges | length)) }}
       {% endfor %}
 
       {% if type == "More" %}


### PR DESCRIPTION
Users should be able to identify dojos with unsolved challenges at a glance on the dojos page.  This may not be the prettiest, but it displays that information.