### PR TITLE
vm start - source challenge specific initvm

### DIFF
--- a/challenge/vm/init
+++ b/challenge/vm/init
@@ -34,17 +34,8 @@ find /challenge -name '*.ko' -exec /usr/sbin/insmod {} \;
 
 service ssh start
 
-# Note: This currently only works on custom challenge images
-if [ -e /challenge/.docker ]; then
-	# /var/lib/docker needs to be ext4 in order to use overlayfs
-	dd if=/dev/zero of=/tmp/data bs=1M count=0 seek=2000
-	yes | mkfs.ext4 -O ^has_journal /tmp/data
-	mount /tmp/data -o X-mount.mkdir /var/lib/docker
-
-	# get my cgroup mounts into /sys/fs/cgroup
-	cgroupfs-mount
-
-	sudo dockerd > /dev/null 2>&1 &
+if [ -e /challenge/.initvm ]; then
+	. /challenge/.initvm
 fi
 
 if [ -e /usr/sbin/docker-init ]; then


### PR DESCRIPTION
Substitute challenge or dojo specific VM init instructions for a challenge defined .initvm file that can be sourced by the vm's default init script if present.