### PR TITLE
Enable easy public dojos

### DIFF
--- a/dojo_plugin/api/v1/dojo.py
+++ b/dojo_plugin/api/v1/dojo.py
@@ -83,12 +83,12 @@ class PruneAwards(Resource):
     def post(self, dojo):
         all_completions = set(user for user,_ in dojo.completions())
         num_pruned = 0
-        for award in Emojis.query.where(Emojis.category==dojo.reference_id):
+        for award in Emojis.query.where(Emojis.category==dojo.hex_dojo_id):
             if award.user not in all_completions:
                 num_pruned += 1
                 db.session.delete(award)
         db.session.commit()
-        return {"success": True, "pruned_awards": num_pruned, "all_completions": str(all_completions)}
+        return {"success": True, "pruned_awards": num_pruned}
 
 @dojo_namespace.route("/<dojo>/promote-admin")
 class PromoteAdmin(Resource):

--- a/dojo_plugin/api/v1/dojo.py
+++ b/dojo_plugin/api/v1/dojo.py
@@ -78,8 +78,8 @@ def create_dojo(user, repository, public_key, private_key):
 @dojo_namespace.route("/<dojo>/prune-awards")
 class PruneAwards(Resource):
     @authed_only
-    @dojo_admin
     @dojo_route
+    @dojo_admin
     def post(self, dojo):
         all_completions = set(user for user,_ in dojo.completions())
         num_pruned = 0
@@ -93,8 +93,8 @@ class PruneAwards(Resource):
 @dojo_namespace.route("/<dojo>/promote-admin")
 class PromoteAdmin(Resource):
     @authed_only
-    @dojo_admin
     @dojo_route
+    @dojo_admin
     def post(self, dojo):
         data = request.get_json()
         if 'user_id' not in data:

--- a/dojo_plugin/api/v1/dojo.py
+++ b/dojo_plugin/api/v1/dojo.py
@@ -75,6 +75,21 @@ def create_dojo(user, repository, public_key, private_key):
 
     return {"success": True, "dojo": dojo.reference_id}
 
+@dojo_namespace.route("/<dojo>/prune-awards")
+class PruneAwards(Resource):
+    @authed_only
+    @dojo_admin
+    @dojo_route
+    def post(self, dojo):
+        all_completions = set(user for user,_ in dojo.completions())
+        num_pruned = 0
+        for award in Emojis.query.where(Emojis.category==dojo.reference_id):
+            if award.user not in all_completions:
+                num_pruned += 1
+                db.session.delete(award)
+        db.session.commit()
+        return {"success": True, "pruned_awards": num_pruned, "all_completions": str(all_completions)}
+
 @dojo_namespace.route("/<dojo>/promote-admin")
 class PromoteAdmin(Resource):
     @authed_only

--- a/dojo_plugin/api/v1/dojo.py
+++ b/dojo_plugin/api/v1/dojo.py
@@ -21,8 +21,8 @@ from CTFd.utils.user import get_current_user, is_admin
 from CTFd.utils.modes import get_model
 from CTFd.utils.security.sanitize import sanitize_html
 
-from ...models import Dojos, DojoMembers, DojoAdmins, DojoUsers
-from ...utils.dojo import dojo_accessible, dojo_clone, load_dojo_dir, dojo_route
+from ...models import Dojos, DojoMembers, DojoAdmins, DojoUsers, Emojis
+from ...utils.dojo import dojo_accessible, dojo_clone, load_dojo_dir, dojo_route, dojo_admin
 
 
 dojo_namespace = Namespace(
@@ -78,15 +78,13 @@ def create_dojo(user, repository, public_key, private_key):
 @dojo_namespace.route("/<dojo>/promote-admin")
 class PromoteAdmin(Resource):
     @authed_only
+    @dojo_admin
     @dojo_route
     def post(self, dojo):
         data = request.get_json()
         if 'user_id' not in data:
             return {"success": False, "error": "User not specified."}, 400
         new_admin_id = data['user_id']
-        user = get_current_user()
-        if not dojo.is_admin(user):
-            return {"success": False, "error": "Requestor is not a dojo admin."}, 403
         u = DojoUsers.query.filter_by(dojo=dojo, user_id=new_admin_id).first()
         if u:
             u.type = 'admin'

--- a/dojo_plugin/api/v1/dojo.py
+++ b/dojo_plugin/api/v1/dojo.py
@@ -22,7 +22,7 @@ from CTFd.utils.modes import get_model
 from CTFd.utils.security.sanitize import sanitize_html
 
 from ...models import Dojos, DojoMembers, DojoAdmins, DojoUsers, Emojis
-from ...utils.dojo import dojo_accessible, dojo_clone, load_dojo_dir, dojo_route, dojo_admin
+from ...utils.dojo import dojo_accessible, dojo_clone, load_dojo_dir, dojo_route, dojo_admins_only
 
 
 dojo_namespace = Namespace(
@@ -79,7 +79,7 @@ def create_dojo(user, repository, public_key, private_key):
 class PruneAwards(Resource):
     @authed_only
     @dojo_route
-    @dojo_admin
+    @dojo_admins_only
     def post(self, dojo):
         all_completions = set(user for user,_ in dojo.completions())
         num_pruned = 0
@@ -94,7 +94,7 @@ class PruneAwards(Resource):
 class PromoteAdmin(Resource):
     @authed_only
     @dojo_route
-    @dojo_admin
+    @dojo_admins_only
     def post(self, dojo):
         data = request.get_json()
         if 'user_id' not in data:

--- a/dojo_plugin/api/v1/scoreboard.py
+++ b/dojo_plugin/api/v1/scoreboard.py
@@ -91,7 +91,7 @@ def get_scoreboard_page(model, duration=None, page=1, per_page=20):
     pagination = Pagination(None, page, per_page, len(results), results[start_idx:end_idx])
     user = get_current_user()
 
-    viewable_dojos = { dojo.reference_id for dojo in Dojos.viewable(user=user) }
+    viewable_dojos = { dojo.hex_dojo_id:dojo for dojo in Dojos.viewable(user=user) }
     emojis = { }
     for emoji in Emojis.query.order_by(Emojis.date).all():
         if emoji.category not in viewable_dojos:
@@ -101,7 +101,7 @@ def get_scoreboard_page(model, duration=None, page=1, per_page=20):
             "text": emoji.description,
             "emoji": emoji.name,
             "count": 1,
-            "url": url_for("pwncollege_dojo.listing", dojo=emoji.category)
+            "url": url_for("pwncollege_dojo.listing", dojo=viewable_dojos[emoji.category])
         })
 
     def standing(item):

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -185,6 +185,7 @@ class Dojos(db.Model):
         return (
             (cls.from_id(id) if id is not None else cls.query)
             .filter(or_(cls.official,
+                        and_(cls.data["type"] == "public", cls.password == None),
                         cls.dojo_id.in_(db.session.query(DojoUsers.dojo_id)
                                         .filter_by(user=user)
                                         .subquery())))

--- a/dojo_plugin/utils/awards.py
+++ b/dojo_plugin/utils/awards.py
@@ -40,7 +40,7 @@ def get_user_emojis(user):
         if not emoji:
             continue
         if dojo.completed(user):
-            emojis.append((emoji, dojo.name, dojo.reference_id))
+            emojis.append((emoji, dojo.name, dojo.hex_dojo_id))
     return emojis
 
 def get_belts():

--- a/dojo_plugin/utils/dojo/__init__.py
+++ b/dojo_plugin/utils/dojo/__init__.py
@@ -362,7 +362,7 @@ def dojo_accessible(id):
         return Dojos.from_id(id).first()
     return Dojos.viewable(id=id, user=get_current_user()).first()
 
-def dojo_admin(func):
+def dojo_admins_only(func):
     signature = inspect.signature(func)
     @functools.wraps(func)
     def wrapper(*args, **kwargs):

--- a/dojo_plugin/utils/dojo/__init__.py
+++ b/dojo_plugin/utils/dojo/__init__.py
@@ -362,6 +362,18 @@ def dojo_accessible(id):
         return Dojos.from_id(id).first()
     return Dojos.viewable(id=id, user=get_current_user()).first()
 
+def dojo_admin(func):
+    signature = inspect.signature(func)
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        bound_args = signature.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+
+        dojo = bound_args.arguments["dojo"]
+        if not dojo.is_admin(get_current_user()):
+            abort(403)
+        return func(*bound_args.args, **bound_args.kwargs)
+    return wrapper
 
 def dojo_route(func):
     signature = inspect.signature(func)

--- a/dojo_theme/static/js/dojo/settings.js
+++ b/dojo_theme/static/js/dojo/settings.js
@@ -51,6 +51,9 @@ $(() => {
         var user_name = form.find(`#name-for-${params["user_id"]}`)
         return `Promote ${user_name.text()} (UID ${params["user_id"]}) to admin?`;
     });
+    form_fetch_and_show("dojo-award-prune", `/pwncollege_api/v1/dojo/${init.dojo}/prune-awards`, "POST", "Legacy awards have been pruned.", confirm_msg = (form, params) => {
+        return `Prune all awarded emoji based on updated completion requirements?`;
+    });
 
     $(".copy-button").click((event) => {
         let input = $(event.target).parents(".input-group").children("input")[0];

--- a/dojo_theme/templates/dojo_admin.html
+++ b/dojo_theme/templates/dojo_admin.html
@@ -46,6 +46,14 @@
             </figure>
           </div>
         {% endif %}
+      <br>
+      <form method="post" id="dojo-award-prune-form" autocomplete="off">
+        <div class="form-group">
+          <input class="btn btn-mini btn-primary" id="_submit" name="_submit" type="submit" value="Prune Legacy Emoji Awards">
+        </div>
+        <div id="dojo-award-prune-results" class="form-group">
+        </div>
+      </form>
     </div>
     <b style="font-family: 'Courier New', Courier, monospace">Reference ID: </b><code>{{ dojo.reference_id }}</code>
     <br>

--- a/dojo_theme/templates/dojos.html
+++ b/dojo_theme/templates/dojos.html
@@ -10,6 +10,13 @@
 <div class="container">
   {% for type, dojos in typed_dojos.items() %}
     <h2>{{ type | title }}</h2>
+    {% if type == "Topics" %}
+    <p>These dojos form the official the pwn.college curriculum. We recommend that you tackle them in order. Good luck!</p>
+    {% elif type == "Courses" %}
+    <p>We run a number of courses on this platform. For the most part, these courses import the above material, though some might introduce new concepts and challenges.</p>
+    {% elif type == "More" %}
+    <p>This section contains public dojos created by the pwn.college community. Completing these dojos will grant you emoji badges!</p>
+    {% endif %}
     <ul class="card-list">
       {% for dojo in dojos %}
       {{ card(url_for("pwncollege_dojos.view_dojo", dojo=dojo.reference_id),

--- a/dojo_theme/templates/dojos.html
+++ b/dojo_theme/templates/dojos.html
@@ -22,7 +22,8 @@
       {{ card(url_for("pwncollege_dojos.view_dojo", dojo=dojo.reference_id),
       title=dojo.name,
       text="{} Modules : ".format(dojo.modules | length) + "{} / {}".format(dojo.solves(user=user, ignore_visibility=True, ignore_admins=False).count() if user else 0, dojo.challenges | length),
-      icon="/themes/dojo_theme/static/img/dojo/{}.svg".format(dojo.award.belt) if (dojo.award.belt and dojo.official) else None) }}
+      icon="/themes/dojo_theme/static/img/dojo/{}.svg".format(dojo.award.belt) if (dojo.award.belt and dojo.official) else None,
+      emoji=dojo.award.emoji ) }}
       {% endfor %}
 
       {% if type == "More" %}

--- a/dojo_theme/templates/macros/widgets.html
+++ b/dojo_theme/templates/macros/widgets.html
@@ -16,13 +16,16 @@
 </li>
 {% endmacro %}
 
-{% macro card(url, title=None, text=None, icon=None, custom=False) -%}
+{% macro card(url, title=None, text=None, icon=None, emoji=None, custom=False) -%}
   <a class="text-decoration-none" href="{{ url }}">
     <li class="card card-small">
       <div class="card-body">
         {% if title %}<h4 class="card-title">{{ title }}</h4>{% endif %}
         {% if text %}<p class="card-text">{{ text }}</p>{% endif %}
-        {% if icon %}<img class="card-icon" src={{ icon }}>{% endif %}
+        <div class="card-icon">
+          {% if icon %}<img src={{ icon }}>{% endif %}
+          {% if emoji %}<big>{{ emoji }}</big>{% endif %}
+        </div>
         {% if custom %}{{ caller() }}{% endif %}
       </div>
     </li>

--- a/test/test_running.py
+++ b/test/test_running.py
@@ -163,13 +163,12 @@ def test_promote_dojo_member(admin_session, singleton_user):
 
 @pytest.mark.dependency(depends=["test_join_dojo"])
 def test_prune_dojo_awards(admin_session, singleton_user, example_dojo_rid):
-    db_sql(f"INSERT into awards (type,category,user_id,name) values ('emoji', '{example_dojo_rid}', {get_user_id(singleton_user[0])}, 'test')")
-    assert int(db_sql_one(f"SELECT count(*) from awards where category='{example_dojo_rid}'")) == 1
-    response = admin_session.post(f"{PROTO}://{HOST}/pwncollege_api/v1/dojo/{example_dojo_rid}/prune-awards", json={})
+    example_hex_id = example_dojo_rid.split("~")[-1]
+    db_sql(f"INSERT into awards (type,category,user_id,name) values ('emoji', '{example_hex_id}', {get_user_id(singleton_user[0])}, 'test')")
+    assert int(db_sql_one(f"SELECT count(*) from awards where category='{example_hex_id}'")) == 1
+    response = admin_session.post(f"{PROTO}://{HOST}/pwncollege_api/v1/dojo/example/prune-awards", json={})
     assert response.status_code == 200
-    print(response.json())
-    print(db_sql("SELECT * from awards"))
-    assert int(db_sql_one(f"SELECT count(*) from awards where category='{example_dojo_rid}'")) == 0
+    assert int(db_sql_one(f"SELECT count(*) from awards where category='{example_hex_id}'")) == 0
 
 @pytest.mark.dependency(depends=["test_start_challenge"])
 @pytest.mark.parametrize("path", ["/flag", "/challenge/apple"])

--- a/test/test_running.py
+++ b/test/test_running.py
@@ -161,6 +161,16 @@ def test_promote_dojo_member(admin_session, singleton_user):
     response = admin_session.get(f"{PROTO}://{HOST}/dojo/example/admin/")
     assert random_user_name in response.text and response.text.index("Members") > response.text.index(random_user_name)
 
+@pytest.mark.dependency(depends=["test_join_dojo"])
+def test_prune_dojo_awards(admin_session, singleton_user, example_dojo_rid):
+    db_sql(f"INSERT into awards (type,category,user_id,name) values ('emoji', '{example_dojo_rid}', {get_user_id(singleton_user[0])}, 'test')")
+    assert int(db_sql_one(f"SELECT count(*) from awards where category='{example_dojo_rid}'")) == 1
+    response = admin_session.post(f"{PROTO}://{HOST}/pwncollege_api/v1/dojo/{example_dojo_rid}/prune-awards", json={})
+    assert response.status_code == 200
+    print(response.json())
+    print(db_sql("SELECT * from awards"))
+    assert int(db_sql_one(f"SELECT count(*) from awards where category='{example_dojo_rid}'")) == 0
+
 @pytest.mark.dependency(depends=["test_start_challenge"])
 @pytest.mark.parametrize("path", ["/flag", "/challenge/apple"])
 def test_workspace_path_exists(path):


### PR DESCRIPTION
This PR:

1. Shows `type: public` dojos under "More" and makes them fully visible.
2. Shows emoji awards on dojos with emoji awards.
3. Adds explanatory text on pwn.college/dojos
4. Adds functionality to prune stale emoji awards (triggerable by dojo admins).