### PR TITLE
Dojo: Increase admin visibility

### DIFF
--- a/dojo_plugin/pages/dojos.py
+++ b/dojo_plugin/pages/dojos.py
@@ -13,7 +13,7 @@ from CTFd.plugins import bypass_csrf_protection
 
 from ..models import DojoAdmins, DojoChallenges, DojoMembers, DojoModules, DojoUsers, Dojos
 from ..utils import user_dojos
-from ..utils.dojo import dojo_route, generate_ssh_keypair, dojo_update
+from ..utils.dojo import dojo_route, generate_ssh_keypair, dojo_update, dojo_admins_only
 
 
 dojos = Blueprint("pwncollege_dojos", __name__)
@@ -115,18 +115,15 @@ def update_dojo(dojo, update_code=None):
 
 @dojos.route("/dojo/<dojo>/admin/")
 @dojo_route
+@dojo_admins_only
 def view_dojo_admin(dojo):
-    if not dojo.is_admin():
-        abort(403)
     return render_template("dojo_admin.html", dojo=dojo, is_admin=is_admin)
 
 
 @dojos.route("/dojo/<dojo>/admin/activity")
 @dojo_route
+@dojo_admins_only
 def view_dojo_activity(dojo):
-    if not dojo.is_admin():
-        abort(403)
-
     docker_client = docker.from_env()
     filters = {
         "name": "user_",
@@ -158,9 +155,8 @@ def view_dojo_activity(dojo):
 
 @dojos.route("/dojo/<dojo>/admin/solves.csv")
 @dojo_route
+@dojo_admins_only
 def view_dojo_solves(dojo):
-    if not dojo.is_admin():
-        abort(403)
     def stream():
         yield "user,module,challenge,time\n"
         solves = (

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -395,7 +395,7 @@ def dojo_admins_only(func):
         bound_args.apply_defaults()
 
         dojo = bound_args.arguments["dojo"]
-        if not dojo.is_admin(get_current_user()):
+        if not (dojo.is_admin(get_current_user()) or is_admin()):
             abort(403)
         return func(*bound_args.args, **bound_args.kwargs)
     return wrapper

--- a/dojo_theme/templates/dojo.html
+++ b/dojo_theme/templates/dojo.html
@@ -25,7 +25,7 @@
       </figure>
     </div>
     {% endif %}
-    {% if dojo_user.type == "admin" %}
+    {% if dojo_user.type == "admin" or user.type == "admin" %}
     <div class="col-lg-auto m-3">
       <figure>
         <a class="text-decoration-none" href="{{ url_for('pwncollege_dojos.view_dojo_admin', dojo=dojo.reference_id) }}">


### PR DESCRIPTION
Motivated from the Discord:

> Hi Dr. Kanak, I have a question about the owner/creator of one dojo and the dojo admin. It seems some functionability (e.g., make the dojo official) needs both roles satisfied.
> And I encountered a wired issue in making one dojo official: The owner A creates a dojo. He/She can see this dojo in its management webpage and have “Promote to Admin”, but does not have "Make the dojo official". However, the dojo admin cannot access this dojo with admin privilege.
> So we need to resort to database modification about this operation
> 