### PR TITLE
Updates to emoji implementation

### DIFF
--- a/dojo_plugin/utils/awards.py
+++ b/dojo_plugin/utils/awards.py
@@ -158,5 +158,5 @@ def update_awards(user):
         emoji_award = Emojis.query.filter_by(user=user, name=emoji, category=dojo_id).first()
         if emoji_award:
             continue
-        db.session.add(Emojis(user=user, name=emoji, description=f"Awarded for completing the {dojo_name} dojo.", category=dojo_id))
+        db.session.add(Emojis(user=user, name="completion", description=f"Awarded for completing the {dojo_name} dojo.", category=dojo_id))
         db.session.commit()


### PR DESCRIPTION
Right now, we store emojis by putting the emoji in the name, a description, and a reference to the dojo (if any) for which the emoji was earned. This causes some headaches:

1. To understand the type of emoji, you need to actually read the description or remember what different emojis mean.
2. If we want to update an emoji (we did this for the welcome dojo, for example), we need to do crazy sql queries involving emoji, which is insane (and error prone, depending on one's terminal).

This PR changes the design to:

- the emoji name is a signifier for the type of emoji, such as "dojo_sensei", "completion", "bug_bounty", "first_place", etc.
- the emoji category remains the dojo hex id, if the emoji is bound to a dojo
- no one has to consult the description for anything
- the actual emoji to display is pulled, depending on the `name` field, from the `SPECIAL_EMOJIS` global or from the `dojo.data['award']['emoji']` of the respective dojo

The main effects have to do with dojos changing their awards:

1. When a dojo changes its emoji, the results are now immediately reflected rather than requiring manual effort. I'm not sure which style we prefer.
2. This means that the dojo can _delete_ its emoji, and then we don't know what emoji to display. Currently, this displays ❌ via `SPECIAL_EMOJIS["missing"]`

This PR maintains backwards compatibility with legacy emojis, though presumably we'll update the DB and remove that compatibility ASAP.

A further thing we might want to do is fix up emoji.category to key off the integer dojo ID, so that we can actually `join` onto it, but the current was is workable as well.