### PR TITLE
Add a few loading messages to reduce learner anxiety

### DIFF
--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -135,6 +135,18 @@ function startChallenge(event) {
         "practice": practice,
     };
 
+    var result_notification = item.find('#result-notification');
+    var result_message = item.find('#result-message');
+    result_notification.addClass('alert alert-warning alert-dismissable text-center');
+    result_message.html("Loading.");
+    result_notification.slideDown();
+    setTimeout(function loadmsg() {
+        if (result_message.html().startsWith("Loading")) {
+            result_message.append(".");
+            setTimeout(loadmsg, 500);
+        }
+    }, 500);
+
     CTFd.fetch('/pwncollege_api/v1/docker', {
         method: 'POST',
         credentials: 'same-origin',

--- a/dojo_theme/static/js/dojo/scoreboard.js
+++ b/dojo_theme/static/js/dojo/scoreboard.js
@@ -4,6 +4,16 @@ function loadScoreboard(duration, page) {
     const scoreboard = $("#scoreboard");
 
     const endpoint = `/pwncollege_api/v1/scoreboard/${dojo}/${module}/${duration}/${page}`;
+    scoreboard.empty();
+    message = "Loading."
+    scoreboard.html(`<td colspan=6>${message}</td>`);
+    setTimeout(function loadmsg() {
+        if (scoreboard.html().includes(message)) {
+            message += "."
+            scoreboard.html(`<td colspan=6>${message}</td>`);
+            setTimeout(loadmsg, 1000);
+        }
+    }, 500);
 
     CTFd.fetch(endpoint, {
         method: "GET",


### PR DESCRIPTION
I got interesting feedback recently from someone that watched their teenage child interact with the dojo, and a surprising source of frustration was the lack of feedback about, e.g., what is happening when you click "Start". To address this, I added loading messages to challenge starting and (bonus) to scoreboard loading.