### PR TITLE
challenge/Dockerfile: add a package dwarves

### DIFF
--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -85,6 +85,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         cpio
         openjdk-17-jdk
         flex
+	dwarves
         g++-multilib
         gcc-multilib
         git


### PR DESCRIPTION
The linux kernel 5.4 compilation encounters the following warning:

.tmp_vmlinux.btf: pahole (pahole) is not available

Fix it by adding a package dwarves