### PR TITLE
Allow selectively disabling practice mode

### DIFF
--- a/dojo_plugin/api/v1/docker.py
+++ b/dojo_plugin/api/v1/docker.py
@@ -245,6 +245,9 @@ class RunDocker(Resource):
         if not dojo_challenge.visible() and not dojo.is_admin():
             return {"success": False, "error": "Invalid challenge"}
 
+        if practice and not dojo_challenge.practice_enabled:
+            return {"success": False, "error": "This challenge does not support practice mode."}
+
         try:
             start_challenge(user, dojo_challenge, practice)
         except RuntimeError as e:

--- a/dojo_plugin/api/v1/docker.py
+++ b/dojo_plugin/api/v1/docker.py
@@ -245,7 +245,7 @@ class RunDocker(Resource):
         if not dojo_challenge.visible() and not dojo.is_admin():
             return {"success": False, "error": "Invalid challenge"}
 
-        if practice and not dojo_challenge.practice_enabled:
+        if practice and not dojo_challenge.allow_privileged:
             return {"success": False, "error": "This challenge does not support practice mode."}
 
         try:

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -404,6 +404,7 @@ class DojoChallenges(db.Model):
                                  uselist=False,
                                  cascade="all, delete-orphan",
                                  back_populates="challenge")
+    practice_enabled = db.Column(db.Boolean, default=True)
 
     def __init__(self, *args, **kwargs):
         default = kwargs.pop("default", None)

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -64,7 +64,9 @@ class Dojos(db.Model):
 
     data = db.Column(db.JSON)
     data_fields = ["type", "award", "comparator", "course", "unimportable"]
-    data_defaults = { }
+    data_defaults = {
+        "unimportable": False
+    }
 
     users = db.relationship("DojoUsers", back_populates="dojo")
     members = db.relationship("DojoMembers", back_populates="dojo")
@@ -284,7 +286,9 @@ class DojoModules(db.Model):
 
     data = db.Column(db.JSON)
     data_fields = ["unimportable"]
-    data_defaults = { }
+    data_defaults = {
+        "unimportable": False
+    }
 
     dojo = db.relationship("Dojos", back_populates="_modules")
     _challenges = db.relationship("DojoChallenges",
@@ -394,8 +398,11 @@ class DojoChallenges(db.Model):
     description = db.Column(db.Text)
 
     data = db.Column(db.JSON)
-    data_fields = ["image", "path_override", "unimportable"]
-    data_defaults = { }
+    data_fields = ["image", "path_override", "unimportable", "practice_enabled"]
+    data_defaults = {
+        "unimportable": False,
+        "practice_enabled": True
+    }
 
     dojo = db.relationship("Dojos",
                            foreign_keys=[dojo_id],
@@ -407,7 +414,6 @@ class DojoChallenges(db.Model):
                                  uselist=False,
                                  cascade="all, delete-orphan",
                                  back_populates="challenge")
-    practice_enabled = db.Column(db.Boolean, default=True)
 
     def __init__(self, *args, **kwargs):
         default = kwargs.pop("default", None)

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -63,9 +63,9 @@ class Dojos(db.Model):
     password = db.Column(db.String(128))
 
     data = db.Column(db.JSON)
-    data_fields = ["type", "award", "comparator", "course", "unimportable"]
+    data_fields = ["type", "award", "comparator", "course", "importable"]
     data_defaults = {
-        "unimportable": False
+        "importable": True
     }
 
     users = db.relationship("DojoUsers", back_populates="dojo")
@@ -285,9 +285,9 @@ class DojoModules(db.Model):
     description = db.Column(db.Text)
 
     data = db.Column(db.JSON)
-    data_fields = ["unimportable"]
+    data_fields = ["importable"]
     data_defaults = {
-        "unimportable": False
+        "importable": True
     }
 
     dojo = db.relationship("Dojos", back_populates="_modules")
@@ -398,9 +398,9 @@ class DojoChallenges(db.Model):
     description = db.Column(db.Text)
 
     data = db.Column(db.JSON)
-    data_fields = ["image", "path_override", "unimportable", "allow_privileged"]
+    data_fields = ["image", "path_override", "importable", "allow_privileged"]
     data_defaults = {
-        "unimportable": False,
+        "importable": True,
         "allow_privileged": True
     }
 

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -398,10 +398,10 @@ class DojoChallenges(db.Model):
     description = db.Column(db.Text)
 
     data = db.Column(db.JSON)
-    data_fields = ["image", "path_override", "unimportable", "practice_enabled"]
+    data_fields = ["image", "path_override", "unimportable", "allow_privileged"]
     data_defaults = {
         "unimportable": False,
-        "practice_enabled": True
+        "allow_privileged": True
     }
 
     dojo = db.relationship("Dojos",

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -63,7 +63,7 @@ class Dojos(db.Model):
     password = db.Column(db.String(128))
 
     data = db.Column(db.JSON)
-    data_fields = ["type", "award", "comparator", "course"]
+    data_fields = ["type", "award", "comparator", "course", "unimportable"]
 
     users = db.relationship("DojoUsers", back_populates="dojo")
     members = db.relationship("DojoMembers", back_populates="dojo")
@@ -282,7 +282,7 @@ class DojoModules(db.Model):
     description = db.Column(db.Text)
 
     data = db.Column(db.JSON)
-    data_fields = []
+    data_fields = ["unimportable"]
 
     dojo = db.relationship("Dojos", back_populates="_modules")
     _challenges = db.relationship("DojoChallenges",
@@ -392,7 +392,7 @@ class DojoChallenges(db.Model):
     description = db.Column(db.Text)
 
     data = db.Column(db.JSON)
-    data_fields = ["image", "path_override"]
+    data_fields = ["image", "path_override", "unimportable"]
 
     dojo = db.relationship("Dojos",
                            foreign_keys=[dojo_id],

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -64,6 +64,7 @@ class Dojos(db.Model):
 
     data = db.Column(db.JSON)
     data_fields = ["type", "award", "comparator", "course", "unimportable"]
+    data_defaults = { }
 
     users = db.relationship("DojoUsers", back_populates="dojo")
     members = db.relationship("DojoMembers", back_populates="dojo")
@@ -97,7 +98,7 @@ class Dojos(db.Model):
 
     def __getattr__(self, name):
         if name in self.data_fields:
-            return self.data.get(name)
+            return self.data.get(name, self.data_defaults.get(name))
         raise AttributeError(f"No attribute '{name}'")
 
     def __setattr__(self, name, value):
@@ -283,6 +284,7 @@ class DojoModules(db.Model):
 
     data = db.Column(db.JSON)
     data_fields = ["unimportable"]
+    data_defaults = { }
 
     dojo = db.relationship("Dojos", back_populates="_modules")
     _challenges = db.relationship("DojoChallenges",
@@ -326,7 +328,7 @@ class DojoModules(db.Model):
 
     def __getattr__(self, name):
         if name in self.data_fields:
-            return self.data.get(name)
+            return self.data.get(name, self.data_defaults.get(name))
         raise AttributeError(f"No attribute '{name}'")
 
     @classmethod
@@ -393,6 +395,7 @@ class DojoChallenges(db.Model):
 
     data = db.Column(db.JSON)
     data_fields = ["image", "path_override", "unimportable"]
+    data_defaults = { }
 
     dojo = db.relationship("Dojos",
                            foreign_keys=[dojo_id],
@@ -430,7 +433,7 @@ class DojoChallenges(db.Model):
 
     def __getattr__(self, name):
         if name in self.data_fields:
-            return self.data.get(name)
+            return self.data.get(name, self.data_defaults.get(name))
         raise AttributeError(f"No attribute '{name}'")
 
     @classmethod

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -241,12 +241,14 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
             return cls(start=start, stop=stop)
 
     _missing = object()
-    def shadow(attr, *datas, default=_missing):
+    def shadow(attr, *datas, default=_missing, default_dict=None):
         for data in reversed(datas):
             if attr in data:
                 return data[attr]
         if default is not _missing:
             return default
+        elif default_dict and attr in default_dict:
+            return default_dict[attr]
         raise KeyError(f"Missing `{attr}` in `{datas}`")
 
     def import_ids(attrs, *datas):
@@ -260,8 +262,8 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
                 DojoChallenges(
                     **{kwarg: challenge_data.get(kwarg) for kwarg in ["id", "name", "description"]},
                     image=shadow("image", dojo_data, module_data, challenge_data, default=None),
-                    allow_privileged=shadow("allow_privileged", dojo_data, module_data, challenge_data, default=True),
-                    importable=shadow("importable", dojo_data, module_data, challenge_data, default=True),
+                    allow_privileged=shadow("allow_privileged", dojo_data, module_data, challenge_data, default_dict=DojoChallenges.data_defaults),
+                    importable=shadow("importable", dojo_data, module_data, challenge_data, default_dict=DojoChallenges.data_defaults),
                     challenge=challenge(module_data.get("id"), challenge_data.get("id")) if "import" not in challenge_data else None,
                     visibility=visibility(DojoChallengeVisibilities, dojo_data, module_data, challenge_data),
                     default=(assert_import_one(DojoChallenges.from_id(*import_ids(["dojo", "module", "challenge"], dojo_data, module_data, challenge_data)),

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -53,6 +53,7 @@ DOJO_SPEC = Schema({
     },
 
     Optional("image"): IMAGE_REGEX,
+    Optional("practice_enabled"): bool,
 
     Optional("import"): {
         "dojo": UNIQUE_ID_REGEX,
@@ -63,6 +64,7 @@ DOJO_SPEC = Schema({
         **VISIBILITY,
 
         Optional("image"): IMAGE_REGEX,
+        Optional("practice_enabled"): bool,
 
         Optional("import"): {
             Optional("dojo"): UNIQUE_ID_REGEX,
@@ -74,6 +76,7 @@ DOJO_SPEC = Schema({
             **VISIBILITY,
 
             Optional("image"): IMAGE_REGEX,
+            Optional("practice_enabled"): bool,
             # Optional("path"): Regex(r"^[^\s\.\/][^\s\.]{,255}$"),
 
             Optional("import"): {
@@ -243,6 +246,7 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
                 DojoChallenges(
                     **{kwarg: challenge_data.get(kwarg) for kwarg in ["id", "name", "description"]},
                     image=shadow("image", dojo_data, module_data, challenge_data, default=None),
+                    practice_enabled=shadow("practice_enabled", dojo_data, module_data, challenge_data, default=True),
                     challenge=challenge(module_data.get("id"), challenge_data.get("id")) if "import" not in challenge_data else None,
                     visibility=visibility(DojoChallengeVisibilities, dojo_data, module_data, challenge_data),
                     default=(assert_one(DojoChallenges.from_id(*import_ids(["dojo", "module", "challenge"], dojo_data, module_data, challenge_data)),

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -53,7 +53,7 @@ DOJO_SPEC = Schema({
     },
 
     Optional("image"): IMAGE_REGEX,
-    Optional("practice_enabled"): bool,
+    Optional("allow_privileged"): bool,
     Optional("unimportable"): bool,
 
     Optional("import"): {
@@ -65,7 +65,7 @@ DOJO_SPEC = Schema({
         **VISIBILITY,
 
         Optional("image"): IMAGE_REGEX,
-        Optional("practice_enabled"): bool,
+        Optional("allow_privileged"): bool,
         Optional("unimportable"): bool,
 
         Optional("import"): {
@@ -78,7 +78,7 @@ DOJO_SPEC = Schema({
             **VISIBILITY,
 
             Optional("image"): IMAGE_REGEX,
-            Optional("practice_enabled"): bool,
+            Optional("allow_privileged"): bool,
             Optional("unimportable"): bool,
             # Optional("path"): Regex(r"^[^\s\.\/][^\s\.]{,255}$"),
 
@@ -260,7 +260,7 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
                 DojoChallenges(
                     **{kwarg: challenge_data.get(kwarg) for kwarg in ["id", "name", "description"]},
                     image=shadow("image", dojo_data, module_data, challenge_data, default=None),
-                    practice_enabled=shadow("practice_enabled", dojo_data, module_data, challenge_data, default=True),
+                    allow_privileged=shadow("allow_privileged", dojo_data, module_data, challenge_data, default=True),
                     unimportable=shadow("unimportable", dojo_data, module_data, challenge_data, default=False),
                     challenge=challenge(module_data.get("id"), challenge_data.get("id")) if "import" not in challenge_data else None,
                     visibility=visibility(DojoChallengeVisibilities, dojo_data, module_data, challenge_data),

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -54,7 +54,7 @@ DOJO_SPEC = Schema({
 
     Optional("image"): IMAGE_REGEX,
     Optional("allow_privileged"): bool,
-    Optional("unimportable"): bool,
+    Optional("importable"): bool,
 
     Optional("import"): {
         "dojo": UNIQUE_ID_REGEX,
@@ -66,7 +66,7 @@ DOJO_SPEC = Schema({
 
         Optional("image"): IMAGE_REGEX,
         Optional("allow_privileged"): bool,
-        Optional("unimportable"): bool,
+        Optional("importable"): bool,
 
         Optional("import"): {
             Optional("dojo"): UNIQUE_ID_REGEX,
@@ -79,7 +79,7 @@ DOJO_SPEC = Schema({
 
             Optional("image"): IMAGE_REGEX,
             Optional("allow_privileged"): bool,
-            Optional("unimportable"): bool,
+            Optional("importable"): bool,
             # Optional("path"): Regex(r"^[^\s\.\/][^\s\.]{,255}$"),
 
             Optional("import"): {
@@ -187,7 +187,7 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
         raise AssertionError(e)  # TODO: this probably shouldn't be re-raised as an AssertionError
 
     def assert_importable(o):
-        assert not o.unimportable, f"Import disallowed for {o}."
+        assert o.importable, f"Import disallowed for {o}."
         if isinstance(o, Dojos):
             for m in o.module:
                 assert_importable(m)
@@ -261,7 +261,7 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
                     **{kwarg: challenge_data.get(kwarg) for kwarg in ["id", "name", "description"]},
                     image=shadow("image", dojo_data, module_data, challenge_data, default=None),
                     allow_privileged=shadow("allow_privileged", dojo_data, module_data, challenge_data, default=True),
-                    unimportable=shadow("unimportable", dojo_data, module_data, challenge_data, default=False),
+                    importable=shadow("importable", dojo_data, module_data, challenge_data, default=True),
                     challenge=challenge(module_data.get("id"), challenge_data.get("id")) if "import" not in challenge_data else None,
                     visibility=visibility(DojoChallengeVisibilities, dojo_data, module_data, challenge_data),
                     default=(assert_import_one(DojoChallenges.from_id(*import_ids(["dojo", "module", "challenge"], dojo_data, module_data, challenge_data)),

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -84,14 +84,14 @@
             <p>{{ challenge.description | markdown }}</p>
           </div>
           <div class="row">
-            <div class="col-sm-{% if challenge.practice_enabled %}6{% else %}12{% endif %} form-group text-center">
+            <div class="col-sm-{% if challenge.allow_privileged %}6{% else %}12{% endif %} form-group text-center">
               <button id="challenge-start" type="submit" class="btn btn-md btn-outline-secondary w-100">
                 <span class="d-sm-block d-md-block d-lg-block">
                   <i class="fas fa-play fa-2x pr-3"></i>Start
                 </span>
               </button>
             </div>
-            {% if challenge.practice_enabled %}
+            {% if challenge.allow_privileged %}
             <div class="col-sm-6 form-group text-center">
               <button id="challenge-practice" type="submit" class="btn btn-md btn-outline-secondary w-100">
                 <span class="d-sm-block d-md-block d-lg-block">

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -84,13 +84,14 @@
             <p>{{ challenge.description | markdown }}</p>
           </div>
           <div class="row">
-            <div class="col-sm-6 form-group text-center">
+            <div class="col-sm-{% if challenge.practice_enabled %}6{% else %}12{% endif %} form-group text-center">
               <button id="challenge-start" type="submit" class="btn btn-md btn-outline-secondary w-100">
                 <span class="d-sm-block d-md-block d-lg-block">
                   <i class="fas fa-play fa-2x pr-3"></i>Start
                 </span>
               </button>
             </div>
+            {% if challenge.practice_enabled %}
             <div class="col-sm-6 form-group text-center">
               <button id="challenge-practice" type="submit" class="btn btn-md btn-outline-secondary w-100">
                 <span class="d-sm-block d-md-block d-lg-block">
@@ -98,6 +99,7 @@
                 </span>
               </button>
             </div>
+            {% endif %}
           </div>
           <div class="row submit-row">
             <div class="col-md-9 form-group">

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -61,6 +61,14 @@ def simple_award_dojo(admin_session):
     return create_dojo_yml(open(TEST_DOJOS_LOCATION / "simple_award_dojo.yml").read(), session=admin_session)
 
 @pytest.fixture(scope="session")
+def no_practice_challenge_dojo(admin_session):
+    return create_dojo_yml(open(TEST_DOJOS_LOCATION / "no_practice_challenge.yml").read(), session=admin_session)
+
+@pytest.fixture(scope="session")
+def no_practice_dojo(admin_session):
+    return create_dojo_yml(open(TEST_DOJOS_LOCATION / "no_practice_dojo.yml").read(), session=admin_session)
+
+@pytest.fixture(scope="session")
 def welcome_dojo(admin_session):
     try:
         rid = create_dojo("pwncollege/welcome-dojo", session=admin_session)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -65,6 +65,12 @@ def no_practice_challenge_dojo(admin_session):
     return create_dojo_yml(open(TEST_DOJOS_LOCATION / "no_practice_challenge.yml").read(), session=admin_session)
 
 @pytest.fixture(scope="session")
+def no_import_challenge_dojo(admin_session):
+    rid = create_dojo_yml(open(TEST_DOJOS_LOCATION / "no_import_challenge.yml").read(), session=admin_session)
+    make_dojo_official(rid, admin_session)
+    return rid
+
+@pytest.fixture(scope="session")
 def no_practice_dojo(admin_session):
     return create_dojo_yml(open(TEST_DOJOS_LOCATION / "no_practice_dojo.yml").read(), session=admin_session)
 

--- a/test/dojos/forbidden_import.yml
+++ b/test/dojos/forbidden_import.yml
@@ -1,0 +1,11 @@
+id: forbidden-import
+type: public
+modules:
+  - id: test
+    challenges:
+      - id: test
+        import:
+          dojo: no-import-challenge
+          module: test
+          challenge: test
+      

--- a/test/dojos/no_import_challenge.yml
+++ b/test/dojos/no_import_challenge.yml
@@ -4,7 +4,7 @@ modules:
   - id: test
     challenges:
       - id: test
-        unimportable: true
+        importable: false
         import:
           dojo: example
           module: world

--- a/test/dojos/no_import_challenge.yml
+++ b/test/dojos/no_import_challenge.yml
@@ -1,0 +1,12 @@
+id: no-import-challenge
+type: public
+modules:
+  - id: test
+    challenges:
+      - id: test
+        unimportable: true
+        import:
+          dojo: example
+          module: world
+          challenge: earth
+      

--- a/test/dojos/no_practice_challenge.yml
+++ b/test/dojos/no_practice_challenge.yml
@@ -1,0 +1,12 @@
+id: no-practice-challenge
+type: public
+modules:
+  - id: test
+    challenges:
+      - id: test
+        practice_enabled: False
+        import:
+          dojo: example
+          module: world
+          challenge: earth
+      

--- a/test/dojos/no_practice_challenge.yml
+++ b/test/dojos/no_practice_challenge.yml
@@ -4,7 +4,7 @@ modules:
   - id: test
     challenges:
       - id: test
-        practice_enabled: False
+        allow_privileged: False
         import:
           dojo: example
           module: world

--- a/test/dojos/no_practice_dojo.yml
+++ b/test/dojos/no_practice_dojo.yml
@@ -1,0 +1,12 @@
+id: no-practice-challenge
+type: public
+practice_enabled: False
+modules:
+  - id: test
+    challenges:
+      - id: test
+        import:
+          dojo: example
+          module: world
+          challenge: earth
+      

--- a/test/dojos/no_practice_dojo.yml
+++ b/test/dojos/no_practice_dojo.yml
@@ -1,4 +1,4 @@
-id: no-practice-challenge
+id: no-practice-dojo
 type: public
 allow_privileged: False
 modules:

--- a/test/dojos/no_practice_dojo.yml
+++ b/test/dojos/no_practice_dojo.yml
@@ -1,6 +1,6 @@
 id: no-practice-challenge
 type: public
-practice_enabled: False
+allow_privileged: False
 modules:
   - id: test
     challenges:

--- a/test/test_running.py
+++ b/test/test_running.py
@@ -125,6 +125,22 @@ def test_dojo_completion(simple_award_dojo, completionist_user):
     assert len(us["badges"]) == 1
 
 @pytest.mark.dependency(depends=["test_join_dojo"])
+def test_no_practice(no_practice_challenge_dojo, no_practice_dojo, random_user):
+    _, session = random_user
+    for dojo in [ no_practice_challenge_dojo, no_practice_dojo ]:
+        response = session.get(f"{PROTO}://{HOST}/dojo/{dojo}/join/")
+        assert response.status_code == 200
+        response = session.post(f"{PROTO}://{HOST}/pwncollege_api/v1/docker", json={
+            "dojo": dojo,
+            "module": "test",
+            "challenge": "test",
+            "practice": True
+        })
+        assert response.status_code == 200
+        assert not response.json()["success"]
+        assert "practice" in response.json()["error"]
+
+@pytest.mark.dependency(depends=["test_join_dojo"])
 def test_prune_dojo_awards(simple_award_dojo, admin_session, completionist_user):
     user_name, _ = completionist_user
     db_sql(f"DELETE FROM solves WHERE user_id={get_user_id(user_name)} LIMIT 1")

--- a/test/test_running.py
+++ b/test/test_running.py
@@ -7,9 +7,9 @@ import subprocess
 import requests
 import pytest
 
-#pylint:disable=redefined-outer-name,use-dict-literal,missing-timeout,unspecified-encoding,consider-using-with
+#pylint:disable=redefined-outer-name,use-dict-literal,missing-timeout,unspecified-encoding,consider-using-with,unused-argument
 
-from utils import PROTO, HOST, login, dojo_run, workspace_run
+from utils import TEST_DOJOS_LOCATION, PROTO, HOST, login, dojo_run, workspace_run, create_dojo_yml
 
 def get_flag(user):
     return workspace_run("cat /flag", user=user, root=True).stdout
@@ -139,6 +139,15 @@ def test_no_practice(no_practice_challenge_dojo, no_practice_dojo, random_user):
         assert response.status_code == 200
         assert not response.json()["success"]
         assert "practice" in response.json()["error"]
+
+@pytest.mark.dependency(depends=["test_join_dojo"])
+def test_no_import(no_import_challenge_dojo, admin_session):
+    try:
+        create_dojo_yml(open(TEST_DOJOS_LOCATION / "forbidden_import.yml").read(), session=admin_session)
+    except AssertionError as e:
+        assert "Import disallowed" in str(e)
+    else:
+        raise AssertionError("forbidden-import dojo creation should have failed, but it succeeded")
 
 @pytest.mark.dependency(depends=["test_join_dojo"])
 def test_prune_dojo_awards(simple_award_dojo, admin_session, completionist_user):


### PR DESCRIPTION
Practice mode makes it difficult to have challenges with static secret sauce. @ltfish and others have workarounds where they detect practice mode and delete secrets, but we should make this easier.

A side benefit of allowing disabling of practice mode is that we'll be able to disable practice mode on the early levels of the welcome dojo, until practice mode is discussed.

Deployment caveat: this adds a column to DojoChallenges.