### PR TITLE
Bring back the hacker profiles

### DIFF
--- a/dojo_plugin/pages/users.py
+++ b/dojo_plugin/pages/users.py
@@ -13,6 +13,7 @@ from CTFd.cache import cache
 from ..models import Dojos, DojoModules, DojoChallenges
 from ..config import DATA_DIR
 from ..utils.scores import dojo_scores, module_scores
+from ..utils.awards import get_belts, get_viewable_emojis
 
 
 users = Blueprint("pwncollege_users", __name__)
@@ -21,7 +22,12 @@ users = Blueprint("pwncollege_users", __name__)
 def view_hacker(user):
     dojos = Dojos.query.where(or_(Dojos.official, Dojos.data["type"] == "public")).all()
 
-    return render_template("hacker.html", dojos=dojos, user=user, dojo_scores=dojo_scores(), module_scores=module_scores())
+    return render_template(
+        "hacker.html",
+        dojos=dojos, user=user,
+        dojo_scores=dojo_scores(), module_scores=module_scores(),
+        belts=get_belts(), badges=get_viewable_emojis(user)
+    )
 
 @users.route("/hacker/<int:user_id>")
 def view_other(user_id):

--- a/dojo_plugin/pages/users.py
+++ b/dojo_plugin/pages/users.py
@@ -4,7 +4,7 @@ import itertools
 import re
 
 from flask import Blueprint, Response, render_template, abort, url_for
-from sqlalchemy.sql import and_
+from sqlalchemy.sql import and_, or_
 from CTFd.utils.user import get_current_user
 from CTFd.utils.decorators import authed_only
 from CTFd.models import db, Users, Challenges, Solves
@@ -12,24 +12,16 @@ from CTFd.cache import cache
 
 from ..models import Dojos, DojoModules, DojoChallenges
 from ..config import DATA_DIR
+from ..utils.scores import dojo_scores, module_scores
 
 
 users = Blueprint("pwncollege_users", __name__)
 
 
 def view_hacker(user):
-    current_user_dojos = set(Dojos.viewable(user=get_current_user()))
-    dojos = [dojo for dojo in Dojos.viewable(user=user) if dojo in current_user_dojos]
+    dojos = Dojos.query.where(or_(Dojos.official, Dojos.data["type"] == "public")).all()
 
-    def ranking(model, user):
-        solves = db.func.count().label("solves")
-        rank = db.func.row_number().over(order_by=(solves.desc(), db.func.max(Solves.id))).label("rank")
-        rankings = model.solves().group_by(Solves.user_id).with_entities(rank, Solves.user_id).all()
-        user_rank = next((ranking.rank for ranking in rankings if ranking.user_id == user.id), None)
-        max_rank = len(rankings)
-        return user_rank, max_rank
-
-    return render_template("hacker.html", dojos=dojos, user=user, ranking=ranking)
+    return render_template("hacker.html", dojos=dojos, user=user, dojo_scores=dojo_scores(), module_scores=module_scores())
 
 @users.route("/hacker/<int:user_id>")
 def view_other(user_id):

--- a/dojo_plugin/pages/users.py
+++ b/dojo_plugin/pages/users.py
@@ -20,6 +20,9 @@ users = Blueprint("pwncollege_users", __name__)
 
 
 def view_hacker(user):
+    if user.hidden:
+        abort(404)
+
     dojos = Dojos.query.where(or_(Dojos.official, Dojos.data["type"] == "public")).all()
 
     return render_template(

--- a/dojo_plugin/utils/awards.py
+++ b/dojo_plugin/utils/awards.py
@@ -94,3 +94,18 @@ def update_awards(user):
             continue
         db.session.add(Emojis(user=user, name=emoji, description=f"Awarded for completing the {dojo_name} dojo.", category=dojo_id))
         db.session.commit()
+
+def get_viewable_emojis(user):
+    viewable_dojos = { dojo.hex_dojo_id:dojo for dojo in Dojos.viewable(user=user) }
+    emojis = { }
+    for emoji in Emojis.query.order_by(Emojis.date).all():
+        if emoji.category not in viewable_dojos:
+            continue
+
+        emojis.setdefault(emoji.user.id, []).append({
+            "text": emoji.description,
+            "emoji": emoji.name,
+            "count": 1,
+            "url": url_for("pwncollege_dojo.listing", dojo=viewable_dojos[emoji.category].reference_id)
+        })
+    return emojis

--- a/dojo_plugin/utils/scores.py
+++ b/dojo_plugin/utils/scores.py
@@ -1,0 +1,18 @@
+from sqlalchemy.sql import or_
+from CTFd.models import Solves, db
+from CTFd.cache import cache
+from ..models import Dojos, DojoChallenges
+
+@cache.memoize(timeout=1200)
+def global_solve_counts():
+    solve_count = db.func.count(Solves.id).label("solve_count")
+    last_solve_id = db.func.max(Solves.id).label("last_solve_id")
+    dsc_query = db.session.query(Dojos.id, Solves.user_id, solve_count, last_solve_id).where(Dojos.dojo_id == DojoChallenges.dojo_id, DojoChallenges.challenge_id == Solves.challenge_id, or_(Dojos.data["type"] == "public", Dojos.official)).group_by(Dojos.id, Solves.user_id).order_by(Dojos.id, solve_count.desc(), last_solve_id)
+    user_ranks = { }
+    user_solves = { }
+    dojo_ranks = { }
+    for dojo_id, user_id, solve_count, last_solve_id in dsc_query:
+        dojo_ranks.setdefault(dojo_id, [ ]).append(user_id)
+        user_ranks.setdefault(user_id, {})[dojo_id] = len(dojo_ranks[dojo_id])
+        user_solves.setdefault(user_id, {})[dojo_id] = solve_count
+    return user_ranks, user_solves, dojo_ranks

--- a/dojo_plugin/utils/scores.py
+++ b/dojo_plugin/utils/scores.py
@@ -4,10 +4,14 @@ from CTFd.cache import cache
 from ..models import Dojos, DojoChallenges
 
 @cache.memoize(timeout=1200)
-def global_solve_counts():
+def dojo_scores():
     solve_count = db.func.count(Solves.id).label("solve_count")
     last_solve_id = db.func.max(Solves.id).label("last_solve_id")
-    dsc_query = db.session.query(Dojos.id, Solves.user_id, solve_count, last_solve_id).where(Dojos.dojo_id == DojoChallenges.dojo_id, DojoChallenges.challenge_id == Solves.challenge_id, or_(Dojos.data["type"] == "public", Dojos.official)).group_by(Dojos.id, Solves.user_id).order_by(Dojos.id, solve_count.desc(), last_solve_id)
+    dsc_query = db.session.query(Dojos.id, Solves.user_id, solve_count, last_solve_id).where(
+        Dojos.dojo_id == DojoChallenges.dojo_id, DojoChallenges.challenge_id == Solves.challenge_id,
+        or_(Dojos.data["type"] == "public", Dojos.official)
+    ).group_by(Dojos.id, Solves.user_id).order_by(Dojos.id, solve_count.desc(), last_solve_id)
+
     user_ranks = { }
     user_solves = { }
     dojo_ranks = { }
@@ -15,4 +19,32 @@ def global_solve_counts():
         dojo_ranks.setdefault(dojo_id, [ ]).append(user_id)
         user_ranks.setdefault(user_id, {})[dojo_id] = len(dojo_ranks[dojo_id])
         user_solves.setdefault(user_id, {})[dojo_id] = solve_count
-    return user_ranks, user_solves, dojo_ranks
+
+    return {
+        "user_ranks": user_ranks,
+        "user_solves": user_solves,
+        "dojo_ranks": dojo_ranks
+    }
+
+@cache.memoize(timeout=1200)
+def module_scores():
+    solve_count = db.func.count(Solves.id).label("solve_count")
+    last_solve_id = db.func.max(Solves.id).label("last_solve_id")
+    dsc_query = db.session.query(Dojos.id, DojoChallenges.module_index, Solves.user_id, solve_count, last_solve_id).where(
+        Dojos.dojo_id == DojoChallenges.dojo_id, DojoChallenges.challenge_id == Solves.challenge_id,
+        or_(Dojos.data["type"] == "public", Dojos.official)
+    ).group_by(Dojos.id, DojoChallenges.module_index, Solves.user_id).order_by(Dojos.id, DojoChallenges.module_index, solve_count.desc(), last_solve_id)
+
+    user_ranks = { }
+    user_solves = { }
+    module_ranks = { }
+    for dojo_id, module_idx, user_id, solve_count, last_solve_id in dsc_query:
+        module_ranks.setdefault(dojo_id, {}).setdefault(module_idx, []).append(user_id)
+        user_ranks.setdefault(user_id, {}).setdefault(dojo_id, {})[module_idx] = len(module_ranks[dojo_id][module_idx])
+        user_solves.setdefault(user_id, {}).setdefault(dojo_id, {})[module_idx] = solve_count
+
+    return {
+        "user_ranks": user_ranks,
+        "user_solves": user_solves,
+        "module_ranks": module_ranks
+    }

--- a/dojo_theme/templates/hacker.html
+++ b/dojo_theme/templates/hacker.html
@@ -39,14 +39,15 @@
   </div>
 
   <div class="container">
-    {% for dojo in dojos if dojo.solves(user=user, ignore_visibility=True, ignore_admins=False).count() > 0 %}
-      {% set rank, max_rank = ranking(dojo, user) %}
-      {% set solves = dojo.solves(user=user, ignore_visibility=True, ignore_admins=False).all() | map(attribute="challenge_id") | list %}
+    {% for dojo in dojos if dojo_scores.user_ranks[user.id] and dojo_scores.user_ranks[user.id][dojo.id] %}
+      {% set rank = dojo_scores.user_ranks[user.id][dojo.id] %}
+      {% set max_rank = dojo_scores.dojo_ranks[dojo.id] | length %}
+      {% set solves = dojo_scores.user_solves[user.id][dojo.id] %}
       <a class="text-decoration-none" href="{{ url_for('pwncollege_dojo.listing', dojo=dojo.reference_id) }}">
         <h2>{{ dojo.name }}</h2>
         <h4>
           <i class="fas fa-flag pt-3 pr-3" title="Solves"></i>
-          <td>{{ solves | length }} / {{ dojo.challenges | length }}</td>
+          <td>{{ solves }} / {{ dojo.challenges | length }}</td>
           <i class="fas fa-trophy pt-3 pr-3 pl-5 " title="Rank"></i>
           <td>{{ rank or "-" }} / {{ max_rank or "-" }}</td>
         </h4>
@@ -56,25 +57,20 @@
 
       <div class="accordion" id="modules-{{dojo.hex_dojo_id}}">
         {% for module in dojo.modules %}
-          {% set solves = module.solves(user=user, ignore_visibility=True, ignore_admins=False).all() | map(attribute="challenge_id") | list %}
-          {% set rank, max_rank = ranking(module, user) %}
+          {% set solves = module_scores.user_solves[user.id][dojo.id][module.module_index] %}
+          {% set rank = module_scores.user_ranks[user.id][dojo.id][module.module_index] %}
+          {% set max_rank = module_scores.module_ranks[dojo.id][module.module_index] | length %}
           {% call(header) accordion_item("modules-{}".format(dojo.hex_dojo_id), loop.index) %}
             {% if header %}
               <h4 class="accordion-item-name">{{ module.name }}</h4>
               <span class="total-solves">
                 <i class="fas fa-flag pr-1" title="Solves"></i>
-                <td>{{ solves | length }} / {{ module.challenges | length }}</td>
+                <td>{{ solves }} / {{ module.challenges | length }}</td>
                 <i class="fas fa-trophy pr-1 pl-3 " title="Rank"></i>
                 <td>{{ rank or "-" }} / {{ max_rank or "-" }}</td>
               </span>
             {% else %}
-              {% for challenge in module.challenges %}
-                {% set challenge_status = "challenge-solved" if challenge.challenge_id in solves else "challenge-unsolved" %}
-                <h5>
-                  <i class="fas fa-flag pr-3 pt-3 {{ challenge_status }}"></i>
-                  <td>{{ challenge.name }}</td>
-                </h5>
-              {% endfor %}
+              TODO
             {% endif %}
           {% endcall %}
         {% endfor %}

--- a/dojo_theme/templates/hacker.html
+++ b/dojo_theme/templates/hacker.html
@@ -4,7 +4,27 @@
 {% block content %}
   <div class="jumbotron">
     <div class="container">
-      <h1>{{ user.name }}<br><img src="{{ belt }}" class="scoreboard-belt"></h1>
+      <h1>{{ user.name }}</h1>
+      <h1>
+        <a href="{{ url_for("pwncollege_belts.view_belts") }}">
+          {% if belts.users[user.id] %}
+          <span title="Earned on {{belts.users[user.id].date}}">
+            <img src="{{ url_for("views.themes", path="img/dojo/"+belts.users[user.id].color+".svg") }}", class="scoreboard-belt">
+          </span>
+          {% else %}
+          <img src="{{ url_for("views.themes", path="img/dojo/white.svg") }}" class="scoreboard-belt">
+          {% endif %}
+        </a>
+      </h1>
+      <h2>
+        {% for badge in badges[user.id] %}
+        <span title="{{badge.text}}">
+          <a href="{{badge.url}}">{{badge.emoji}}</a>
+          </span><span>
+        </span>
+        {% endfor %}
+      </h2>
+
 
       {% if user.affiliation %}
         <h3 class="d-inline-block">


### PR DESCRIPTION
This brings back the hacker profiles using two fast(er) global queries that can be reasonably cached. The drawbacks:

1. the utils.scores code has some duplication that i'm too tired to sort out
2. i removed the per-challenge data. This will need to be loaded dynamically, I think.