### PR TITLE
Add dojo-LFS support

### DIFF
--- a/dojo_plugin/api/v1/dojo.py
+++ b/dojo_plugin/api/v1/dojo.py
@@ -25,45 +25,30 @@ from CTFd.utils.modes import get_model
 from CTFd.utils.security.sanitize import sanitize_html
 
 from ...models import Dojos, DojoMembers, DojoAdmins, DojoUsers, Emojis
-from ...utils.dojo import dojo_accessible, dojo_clone, dojo_from_dir, dojo_from_spec, dojo_route, dojo_admins_only
+from ...utils.dojo import dojo_accessible, dojo_clone, dojo_from_dir, dojo_yml_dir, dojo_route, dojo_admins_only
 
 
 dojo_namespace = Namespace(
     "dojo", description="Endpoint to manage dojos"
 )
 
-def create_dojo_yml(user, spec):
-    DOJO_EXISTS = "This repository already exists as a dojo"
-    try:
-        dojo = dojo_from_spec(spec)
-        dojo.admins = [DojoAdmins(user=user)]
-
-        db.session.add(dojo)
-        db.session.commit()
-    except IntegrityError as e:
-        return {"success": False, "error": DOJO_EXISTS}, 400
-
-    except AssertionError as e:
-        return {"success": False, "error": str(e)}, 400
-
-    except Exception as e:
-        print("ERROR: Dojo from spec failed", file=sys.stderr, flush=True)
-        traceback.print_exc(file=sys.stderr)
-        return {"success": False, "error": str(e)}, 400
-
-    return {"success": True, "dojo": dojo.reference_id}, 200
-
-def create_dojo(user, repository, public_key, private_key):
+def create_dojo(user, repository, public_key, private_key, spec):
     DOJO_EXISTS = "This repository already exists as a dojo"
 
     try:
-        repository_re = r"[\w\-]+/[\w\-]+"
-        repository = repository.replace("https://github.com/", "")
-        assert re.match(repository_re, repository), f"Invalid repository, expected format: <code>{repository_re}</code>"
+        if repository:
+            repository_re = r"[\w\-]+/[\w\-]+"
+            repository = repository.replace("https://github.com/", "")
+            assert re.match(repository_re, repository), f"Invalid repository, expected format: <code>{repository_re}</code>"
 
-        assert not Dojos.query.filter_by(repository=repository).first(), DOJO_EXISTS
+            assert not Dojos.query.filter_by(repository=repository).first(), DOJO_EXISTS
 
-        dojo_dir = dojo_clone(repository, private_key)
+            dojo_dir = dojo_clone(repository, private_key)
+        elif spec:
+            assert is_admin(), "Must be an admin user to create dojos from spec rather than repositories"
+            dojo_dir = dojo_yml_dir(spec)
+            repository, public_key, private_key = None, None, None
+
         dojo_path = pathlib.Path(dojo_dir.name)
 
         dojo = dojo_from_dir(dojo_path)
@@ -141,12 +126,6 @@ class PromoteAdmin(Resource):
         db.session.commit()
         return {"success": True}
 
-@dojo_namespace.route("/create-spec")
-class CreateDojoSpec(Resource):
-    @admins_only
-    def post(self):
-        return create_dojo_yml(get_current_user(), yaml.safe_load(request.get_json()["spec"]))
-
 @dojo_namespace.route("/create")
 class CreateDojo(Resource):
     @authed_only
@@ -155,6 +134,7 @@ class CreateDojo(Resource):
         user = get_current_user()
 
         repository = data.get("repository", "")
+        spec = data.get("spec", "")
         public_key = data.get("public_key", "")
         private_key = data.get("private_key", "").replace("\r\n", "\n")
 
@@ -164,7 +144,7 @@ class CreateDojo(Resource):
         if not is_admin() and cache.get(key) is not None:
             return {"success": False, "error": "You can only create 1 dojo per day."}, 429
 
-        result = create_dojo(user, repository, public_key, private_key)
+        result = create_dojo(user, repository, public_key, private_key, spec)
         if result[0]["success"]:
             cache.set(key, 1, timeout=timeout)
 

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -337,6 +337,14 @@ def generate_ssh_keypair():
 
     return (public_key.read_text().strip(), private_key.read_text())
 
+def dojo_yml_dir(spec):
+    tmp_dojos_dir = DOJOS_DIR / "tmp"
+    tmp_dojos_dir.mkdir(exist_ok=True)
+    yml_dir = tempfile.TemporaryDirectory(dir=tmp_dojos_dir)    # TODO: ignore_cleanup_errors=True
+    yml_dir_path = pathlib.Path(yml_dir.name)
+    with open(yml_dir_path / "dojo.yml", "w") as do:
+        do.write(spec)
+    return yml_dir
 
 def dojo_clone(repository, private_key):
     tmp_dojos_dir = DOJOS_DIR / "tmp"

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -181,6 +181,7 @@ def load_dojo_subyamls(data, dojo_dir):
 
 def dojo_initialize_files(data, dojo_dir):
     for dojo_file in data.get("files", []):
+        assert is_admin(), f"LFS support requires admin privileges"
         rel_path = dojo_dir / dojo_file["path"]
         abs_path = dojo_dir / rel_path
         assert not abs_path.is_symlink(), f"{rel_path} is a symbolic link!"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -75,6 +75,10 @@ def no_practice_dojo(admin_session):
     return create_dojo_yml(open(TEST_DOJOS_LOCATION / "no_practice_dojo.yml").read(), session=admin_session)
 
 @pytest.fixture(scope="session")
+def lfs_dojo(admin_session):
+    return create_dojo_yml(open(TEST_DOJOS_LOCATION / "lfs_dojo.yml").read(), session=admin_session)
+
+@pytest.fixture(scope="session")
 def welcome_dojo(admin_session):
     try:
         rid = create_dojo("pwncollege/welcome-dojo", session=admin_session)

--- a/test/dojos/lfs_dojo.yml
+++ b/test/dojos/lfs_dojo.yml
@@ -1,0 +1,10 @@
+id: lfs
+type: public
+modules:
+  - id: test
+    challenges:
+      - id: test
+files:
+  - type: download
+    url: "https://www.dropbox.com/scl/fi/deyhfwioo3d824ext4k42/dojo.txt?rlkey=h1wmm4oe9hq67ooan9oh2r36j&dl=1"
+    path: "test/test/dojo.txt"

--- a/test/test_running.py
+++ b/test/test_running.py
@@ -141,6 +141,16 @@ def test_no_practice(no_practice_challenge_dojo, no_practice_dojo, random_user):
         assert "practice" in response.json()["error"]
 
 @pytest.mark.dependency(depends=["test_join_dojo"])
+def test_lfs(lfs_dojo, random_user):
+    uid, session = random_user
+    assert session.get(f"{PROTO}://{HOST}/dojo/{lfs_dojo}/join/").status_code == 200
+    start_challenge(lfs_dojo, "test", "test", session=session)
+    try:
+        workspace_run("[ -f '/challenge/dojo.txt' ]", user=uid)
+    except subprocess.CalledProcessError:
+        assert False, "LFS didn't create dojo.txt"
+
+@pytest.mark.dependency(depends=["test_join_dojo"])
 def test_no_import(no_import_challenge_dojo, admin_session):
     try:
         create_dojo_yml(open(TEST_DOJOS_LOCATION / "forbidden_import.yml").read(), session=admin_session)

--- a/test/utils.py
+++ b/test/utils.py
@@ -46,7 +46,7 @@ def create_dojo(repository, *, session):
     return dojo_reference_id
 
 def create_dojo_yml(spec, *, session):
-    response = session.post(f"{PROTO}://{HOST}/pwncollege_api/v1/dojo/create-spec", json={"spec": spec})
+    response = session.post(f"{PROTO}://{HOST}/pwncollege_api/v1/dojo/create", json={"spec": spec})
     assert response.status_code == 200, f"Expected status code 200, but got {response.status_code} - {response.json()}"
     dojo_reference_id = response.json()["dojo"]
     return dojo_reference_id


### PR DESCRIPTION
github doesn't allow very large files to be checked into git repos, which is problematic for some dojos that need, e.g., different kernel builds. This adds support for downloading files post-clone.