### PR TITLE
add a cachewarmer cronjob that keeps the cache warm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,12 @@ RUN ln -s /opt/pwn.college/etc/systemd/system/pwn.college.service /etc/systemd/s
 RUN ln -s /opt/pwn.college/etc/systemd/system/pwn.college.logging.service /etc/systemd/system/pwn.college.logging.service
 RUN ln -s /opt/pwn.college/etc/systemd/system/pwn.college.backup.service /etc/systemd/system/pwn.college.backup.service
 RUN ln -s /opt/pwn.college/etc/systemd/system/pwn.college.backup.timer /etc/systemd/system/pwn.college.backup.timer
+RUN ln -s /opt/pwn.college/etc/systemd/system/pwn.college.cachewarmer.service /etc/systemd/system/pwn.college.cachewarmer.service
+RUN ln -s /opt/pwn.college/etc/systemd/system/pwn.college.cachewarmer.timer /etc/systemd/system/pwn.college.cachewarmer.timer
 RUN ln -s /etc/systemd/system/pwn.college.service /etc/systemd/system/multi-user.target.wants/pwn.college.service
 RUN ln -s /etc/systemd/system/pwn.college.logging.service /etc/systemd/system/multi-user.target.wants/pwn.college.logging.service
 RUN ln -s /etc/systemd/system/pwn.college.backup.timer /etc/systemd/system/timers.target.wants/pwn.college.backup.timer
+RUN ln -s /etc/systemd/system/pwn.college.cachewarmer.timer /etc/systemd/system/timers.target.wants/pwn.college.cachewarmer.timer
 
 RUN mkdir -p /opt/pwn.college
 ADD . /opt/pwn.college

--- a/etc/systemd/system/pwn.college.cachewarmer.service
+++ b/etc/systemd/system/pwn.college.cachewarmer.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Create a pwn.college backup
+Description=Keep the pwn.college caches warm!
 
 [Service]
 Type=simple

--- a/etc/systemd/system/pwn.college.cachewarmer.service
+++ b/etc/systemd/system/pwn.college.cachewarmer.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Create a pwn.college backup
+
+[Service]
+Type=simple
+ExecStart=warm_cache.sh

--- a/etc/systemd/system/pwn.college.cachewarmer.timer
+++ b/etc/systemd/system/pwn.college.cachewarmer.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Timer to run pwn.college cachewarmer service
+
+[Timer]
+OnCalendar=*-*-* *:*:00
+
+[Install]
+WantedBy=timers.target

--- a/script/container-setup.sh
+++ b/script/container-setup.sh
@@ -78,8 +78,6 @@ mkdir -p $DOJO_DIR/data/logging
 sysctl -w kernel.pty.max=1048576
 echo core > /proc/sys/kernel/core_pattern
 
-route add default gw 172.17.0.1
-
 iptables -N DOCKER-USER
 iptables -I DOCKER-USER -i user_network -j DROP
 for host in $(cat $DOJO_DIR/user_firewall.allowed); do

--- a/script/container-setup.sh
+++ b/script/container-setup.sh
@@ -78,6 +78,8 @@ mkdir -p $DOJO_DIR/data/logging
 sysctl -w kernel.pty.max=1048576
 echo core > /proc/sys/kernel/core_pattern
 
+route add default gw 172.17.0.1
+
 iptables -N DOCKER-USER
 iptables -I DOCKER-USER -i user_network -j DROP
 for host in $(cat $DOJO_DIR/user_firewall.allowed); do

--- a/script/warm_cache.sh
+++ b/script/warm_cache.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+dojo flask <<END
+from ..utils import scores
+ds = scores.dojo_scores()
+ms = scores.module_scores()
+print(f"""
+	  {len(ds)=}
+	  {len(ms)=}
+""")
+END


### PR DESCRIPTION
This runs a cachewarmer every minute (though obv it only hits the DB when the cache expires). Right now it does dojo_scores and module_scores. We should also probably cache the scoreboard of all official dojos while we're at it.