### PR TITLE
Changes to emoji eligibility and some testing upgrades

### DIFF
--- a/dojo_plugin/api/v1/dojo.py
+++ b/dojo_plugin/api/v1/dojo.py
@@ -95,6 +95,7 @@ class PruneAwards(Resource):
 @dojo_namespace.route("/<dojo>/promote-dojo")
 class PromoteDojo(Resource):
     @admins_only
+    @dojo_route
     def post(self, dojo):
         dojo.official = True
         db.session.commit()

--- a/dojo_plugin/api/v1/dojo.py
+++ b/dojo_plugin/api/v1/dojo.py
@@ -24,7 +24,7 @@ from CTFd.utils.modes import get_model
 from CTFd.utils.security.sanitize import sanitize_html
 
 from ...models import Dojos, DojoMembers, DojoAdmins, DojoUsers, Emojis
-from ...utils.dojo import dojo_accessible, dojo_clone, load_dojo_dir, dojo_route, dojo_admins_only
+from ...utils.dojo import dojo_accessible, dojo_clone, dojo_from_dir, dojo_route, dojo_admins_only
 
 
 dojo_namespace = Namespace(
@@ -44,7 +44,7 @@ def create_dojo(user, repository, public_key, private_key):
         dojo_dir = dojo_clone(repository, private_key)
         dojo_path = pathlib.Path(dojo_dir.name)
 
-        dojo = load_dojo_dir(dojo_path)
+        dojo = dojo_from_dir(dojo_path)
         dojo.repository = repository
         dojo.public_key = public_key
         dojo.private_key = private_key

--- a/dojo_plugin/api/v1/dojo.py
+++ b/dojo_plugin/api/v1/dojo.py
@@ -92,6 +92,14 @@ class PruneAwards(Resource):
         db.session.commit()
         return {"success": True, "pruned_awards": num_pruned}
 
+@dojo_namespace.route("/<dojo>/promote-dojo")
+class PromoteDojo(Resource):
+    @admins_only
+    def post(self, dojo):
+        dojo.official = True
+        db.session.commit()
+        return {"success": True}
+
 @dojo_namespace.route("/<dojo>/promote-admin")
 class PromoteAdmin(Resource):
     @authed_only

--- a/dojo_plugin/pages/dojos.py
+++ b/dojo_plugin/pages/dojos.py
@@ -41,6 +41,8 @@ def listing():
             typed_dojos["Courses"].append(dojo)
         elif dojo.type == "hidden":
             continue
+        elif dojo.type == "example" and dojo.official:
+            continue
         else:
             typed_dojos["More"].append(dojo)
 
@@ -55,6 +57,7 @@ def dojo_create():
         "dojo_create.html",
         public_key=public_key,
         private_key=private_key,
+        example_dojos=Dojos.viewable().where(Dojos.data["type"] == "example").all()
     )
 
 

--- a/dojo_plugin/pages/dojos.py
+++ b/dojo_plugin/pages/dojos.py
@@ -31,8 +31,8 @@ def listing():
     user = get_current_user()
     typed_dojos = {
         "Topics": [],
+        "More Material": [],
         "Courses": [],
-        "More": [],
     }
     for dojo in Dojos.viewable(user=user):
         if dojo.type == "topic":
@@ -44,7 +44,7 @@ def listing():
         elif dojo.type == "example" and dojo.official:
             continue
         else:
-            typed_dojos["More"].append(dojo)
+            typed_dojos["More Material"].append(dojo)
 
     return render_template("dojos.html", user=user, typed_dojos=typed_dojos)
 

--- a/dojo_plugin/utils/awards.py
+++ b/dojo_plugin/utils/awards.py
@@ -92,7 +92,7 @@ def update_awards(user):
         db.session.commit()
 
 def get_viewable_emojis(user):
-    viewable_dojos = { dojo.hex_dojo_id:dojo for dojo in Dojos.viewable(user=user) }
+    viewable_dojos = { dojo.hex_dojo_id:dojo for dojo in Dojos.viewable(user=user).where(Dojos.data["type"] != "example") }
     emojis = { }
     for emoji in Emojis.query.order_by(Emojis.date).all():
         if emoji.category and emoji.category not in viewable_dojos:

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -16,9 +16,9 @@ from sqlalchemy.orm.exc import NoResultFound
 from CTFd.models import db, Users, Challenges, Flags, Solves
 from CTFd.utils.user import get_current_user, is_admin
 
-from ...models import Dojos, DojoUsers, DojoModules, DojoChallenges, DojoResources, DojoChallengeVisibilities, DojoResourceVisibilities
-from ...config import DOJOS_DIR
-from ...utils import get_current_container
+from ..models import Dojos, DojoUsers, DojoModules, DojoChallenges, DojoResources, DojoChallengeVisibilities, DojoResourceVisibilities
+from ..config import DOJOS_DIR
+from ..utils import get_current_container
 
 
 ID_REGEX = Regex(r"^[a-z0-9-]{1,32}$")

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -125,7 +125,7 @@ def setdefault_subyaml(data, subyaml_path):
     data.update(subyaml_data)
     data.update(topyaml_data)
 
-def load_dojo_spec(dojo_dir):
+def load_dojo_subyamls(data, dojo_dir):
     """
     The dojo yaml gets augmented with additional yamls and markdown files found in the dojo repo structure.
 
@@ -140,14 +140,6 @@ def load_dojo_spec(dojo_dir):
 
     The higher-level details override the lower-level details.
     """
-
-    dojo_yml_path = dojo_dir / "dojo.yml"
-    assert dojo_yml_path.exists(), "Missing file: `dojo.yml`"
-
-    for path in dojo_dir.rglob("**"):
-        assert dojo_dir == path or dojo_dir in path.resolve().parents, f"Error: symlink `{path}` references path outside of the dojo"
-
-    data = yaml.safe_load(dojo_yml_path.read_text())
 
     setdefault_file(data, "description", dojo_dir / "DESCRIPTION.md")
 
@@ -171,9 +163,18 @@ def load_dojo_spec(dojo_dir):
 
     return data
 
-def load_dojo_dir(dojo_dir, *, dojo=None):
-    data = load_dojo_spec(dojo_dir)
+def dojo_from_dir(dojo_dir, *, dojo=None):
+    dojo_yml_path = dojo_dir / "dojo.yml"
+    assert dojo_yml_path.exists(), "Missing file: `dojo.yml`"
 
+    for path in dojo_dir.rglob("**"):
+        assert dojo_dir == path or dojo_dir in path.resolve().parents, f"Error: symlink `{path}` references path outside of the dojo"
+
+    data_raw = yaml.safe_load(dojo_yml_path.read_text())
+    data = load_dojo_subyamls(data_raw, dojo_dir)
+    return dojo_from_spec(data, dojo_dir=dojo_dir, dojo=dojo)
+
+def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
     try:
         dojo_data = DOJO_SPEC.validate(data)
     except SchemaError as e:
@@ -271,28 +272,29 @@ def load_dojo_dir(dojo_dir, *, dojo=None):
         for module in (import_dojo.modules if import_dojo else [])
     ]
 
-    with dojo.located_at(dojo_dir):
-        missing_challenge_paths = [
-            challenge
-            for module in dojo.modules
-            for challenge in module.challenges
-            if not challenge.path.exists()
-        ]
-        assert not missing_challenge_paths, "".join(
-            f"Missing challenge path: {challenge.module.id}/{challenge.id}\n"
-            for challenge in missing_challenge_paths)
+    if dojo_dir:
+        with dojo.located_at(dojo_dir):
+            missing_challenge_paths = [
+                challenge
+                for module in dojo.modules
+                for challenge in module.challenges
+                if not challenge.path.exists()
+            ]
+            assert not missing_challenge_paths, "".join(
+                f"Missing challenge path: {challenge.module.id}/{challenge.id}\n"
+                for challenge in missing_challenge_paths)
 
-    course_yml_path = dojo_dir / "course.yml"
-    if course_yml_path.exists():
-        course = yaml.safe_load(course_yml_path.read_text())
-        if "discord_role" in course and not dojo.official:
-            raise AssertionError("Unofficial dojos cannot have a discord role")
-        dojo.course = course
+        course_yml_path = dojo_dir / "course.yml"
+        if course_yml_path.exists():
+            course = yaml.safe_load(course_yml_path.read_text())
+            if "discord_role" in course and not dojo.official:
+                raise AssertionError("Unofficial dojos cannot have a discord role")
+            dojo.course = course
 
-        students_yml_path = dojo_dir / "students.yml"
-        if students_yml_path.exists():
-            students = yaml.safe_load(students_yml_path.read_text())
-            dojo.course["students"] = students
+            students_yml_path = dojo_dir / "students.yml"
+            if students_yml_path.exists():
+                students = yaml.safe_load(students_yml_path.read_text())
+                dojo.course["students"] = students
 
     return dojo
 
@@ -354,7 +356,7 @@ def dojo_git_command(dojo, *args):
 
 def dojo_update(dojo):
     dojo_git_command(dojo, "pull")
-    return load_dojo_dir(dojo.path, dojo=dojo)
+    return dojo_from_dir(dojo.path, dojo=dojo)
 
 
 def dojo_accessible(id):

--- a/dojo_theme/templates/dojo_create.html
+++ b/dojo_theme/templates/dojo_create.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "macros/widgets.html" import card %}
 
 {% block content %}
 <div class="jumbotron">
@@ -7,6 +8,17 @@
     </div>
 </div>
 <div class="container">
+  <p>pwn.college dojos are defined in a git repository. You can use the example repositories listed below, or our <a href="https://github.com/pwncollege/official-dojos">official dojo repositories</a>, for examples on how to build a dojo!</p>
+    <ul class="card-list">
+      {% for dojo in example_dojos %}
+      {{ card(url_for("pwncollege_dojos.view_dojo", dojo=dojo.reference_id),
+      title=dojo.name,
+      text="{} Modules : ".format(dojo.modules | length) + "{} / {}".format(dojo.solves(user=user, ignore_visibility=True, ignore_admins=False).count() if user else 0, dojo.challenges | length),
+      icon="/themes/dojo_theme/static/img/dojo/{}.svg".format(dojo.award.belt) if (dojo.award.belt and dojo.official) else None,
+      emoji=dojo.award.emoji ) }}
+      {% endfor %}
+    </ul>
+  <p>When you are ready, create your dojo from your repository using the form below!</p>
     <form method="post" id="dojo-create-form" autocomplete="off">
         <div class="form-group">
             <b><label>GitHub Repository</label></b>

--- a/dojo_theme/templates/dojos.html
+++ b/dojo_theme/templates/dojos.html
@@ -19,7 +19,7 @@
     <p>These dojos form the official the pwn.college curriculum, and you will earn <a href="{{ url_for("pwncollege_belts.view_belts") }}">belts</a> when you complete them. We recommend that you tackle them in order. Good luck!</p>
     {% elif type == "Courses" %}
     <p>We run a number of courses on this platform. For the most part, these courses import the above material, though some might introduce new concepts and challenges.</p>
-    {% elif type == "More" %}
+    {% elif type.startswith("More") %}
     <p>This section contains dojos created by the pwn.college community. Completing these dojos will grant you emoji badges!</p>
     {% endif %}
     <ul class="card-list">
@@ -31,7 +31,7 @@
       emoji=dojo.award.emoji ) }}
       {% endfor %}
 
-      {% if type == "More" %}
+      {% if type.startswith("More") %}
         {% call card(url_for("pwncollege_dojos.dojo_create"), custom=True) %}
           <svg class="w-100 h-100">
             <circle cx="50%" cy="50%" r="30%" stroke="gray" fill="none" stroke-width="8" stroke-dasharray="8"></circle>

--- a/test/dojos/simple_award_dojo.yml
+++ b/test/dojos/simple_award_dojo.yml
@@ -1,0 +1,8 @@
+id: simple-award
+type: public
+award:
+  emoji: 🧪
+modules:
+  - import:
+      dojo: example
+      module: hello


### PR DESCRIPTION
This PR adds the following:

1. It moves example dojos into the Create page, removing them from the main listing.
2. It swaps the order of More Material and Courses on the main page. People looking for the courses will find the courses, but we should work hard to surface the community dojos.
3. It adds an admin-only endpoint for making dojos official.
4. It adds an admin-only endpoint for adding a dojo via yml (@ConnorNelson , i know you were concerned about this. Check out 70d5c5211ff869e09c3eef509fb5f47b8df60641; it's pretty small)
5. It makes example dojos no longer award emoji