### PR TITLE
[WIP] Improve performance of dojo/module ranking using Redis cacheing

### DIFF
--- a/dojo_plugin/api/v1/dojo.py
+++ b/dojo_plugin/api/v1/dojo.py
@@ -22,7 +22,7 @@ from CTFd.utils.modes import get_model
 from CTFd.utils.security.sanitize import sanitize_html
 
 from ...models import Dojos, DojoMembers, DojoAdmins
-from ...utils.dojo import dojo_accessible, dojo_clone, load_dojo_dir
+from ...utils.dojo import dojo_accessible, dojo_clone, load_dojo_dir, dojo_route
 
 
 dojo_namespace = Namespace(
@@ -88,3 +88,32 @@ class CreateDojo(Resource):
         private_key = data.get("private_key", "").replace("\r\n", "\n")
 
         return create_dojo(user, repository, public_key, private_key)
+
+
+@dojo_namespace.route("/<dojo>/modules")
+class GetDojoModules(Resource):
+    @dojo_route
+    def get(self, dojo):
+        modules = [{'id': module.id,
+                    'module_index': module.module_index,
+                    'name': module.name,
+                    'description': module.description,
+                    } for module in dojo.modules]
+
+        return {"success": True, "modules": modules}
+
+
+@dojo_namespace.route("/<dojo>/<module>/challenges")
+class GetDojoModuleChallenges(Resource):
+    @dojo_route
+    def get(self, dojo, module):
+        challenges = [{'id': challenge.id,
+                       'challenge_id': challenge.challenge_id,
+                       'module_index': challenge.module_index,
+                       'challenge_index': challenge.challenge_index,
+                       'name': challenge.name,
+                       'description': challenge.description,
+                       } for challenge in module.visible_challenges()]
+
+        return {"success": True, "challenges": challenges}
+

--- a/dojo_plugin/utils/__init__.py
+++ b/dojo_plugin/utils/__init__.py
@@ -26,8 +26,6 @@ from CTFd.utils.security.sanitize import sanitize_html
 from sqlalchemy import String, Integer
 from sqlalchemy.sql import or_
 
-REDIS_SCOREBOARD_CACHE_TIMEOUT_SECONDS = 60 * 60 * 2 # two hours make to cache all scoreboards
-
 ID_REGEX = "^[A-Za-z0-9_.-]+$"
 def id_regex(s):
     return re.match(ID_REGEX, s) and ".." not in s

--- a/dojo_plugin/utils/__init__.py
+++ b/dojo_plugin/utils/__init__.py
@@ -14,8 +14,8 @@ import pytz
 import os
 import re
 
-import docker
 import bleach
+import docker
 from flask import current_app, Response, Markup, abort, g
 from itsdangerous.url_safe import URLSafeSerializer
 from CTFd.models import db, Solves, Challenges, Users
@@ -26,6 +26,7 @@ from CTFd.utils.security.sanitize import sanitize_html
 from sqlalchemy import String, Integer
 from sqlalchemy.sql import or_
 
+REDIS_SCOREBOARD_CACHE_TIMEOUT_SECONDS = 60 * 60 * 2 # two hours make to cache all scoreboards
 
 ID_REGEX = "^[A-Za-z0-9_.-]+$"
 def id_regex(s):
@@ -360,6 +361,5 @@ class HTMLHandler(logging.Handler): # Inherit from logging.Handler
         if self.html:
             self.html += self.join_tag
         self.html += f"{self.start_tag}<b>{record.levelname}</b>: {sanitize_html(record.getMessage())}{self.end_tag}"
-
 
 from ..models import Dojos, DojoMembers, DojoAdmins, DojoChallenges

--- a/test/test_running.py
+++ b/test/test_running.py
@@ -189,3 +189,66 @@ def test_workspace_practice_challenge(random_user):
         workspace_run("sudo -v", user=user)
     except subprocess.CalledProcessError as e:
         assert False, f"Expected sudo to succeed, but got: {(e.stdout, e.stderr)}"
+
+
+def get_all_standings(session, dojo):
+    """
+    Return a big list of all the standings, going through all the available pages.
+    """
+    to_return = []
+
+    page_number = 1
+    done = False
+
+    while not done:
+        response = session.get(f"{PROTO}://{HOST}/pwncollege_api/v1/scoreboard/{dojo}/_/0/{page_number}")
+        assert response.status_code == 200, f"Expected status code 200, but got {response.status_code}"
+        response = response.json()
+
+        to_return.extend(response["standings"])
+
+        next_page = page_number + 1
+
+        if next_page in response["pages"]:
+            page_number += 1
+        else:
+            done = True
+
+    return to_return
+
+
+@pytest.mark.dependency(depends=["test_workspace_challenge"])
+def test_scoreboard(random_user):
+    user, session = random_user
+
+    dojo = "example"
+
+    prior_standings = get_all_standings(session, dojo)
+
+    # if test_workspace_challenge passed correctly, then we should get a valid flag here
+    result = workspace_run("/challenge/apple", user=user)
+    flag = result.stdout.strip()
+
+    # submit the flag
+    data = {"challenge_id": "blah",
+            "submission": flag}
+    response = session.post(f"{PROTO}://{HOST}/api/v1/challenges/attempt", data=data)
+    assert response.status_code == 200, f"Expected status code 200, but got {response.status_code}"
+    assert response.json()["success"], f"Expected to successfully submit flag"
+
+    # check the scoreboard: is it updated?
+
+    new_standings = get_all_standings(session, dojo)
+    assert len(prior_standings) != len(new_standings), "Expected to have a new entry in the standings"
+
+    found_me = False
+    for standing in new_standings:
+        if standing['name'] == user:
+            found_me = True
+            break
+    assert found_me, f"Unable to find new user {user} in new standings after solving a challenge"
+    
+    
+    
+
+

--- a/test/test_running.py
+++ b/test/test_running.py
@@ -226,6 +226,7 @@ def test_scoreboard(random_user):
     prior_standings = get_all_standings(session, dojo)
 
     # if test_workspace_challenge passed correctly, then we should get a valid flag here
+    start_challenge("example", "hello", "apple", session=session)
     result = workspace_run("/challenge/apple", user=user)
     flag = result.stdout.strip()
 

--- a/test/test_running.py
+++ b/test/test_running.py
@@ -208,8 +208,6 @@ def get_all_standings(session, dojo, module=None):
         assert response.status_code == 200, f"Expected status code 200, but got {response.status_code}"
         response = response.json()
 
-        print(f"{response=}")
-
         to_return.extend(response["standings"])
 
         next_page = page_number + 1
@@ -232,8 +230,6 @@ def test_scoreboard(random_user):
 
     prior_standings = get_all_standings(session, dojo, module)
 
-    print(f"{prior_standings=}")
-
     # get the challenge_id from the dojo API so we can submit the flag
     response = session.get(f"{PROTO}://{HOST}/pwncollege_api/v1/dojo/{dojo}/{module}/challenges")
     assert response.status_code == 200, f"Expected status code 200, but got {response.status_code}"
@@ -251,21 +247,18 @@ def test_scoreboard(random_user):
     result = workspace_run("/challenge/apple", user=user)
     flag = result.stdout.strip()
 
-    print(f"{flag=}")
     # submit the flag
     data = {"challenge_id": challenge_id,
             "submission": flag}
-    print(f"{data=}")
+
     response = session.post(f"{PROTO}://{HOST}/api/v1/challenges/attempt",
                             json=data)
-    print(f"{response=} {response.json()=}")
     assert response.status_code == 200, f"Expected status code 200, but got {response.status_code}"
     assert response.json()["success"], f"Expected to successfully submit flag"
 
     # check the scoreboard: is it updated?
 
     new_standings = get_all_standings(session, dojo, module)
-    print(f"{new_standings=}")
     assert len(prior_standings) != len(new_standings), "Expected to have a new entry in the standings"
 
     found_me = False


### PR DESCRIPTION
Initial implementation. 

Remaining tasks:

- [x] Fetch all the ranking for the dojo/module, and use redis to store the results.
- [x] Invalidate cache when user account is updated
- [x] Invalidate cache when correct solve is made
- [x] Invalidate cache when updating/modifying a dojo
- [x] Create tests.