### PR TITLE
set a default host for the nginx proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,6 +169,7 @@ services:
       - "443:443"
     environment:
       - DOCKER_HOST=unix:///tmp/${DOCKER_PSLR}/docker.sock
+      - DEFAULT_HOST=${DOJO_HOST}
     volumes:
       - conf:/etc/nginx/conf.d
       - html:/usr/share/nginx/html


### PR DESCRIPTION
A common issue people run into is trying to access the dojo by IP when setting up a self-hosted instance. This PR fixes that by adding a default proxy route.