### PR TITLE
Windows VM improvments

### DIFF
--- a/challenge/windows/post_install.ps1
+++ b/challenge/windows/post_install.ps1
@@ -25,6 +25,4 @@ cl challenge-proxy.c
 
 
 # -- shutdown --
-Set-Service -Name sshd -StartupType Manual
-Set-Service -Name tvnserver -StartupType Manual
 Stop-Computer -computername localhost

--- a/challenge/windows/post_install.ps1
+++ b/challenge/windows/post_install.ps1
@@ -25,4 +25,4 @@ cl challenge-proxy.c
 
 
 # -- shutdown --
-Stop-Computer -computername localhost
+Stop-Computer -computername localhost -force

--- a/challenge/windows/setup.ps1
+++ b/challenge/windows/setup.ps1
@@ -253,5 +253,9 @@ Add-Content -Path $env:windir\System32\drivers\etc\hosts -Value "`n$ip`tpublic-l
 Copy-Item A:\config_startup.ps1 -Destination "C:\Program Files\Common Files\startup.ps1"
 & schtasks /create /tn "dojoinit" /sc onstart /delay 0000:00 /rl highest /ru system /tr "powershell.exe -file 'C:\Program Files\Common Files\startup.ps1'" /f
 
+# config services' StartupType to start when Start-Service is called or manually started (Manual) instead of start with Windows (Automatic)
+Set-Service -Name sshd -StartupType Manual
+Set-Service -Name tvnserver -StartupType Manual
+
 # -- shutdown --
 Stop-Computer -computername localhost -force

--- a/challenge/windows/setup.ps1
+++ b/challenge/windows/setup.ps1
@@ -109,7 +109,7 @@ function EnableWmiRemoting($namespace) {
         throw "GetSecurityDescriptor failed: $($output.ReturnValue)"
     }
     $acl = $output.Descriptor
-    
+
     $computerName = (Get-WmiObject Win32_ComputerSystem).Name
     $acc = Get-WmiObject -Class Win32_Group -Filter "Domain='$computerName' and Name='Users'"
 
@@ -157,7 +157,7 @@ EnableWmiRemoting "Root/StandardCimv2"
 (Get-Content -Path C:\Windows\Temp\policy-edit.inf) `
     -replace "PasswordComplexity = 1", "PasswordComplexity = 0" `
     -replace "SeShutdownPrivilege .+", "`$0,hacker" `
-    -replace "SeRemoteShutdownPrivilege .+", "`$0,hacker" | 
+    -replace "SeRemoteShutdownPrivilege .+", "`$0,hacker" |
     Set-Content -Path C:\Windows\Temp\policy-edit.inf
 & secedit /configure /db C:\windows\security\local.sdb /cfg C:\Windows\Temp\policy-edit.inf
 Remove-Item -Force C:\Windows\Temp\policy-edit.inf

--- a/challenge/windows/startup.ps1
+++ b/challenge/windows/startup.ps1
@@ -36,7 +36,7 @@ if (Test-Path X:\practice-mode-enabled) {
   Add-LocalGroupMember -Group "Administrators" -Member hacker
 }
 
-logoff 1
+logoff console
 
 Start-Service sshd
 Start-Service tvnserver

--- a/challenge/windows/startup.ps1
+++ b/challenge/windows/startup.ps1
@@ -11,7 +11,7 @@ echo 'pwn.college{uninitialized}' > C:\flag
 # crash course in the footguns of NTFS's ACL based permissions system that I learned
 #  the hard way:
 # - a "Deny" rule will always take precedence over an "Allow" rule.
-#   For example: Admins Allow Read + Users Deny Read 
+#   For example: Admins Allow Read + Users Deny Read
 #   This will result in no one being able to read the flag because they all fall under
 #    the "Users" rule.
 # - ACLs inherit from the parent directory by default unless explicitly disabled.


### PR DESCRIPTION
Summary of changes:

1. The VNC service should not start with Windows because the VM should not be accessible by the user during the configuring steps in the `startup.ps1`. It should start at the end of startup.ps1 as intended. The `tvnserver` service is starting with Windows because, by default, its service type is `Automatic` which means it will start with Windows. The fix is to set the service type to Manual which means the service will only start if involved to start. I also added setting the service type of the `sshd` service to Manual even though it's already Manual by default just for clarity. So `Set-Service -Name sshd -StartupType Manual` is just there for clarity, it's not needed. After this change, the user will be able to connect to the VM via VNC after the configuring steps in `startup.ps1` instead of when Windows starts.

2. The `Stop-Computer` command will not be able to shut down Windows if there are users logged in and `-force` fixes that. 

3. Logoff by session name, `console`, instead of session ID since session ID can change when logon or logoff occurs.

I verified these changes locally, the vnc change from the user's perspective, and parsed the Windows Event log.

Windows Events Log parse after this change. It shows vnc server starts at end of startup.ps1 (at the `Starting ssh and vnc servers` line)
```
---------------------------------------------------------------------------------------------------------------------------
2024-03-31 04:56:11.801355 UTC - System start                                                                                                                                                           
---------------------------------------------------------------------------------------------------------------------------                                                                                                                                                                                                                                                     
2024-03-31 04:56:32.025317 UTC - OpenSSH - Server listening on :: port 22.                                                                                                                              
2024-03-31 04:56:32.025441 UTC - OpenSSH - Server listening on 0.0.0.0 port 22.                                                                                                                         
---------------------------------------------------------------------------------------------------------------------------                                                                                                                                                                                                                                               
2024-03-31 04:56:28.990228 UTC - startup-script - Started                                                                                                                                               
2024-03-31 04:56:29.974674 UTC - startup-script - Mounted X,Y,Z drive                                                                                                                                   
2024-03-31 04:56:31.818441 UTC - startup-script - Starting ssh and vnc servers                                                                                                                          
2024-03-31 04:56:32.193310 UTC - tvnserver - Service has been started successfully                                                                                                                      
2024-03-31 04:56:32.443436 UTC - startup-script - Finished                                                                                                                                              
2024-03-31 04:56:39.693353 UTC - tvnserver - Authentication passed by 10.0.2.2
---------------------------------------------------------------------------------------------------------------------------
```
