### PR TITLE
display IDs when names are not set

### DIFF
--- a/dojo_theme/templates/dojo.html
+++ b/dojo_theme/templates/dojo.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="jumbotron">
   <div class="container">
-    <h1>{{ dojo.name }}</h1>
+    <h1>{{ dojo.name or dojo.id }}</h1>
   </div>
 </div>
 <div class="container">
@@ -69,7 +69,7 @@
       {# TODO: card-active, card-hidden #}
       <li class="card card-small">
         <div class="card-body">
-          <h4 class="card-title">{{ module.name }}</h4>
+          <h4 class="card-title">{{ module.name or module.id }}</h4>
           <p class="card-text">
             {{ module.solves(user=user, ignore_visibility=True, ignore_admins=False).count() if user else 0 }} / {{ module.visible_challenges() | length }}
           </p>

--- a/dojo_theme/templates/dojos.html
+++ b/dojo_theme/templates/dojos.html
@@ -27,7 +27,7 @@
     <ul class="card-list">
       {% for dojo in dojos %}
       {{ card(url_for("pwncollege_dojos.view_dojo", dojo=dojo.reference_id),
-      title=dojo.name,
+      title=dojo.name or dojo.id,
       text="{} Modules : ".format(dojo.modules | length) + "{} / {}".format(dojo.solves(user=user, ignore_visibility=True, ignore_admins=False).count() if user else 0, dojo.challenges | length),
       icon="/themes/dojo_theme/static/img/dojo/{}.svg".format(dojo.award.belt) if (dojo.award.belt and dojo.official) else None,
       emoji=dojo.award.emoji ) }}

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -4,9 +4,9 @@
 {% block content %}
 <div class="jumbotron">
   <div class="container">
-    <h1>{{ module.name }}</h1>
+    <h1>{{ module.name or module.id }}</h1>
     <br>
-    <h2 class="module-dojo"><a href="{{ url_for('pwncollege_dojos.view_dojo', dojo=dojo.reference_id) }}">{{ dojo.name }}</a></h2>
+    <h2 class="module-dojo"><a href="{{ url_for('pwncollege_dojos.view_dojo', dojo=dojo.reference_id) }}">{{ dojo.name or dojo.id }}</a></h2>
 
     {% if assessments %}
     <br>
@@ -70,7 +70,7 @@
         {% if header %}
           <h4 class="accordion-item-name {{ active }}">
             <span class="d-sm-block d-md-block d-lg-block">
-              <i class="fas fa-flag pr-3 {{ solved }}"></i>{{ challenge.name }}
+              <i class="fas fa-flag pr-3 {{ solved }}"></i>{{ challenge.name or challenge.id }}
               {% if not challenge.visible() %}
               <small><small><small>
                     <i>hidden</i> &mdash; you can see this because you are this dojo's administrator


### PR DESCRIPTION
We might as well display the IDs when people don't set names for everything in their dojos. This is especially useful for testcases, but I think will find use in general (better than displaying None or just blanks).