### PR TITLE
Added verification for port 465 in the mail_tls parameter.

### DIFF
--- a/dojo_plugin/config.py
+++ b/dojo_plugin/config.py
@@ -123,7 +123,7 @@ def bootstrap():
     set_config("mail_password", MAIL_PASSWORD)
     set_config("mailfrom_addr", MAIL_ADDRESS)
     set_config("mail_useauth", bool(MAIL_USERNAME))
-    set_config("mail_tls", MAIL_PORT == "587")
+    set_config("mail_tls", MAIL_PORT == "465" or MAIL_PORT == "587")
 
     if not config.is_setup():
         admin = Admins(


### PR DESCRIPTION
In the config.py file, validation for port 465 has been added, as port 465 is for SSL/TLS.