### PR TITLE
challenge/Dockerfile: fix an issue "less command not found"

### DIFF
--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -33,6 +33,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         vim
         wget
         unzip
+        less
 EOF
 
 RUN rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED
@@ -407,7 +408,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         kmod
         libc6-arm64-cross
         libc6-dev-arm64-cross
-        less
         ltrace
         nano
         neovim


### PR DESCRIPTION
challenge/bash.bashrc uses less command to show the /challenge/README.md. However, this command is not installed unless you use challenge-full.

Fix this by moving less package to essential label.