### PR TITLE
fix display of emoji not attached to a dojo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   smoketest:
     runs-on: ubuntu-22.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v3

--- a/dojo_plugin/utils/awards.py
+++ b/dojo_plugin/utils/awards.py
@@ -72,7 +72,7 @@ def get_viewable_emojis(user):
     emojis = (
         Emojis.query
         .join(Users)
-        .filter(~Users.hidden, Emojis.category.in_((*viewable_dojo_urls.keys(), None)))
+        .filter(~Users.hidden, db.or_(Emojis.category.in_((*viewable_dojo_urls.keys(), None)), Emojis.category == None))
         .order_by(Emojis.date)
         .with_entities(
             Emojis.name,


### PR DESCRIPTION
the recent performance fixes broke non-dojo-specific emojis from displaying. This fixes it.