### PR TITLE
Make the default scoreboard monthly

### DIFF
--- a/dojo_theme/static/js/dojo/scoreboard.js
+++ b/dojo_theme/static/js/dojo/scoreboard.js
@@ -16,6 +16,13 @@ function loadScoreboard(duration, page) {
         return response.json()
     }).then(result => {
         scoreboard.empty();
+        $("#scoreboard-control-week").removeClass("scoreboard-page-selected");
+        $("#scoreboard-control-month").removeClass("scoreboard-page-selected");
+        $("#scoreboard-control-all").removeClass("scoreboard-page-selected");
+        if (duration == 7) $("#scoreboard-control-week").addClass("scoreboard-page-selected");
+        if (duration == 30) $("#scoreboard-control-month").addClass("scoreboard-page-selected");
+        if (duration == 0) $("#scoreboard-control-all").addClass("scoreboard-page-selected");
+
         const standings = result.standings;
         if (result.me) {
             if (result.me.rank < standings[0].rank)

--- a/dojo_theme/templates/dojo.html
+++ b/dojo_theme/templates/dojo.html
@@ -83,11 +83,6 @@
 
   <h2 class="row">Dojo Rankings:</h2>
   <br>
-  <p>
-    <a href="javascript:loadScoreboard(7, 1)">Week</a> |
-    <a href="javascript:loadScoreboard(30, 1)">Month</a> |
-    <a href="javascript:loadScoreboard(0, 1)">All Time</a>
-  </p>
   {% from "macros/scoreboard.html" import scoreboard %}
   {{ scoreboard() }}
 </div>

--- a/dojo_theme/templates/dojo.html
+++ b/dojo_theme/templates/dojo.html
@@ -89,6 +89,6 @@
 {% endblock %}
 
 {% block scripts %}
-<script defer onload="loadScoreboard(0, 1);" src="{{ url_for('views.themes', path='js/dojo/scoreboard.js') }}"></script>
+<script defer onload="loadScoreboard(30, 1);" src="{{ url_for('views.themes', path='js/dojo/scoreboard.js') }}"></script>
 <script defer src="{{ url_for('views.themes', path='js/dojo/copy.js') }}"></script>
 {% endblock %}

--- a/dojo_theme/templates/macros/scoreboard.html
+++ b/dojo_theme/templates/macros/scoreboard.html
@@ -1,31 +1,31 @@
 {% macro scoreboard() -%}
-  <div class="scoreboard-controls row">
-    <p>
-    <a href="javascript:loadScoreboard(7, 1)">Week</a> |
-    <a href="javascript:loadScoreboard(30, 1)">Month</a> |
-    <a href="javascript:loadScoreboard(0, 1)">All Time</a>
-    </p>
+<div class="scoreboard-controls row">
+  <p>
+  <a href="javascript:loadScoreboard(7, 1)">Week</a> |
+  <a href="javascript:loadScoreboard(30, 1)">Month</a> |
+  <a href="javascript:loadScoreboard(0, 1)">All Time</a>
+  </p>
+</div>
+<div class="scoreboard row">
+  <div class="col-md-12 p-0">
+    <table class="table table-striped">
+	    <thead>
+	      <tr>
+	        <td scope="col" class="col-md-1"><b>Rank</b></td>
+          <td scope="col" class="col-md-1"></td>
+	        <td scope="col" class="col-md-4"><b>Hacker</b></td>
+	        <td scope="col" class="col-md-4"><b>Badges</b></td>
+	        <td scope="col" class="col-md-1"></td>
+	        <td scope="col" class="col-md-1"><b>Score</b></td>
+	      </tr>
+	    </thead>
+	    <tbody id="scoreboard">
+	    </tbody>
+    </table>
   </div>
-  <div class="scoreboard row">
-    <div class="col-md-12 p-0">
-      <table class="table table-striped">
-	<thead>
-	  <tr>
-	    <td scope="col" class="col-md-1"><b>Rank</b></td>
-            <td scope="col" class="col-md-1"></td>
-	    <td scope="col" class="col-md-4"><b>Hacker</b></td>
-	    <td scope="col" class="col-md-4"><b>Badges</b></td>
-	    <td scope="col" class="col-md-1"></td>
-	    <td scope="col" class="col-md-1"><b>Score</b></td>
-	  </tr>
-	</thead>
-	<tbody id="scoreboard">
-	</tbody>
-      </table>
-    </div>
-    <div>
-      <ul id="scoreboard-pages" class="p-0">
-      </ul>
-    </div>
+  <div>
+    <ul id="scoreboard-pages" class="p-0">
+    </ul>
   </div>
+</div>
 {%- endmacro %}

--- a/dojo_theme/templates/macros/scoreboard.html
+++ b/dojo_theme/templates/macros/scoreboard.html
@@ -1,9 +1,9 @@
 {% macro scoreboard() -%}
 <div class="scoreboard-controls row">
   <p>
-  <a href="javascript:loadScoreboard(7, 1)">Week</a> |
-  <a href="javascript:loadScoreboard(30, 1)">Month</a> |
-  <a href="javascript:loadScoreboard(0, 1)">All Time</a>
+  <span id="scoreboard-control-week"><a href="javascript:loadScoreboard(7, 1)">Week</a></span> |
+  <span id="scoreboard-control-month"><a href="javascript:loadScoreboard(30, 1)">Month</a></span> |
+  <span id="scoreboard-control-all"><a href="javascript:loadScoreboard(0, 1)">All Time</a></span>
   </p>
 </div>
 <div class="scoreboard row">

--- a/dojo_theme/templates/macros/scoreboard.html
+++ b/dojo_theme/templates/macros/scoreboard.html
@@ -1,4 +1,11 @@
 {% macro scoreboard() -%}
+  <div class="scoreboard-controls row">
+    <p>
+    <a href="javascript:loadScoreboard(7, 1)">Week</a> |
+    <a href="javascript:loadScoreboard(30, 1)">Month</a> |
+    <a href="javascript:loadScoreboard(0, 1)">All Time</a>
+    </p>
+  </div>
   <div class="scoreboard row">
     <div class="col-md-12 p-0">
       <table class="table table-striped">

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -138,5 +138,5 @@
 
 {% block scripts %}
 <script defer src="{{ url_for('views.themes', path='js/dojo/challenges.js') }}"></script>
-<script defer onload="loadScoreboard(0, 1);" src="{{ url_for('views.themes', path='js/dojo/scoreboard.js') }}"></script>
+<script defer onload="loadScoreboard(30, 1);" src="{{ url_for('views.themes', path='js/dojo/scoreboard.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
We'd discussed the annoyance of the static scoreboards. This PR makes the scoreboards monthly (by default), moves the duration controls into the scoreboard macro itself, and bolds the currently-active one.