### PR TITLE
Allow better support of externally hosted DBs

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,6 +1,5 @@
 FROM mariadb:10.4.12
 
 COPY ./start.sh /start.sh
-RUN chmod +x /start.sh
 USER mysql
 

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,0 +1,6 @@
+FROM mariadb:10.4.12
+
+COPY ./start.sh /start.sh
+RUN chmod +x /start.sh
+USER mysql
+

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,5 +1,3 @@
 FROM mariadb:10.4.12
 
 COPY ./start.sh /start.sh
-USER mysql
-

--- a/db/start.sh
+++ b/db/start.sh
@@ -2,7 +2,7 @@
 
 if [ "${DB_EXTERNAL:-no}" = "no" ]
 then
-    mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --wait_timeout=28800 --log-warnings=0
+    /docker-entrypoint.sh mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --wait_timeout=28800 --log-warnings=0
 else
     while true; do sleep 86400; done
 fi

--- a/db/start.sh
+++ b/db/start.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ "${DB_EXTERNAL:-no}" = "no" ]
+then
+    mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --wait_timeout=28800 --log-warnings=0
+else
+    while true; do sleep 86400; done
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,18 +119,20 @@ services:
 
   db:
     container_name: db
-    image: mariadb:10.4.12
+    build:
+      context: ./db
     restart: always
     environment:
       - MYSQL_ROOT_PASSWORD=${DB_PASS}
       - MYSQL_USER=${DB_USER}
       - MYSQL_PASSWORD=${DB_PASS}
       - MYSQL_DATABASE=${DB_NAME}
+      - DB_EXTERNAL=${DB_EXTERNAL}
     volumes:
       - ./data/mysql:/var/lib/mysql
-    command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --wait_timeout=28800, --log-warnings=0]
+    command: [/start.sh]
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-pctfd"]
+      test: ["CMD", "mysqladmin", "ping", "-p${DB_PASS}", "-u${DB_USER}", "-h${DB_HOST}"]
       interval: 10s
       timeout: 10s
       retries: 3

--- a/script/container-setup.sh
+++ b/script/container-setup.sh
@@ -39,6 +39,7 @@ define DB_HOST db
 define DB_NAME ctfd
 define DB_USER ctfd
 define DB_PASS ctfd
+define DB_EXTERNAL no # change to anything but no and the db container will not start mysql
 
 mv $DOJO_DIR/data/.config.env $DOJO_DIR/data/config.env
 . $DOJO_DIR/data/config.env

--- a/script/dojo
+++ b/script/dojo
@@ -13,7 +13,7 @@ fi
 DOCKER_ARGS=${DOCKER_ARGS:--i}
 [ -t 0 ] && DOCKER_ARGS="-t $DOCKER_ARGS"
 
-CONTAINER_WITH_MYSQL=sshd
+CONTAINER_WITH_MYSQL=db
 
 DOJO_DIR=/opt/pwn.college
 . $DOJO_DIR/data/config.env

--- a/script/dojo
+++ b/script/dojo
@@ -16,7 +16,9 @@ DOCKER_ARGS=${DOCKER_ARGS:--i}
 CONTAINER_WITH_MYSQL=db
 
 DOJO_DIR=/opt/pwn.college
-. $DOJO_DIR/data/config.env
+if [ -f $DOJO_DIR/data/config.env ]; then
+    . $DOJO_DIR/data/config.env
+fi
 
 case "$ACTION" in
     # HELP: update: update dojo files (warning: does `git pull`), rebuild containers, and restart any changed services


### PR DESCRIPTION
This way, the docker-compose.yml file does not need to change to support an external db.

Now the db container will detect the DB_EXTERNAL environment variable, and if it is not `no` then the db container will just sleep rather than start up mysql.