### PR TITLE
Fix marking currently active challenge.

### DIFF
--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -431,6 +431,7 @@ def get_current_dojo_challenge(user=None):
     return (
         DojoChallenges.query
         .filter(DojoChallenges.id == container.labels.get("dojo.challenge_id"),
+                DojoChallenges.module == DojoModules.from_id(container.labels.get("dojo.dojo_id"), container.labels.get("dojo.module_id")).first(),
                 DojoChallenges.dojo == Dojos.from_id(container.labels.get("dojo.dojo_id")).first())
         .first()
     )

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -68,7 +68,7 @@
       {% set active = "challenge-active" if challenge.challenge_id == current_dojo_challenge.challenge_id else "" %}
       {% call(header) accordion_item("challenges", loop.index) %}
         {% if header %}
-          <h4 class="accordion-item-name {{ active }}">
+          <h4 class="accordion-item-name challenge-name {{ active }}">
             <span class="d-sm-block d-md-block d-lg-block">
               <i class="fas fa-flag pr-3 {{ solved }}"></i>{{ challenge.name or challenge.id }}
               {% if not challenge.visible() %}


### PR DESCRIPTION
Fix #326 

The issue of marking an active challenge after starting a challenge is because the `challenge-name` id is missing here: https://github.com/pwncollege/dojo/blob/2f3b3d9e2bb21a3d431cea0be39015e639880863/dojo_theme/templates/module.html#L71 
so adding `challenge-name` back fixed this check:
https://github.com/pwncollege/dojo/blob/2f3b3d9e2bb21a3d431cea0be39015e639880863/dojo_theme/static/js/dojo/challenges.js#L154

The issue of not marking the active challenge on refresh is because of this check: 
https://github.com/pwncollege/dojo/blob/2f3b3d9e2bb21a3d431cea0be39015e639880863/dojo_theme/templates/module.html#L68
`current_dojo_challenge` is set by the `get_current_dojo_challenge` function in: 
https://github.com/pwncollege/dojo/blob/2f3b3d9e2bb21a3d431cea0be39015e639880863/dojo_plugin/utils/dojo.py#L405-L415

This function only filters by the `level_id` and `dojo_id` strings. The problem is within a dojo, there can be shared `level_id` strings in different modules.

In the `system-security` dojo, `sandboxing` module, the `level_id` string follows this format ` `level-1`, `level-2`, `level-3`, etc. It is also the first module in the dojo hence lower `challenge_id` numbers. So this filtering issue will not affect the `sandboxing` module. 

The next module, `race-conditions` is also not affected because the `level_id` string follows a slightly different format `level-1-0`,  `level-1-1`,  `level-2-0`, etc.

The next module, `kernel-security` shares the same `level_id` string format as `race-conditions`, the filtering is an issue here because the `get_current_dojo_challenge` will return the first result of the query, it will return the challenge with the corresponding `level_id` string of the `race-conditions` module. But `level-12.0` and  `level-12.1` are not an issue since they are not in the `race-conditions` module. 

You can quickly see this by launching one of the affected levels and go [ here ](https://pwn.college/pwncollege_api/v1/docker), which returns details about the current level by calling `get_current_dojo_challenge`, you will see that if you launch challenge 1.0 - 11.1 in `kernel-security` module, `get_current_dojo_challenge` will actually return challenges for the `race-conditions`. 

The same thing applies to the `system-exploitation` module, it shares the same format as the previous module and there are no unique `level_id` strings, so all the levels are affected. 

The above production dojo behaviors are consistent with my local version.

I think the fix is to also filter by the `module_id` string when querying for the current level by using the container labels.,

So I added this condition:
```python
DojoChallenges.module == DojoModules.from_id(container.labels.get("dojo.dojo_id"), container.labels.get("dojo.module_id")).first()
```

I have tested it locally and it works (after launching a challenge the current level will get marked correctly on fresh and after starting the challenge without refresh). 
