### PR TITLE
challenge/bash.bashrc: fix an issue "less command not found"

### DIFF
--- a/challenge/bash.bashrc
+++ b/challenge/bash.bashrc
@@ -5,8 +5,10 @@ mkdir -p /tmp/.dojo
 if [ -e "/challenge/README.md" ] && [ ! -e "/tmp/.dojo/readme-once" ]; then
     if command -v glow > /dev/null 2>&1; then
         PAGER="less -ERX" glow --pager /challenge/README.md
-    else
+    elif command -v less > /dev/null 2>&1; then
         less -ERX /challenge/README.md
+    else
+	cat /challenge/README.md
     fi
 
     touch /tmp/.dojo/readme-once


### PR DESCRIPTION
Now challenge/bash.bashrc uses less command to show the /challenge/README.md. However, this command is not installed unless you use challenge-full.

Fix this by checking less command is installed or not.