### PR TITLE
Add functionality for multiple ssh keys

### DIFF
--- a/dojo_plugin/api/v1/ssh_key.py
+++ b/dojo_plugin/api/v1/ssh_key.py
@@ -18,11 +18,9 @@ ssh_key_namespace = Namespace(
 @ssh_key_namespace.route("")
 class UpdateKey(Resource):
     @authed_only
-    def patch(self):
-
+    def post(self):
         data = request.get_json()
         key_value = data.get("ssh_key", "")
-
 
         if key_value:
             key_re = "ssh-(rsa|ed25519|dss) AAAA[0-9A-Za-z+/]+[=]{0,2}"
@@ -43,7 +41,6 @@ class UpdateKey(Resource):
             key = SSHKeys(user_id=user.id, value=key_value)
             db.session.add(key)
             db.session.commit()
-
         except IntegrityError:
             db.session.rollback()
             return (
@@ -53,11 +50,8 @@ class UpdateKey(Resource):
 
         return {"success": True}
     
-    
-@ssh_key_namespace.route("/delete")
-class DeleteKey(Resource):
     @authed_only
-    def patch(self):
+    def delete(self):
         data = request.get_json()
         key_value = data.get("ssh_key", "")
 

--- a/dojo_plugin/api/v1/ssh_key.py
+++ b/dojo_plugin/api/v1/ssh_key.py
@@ -55,7 +55,7 @@ class UpdateKey(Resource):
     
     
 @ssh_key_namespace.route("/delete")
-class UpdateKey(Resource):
+class DeleteKey(Resource):
     @authed_only
     def patch(self):
         data = request.get_json()

--- a/dojo_plugin/api/v1/ssh_key.py
+++ b/dojo_plugin/api/v1/ssh_key.py
@@ -38,12 +38,8 @@ class UpdateKey(Resource):
         user = get_current_user()
 
         try:
-            existing_key = SSHKeys.query.filter_by(user_id=user.id).first()
-            if not existing_key:
-                key = SSHKeys(user_id=user.id, value=key_value)
-                db.session.add(key)
-            else:
-                existing_key.value = key_value
+            key = SSHKeys(user_id=user.id, value=key_value)
+            db.session.add(key)
             db.session.commit()
         except IntegrityError:
             db.session.rollback()

--- a/dojo_plugin/api/v1/ssh_key.py
+++ b/dojo_plugin/api/v1/ssh_key.py
@@ -29,7 +29,7 @@ class UpdateKey(Resource):
                 return (
                     {
                         "success": False,
-                        "error": f"Invalid public key, expected format:<br><code>{key_re}</code>"
+                        "error": f"Invalid SSH Key, expected format:<br><code>{key_re}</code>"
                     },
                     400,
                 )
@@ -44,7 +44,7 @@ class UpdateKey(Resource):
         except IntegrityError:
             db.session.rollback()
             return (
-                {"success": False, "error": "Public key already in use"},
+                {"success": False, "error": "SSH Key already in use"},
                 400,
             )
 
@@ -60,7 +60,7 @@ class UpdateKey(Resource):
         key = SSHKeys.query.filter_by(user=user, value=key_value).first()
         if not key:
             return (
-                {"success": False, "error": "Key does not exist"},
+                {"success": False, "error": "SSH Key does not exist"},
                 400,
             )
 

--- a/dojo_plugin/api/v1/ssh_key.py
+++ b/dojo_plugin/api/v1/ssh_key.py
@@ -49,42 +49,22 @@ class UpdateKey(Resource):
             )
 
         return {"success": True}
-    
+
     @authed_only
     def delete(self):
         data = request.get_json()
         key_value = data.get("ssh_key", "")
 
-        data = request.get_json()
-        key_value = data.get("ssh_key", "")
-        if not key_value:
-            return (
-                    {
-                        "success": False,
-                        "error": "No key in request"
-                    },
-                    400,
-                )
-        
         user = get_current_user()
 
-        try:
-            current_key = SSHKeys.query.filter_by(value=key_value)
-            if not current_key.first(): 
-                return (
-                    {"success": False, "error": "Key does not exist"},
-                    400,
-                )
-            if not current_key.first().user_id != user: 
-                return (
-                    {"success": False, "error": "This is not your public key"},
-                    400,
-                )
-            current_key.delete()
-            db.session.commit()
-        except IntegrityError:
+        key = SSHKeys.query.filter_by(user=user, value=key_value).first()
+        if not key:
             return (
-                {"success": False, "errors": "Public key not currently in use"},
+                {"success": False, "error": "Key does not exist"},
                 400,
             )
+
+        db.session.delete(key)
+        db.session.commit()
+
         return {"success": True}

--- a/dojo_plugin/api/v1/ssh_key.py
+++ b/dojo_plugin/api/v1/ssh_key.py
@@ -44,7 +44,7 @@ class UpdateKey(Resource):
         except IntegrityError:
             db.session.rollback()
             return (
-                {"success": False, "errors": {"key": "Public key already in use"}},
+                {"success": False, "error": "Public key already in use"},
                 400,
             )
 

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -679,8 +679,9 @@ class DojoResourceVisibilities(db.Model):
 
 class SSHKeys(db.Model):
     __tablename__ = "ssh_keys"
+    id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(
-        db.Integer, db.ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+        db.Integer, db.ForeignKey("users.id", ondelete="CASCADE")
     )
     value = db.Column(db.Text, unique=True)
 

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -681,7 +681,7 @@ class SSHKeys(db.Model):
     __tablename__ = "ssh_keys"
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(
-        db.Integer, db.ForeignKey("users.id", ondelete="CASCADE")
+        db.Integer, db.ForeignKey("users.id", ondelete="CASCADE"), index=True
     )
     value = db.Column(db.Text, unique=True)
 

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -695,11 +695,10 @@ class DojoResourceVisibilities(db.Model):
 
 class SSHKeys(db.Model):
     __tablename__ = "ssh_keys"
-    id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(
-        db.Integer, db.ForeignKey("users.id", ondelete="CASCADE"), index=True
+        db.Integer, db.ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
     )
-    value = db.Column(db.Text, unique=True)
+    value = db.Column(db.String(512), primary_key=True, unique=True)
 
     user = db.relationship("Users")
 

--- a/dojo_plugin/pages/settings.py
+++ b/dojo_plugin/pages/settings.py
@@ -17,8 +17,8 @@ def settings_override():
     user = get_current_user()
     tokens = UserTokens.query.filter_by(user_id=user.id).all()
 
-    ssh_key = SSHKeys.query.filter_by(user_id=user.id).first()
-    ssh_key = ssh_key.value if ssh_key else None
+    ssh_keys = SSHKeys.query.filter_by(user_id=user.id).all()
+    # ssh_key = ssh_key.value if ssh_key else None
 
     discord_user = get_discord_user(user.id)
 
@@ -38,7 +38,7 @@ def settings_override():
         "settings.html",
         user=user,
         tokens=tokens,
-        ssh_key=ssh_key,
+        ssh_key=[i.value for i in ssh_keys],
         discord_enabled=bool(DISCORD_CLIENT_ID),
         discord_user=discord_user,
         discord_avatar_asset=discord_avatar_asset,

--- a/dojo_plugin/pages/settings.py
+++ b/dojo_plugin/pages/settings.py
@@ -17,8 +17,7 @@ def settings_override():
     user = get_current_user()
     tokens = UserTokens.query.filter_by(user_id=user.id).all()
 
-    ssh_keys = SSHKeys.query.filter_by(user_id=user.id).with_entities(SSHKeys.value).all()
-    # ssh_key = ssh_key.value if ssh_key else None
+    ssh_keys = SSHKeys.query.filter_by(user_id=user.id).all()
 
     discord_user = get_discord_user(user.id)
 
@@ -38,7 +37,7 @@ def settings_override():
         "settings.html",
         user=user,
         tokens=tokens,
-        ssh_keys=[i.value for i in ssh_keys],
+        ssh_keys=[key.value for key in ssh_keys],
         discord_enabled=bool(DISCORD_CLIENT_ID),
         discord_user=discord_user,
         discord_avatar_asset=discord_avatar_asset,

--- a/dojo_plugin/pages/settings.py
+++ b/dojo_plugin/pages/settings.py
@@ -17,7 +17,7 @@ def settings_override():
     user = get_current_user()
     tokens = UserTokens.query.filter_by(user_id=user.id).all()
 
-    ssh_keys = SSHKeys.query.filter_by(user_id=user.id).all()
+    ssh_keys = SSHKeys.query.filter_by(user_id=user.id).with_entities(SSHKeys.value).all()
     # ssh_key = ssh_key.value if ssh_key else None
 
     discord_user = get_discord_user(user.id)
@@ -38,7 +38,7 @@ def settings_override():
         "settings.html",
         user=user,
         tokens=tokens,
-        ssh_key=[i.value for i in ssh_keys],
+        ssh_keys=[i.value for i in ssh_keys],
         discord_enabled=bool(DISCORD_CLIENT_ID),
         discord_user=discord_user,
         discord_avatar_asset=discord_avatar_asset,

--- a/dojo_theme/static/js/dojo/settings.js
+++ b/dojo_theme/static/js/dojo/settings.js
@@ -75,6 +75,7 @@ function button_fetch_and_show(name, endpoint, method,data, success_message, con
 
 $(() => {
     form_fetch_and_show("ssh-key", "/pwncollege_api/v1/ssh_key", "PATCH", "Your public key has been updated");
+    form_fetch_and_show("delete-ssh-key", "/pwncollege_api/v1/ssh_key/delete", "PATCH", "Your public key has been deleted");
     form_fetch_and_show("dojo-create", "/pwncollege_api/v1/dojo/create", "POST", "Your dojo has been created");
     form_fetch_and_show("dojo-promote-admin", `/pwncollege_api/v1/dojo/${init.dojo}/promote-admin`, "POST", "User has been promoted to admin.", confirm_msg = (form, params) => {
         var user_name = form.find(`#name-for-${params["user_id"]}`)

--- a/dojo_theme/static/js/dojo/settings.js
+++ b/dojo_theme/static/js/dojo/settings.js
@@ -74,8 +74,7 @@ function button_fetch_and_show(name, endpoint, method,data, success_message, con
 }
 
 $(() => {
-    form_fetch_and_show("ssh-key", "/pwncollege_api/v1/ssh_key", "PATCH", "Your public key has been updated");
-    form_fetch_and_show("delete-ssh-key", "/pwncollege_api/v1/ssh_key/delete", "PATCH", "Your public key has been deleted");
+    form_fetch_and_show("ssh-key", "/pwncollege_api/v1/ssh_key", "POST", "Your public key has been updated");
     form_fetch_and_show("dojo-create", "/pwncollege_api/v1/dojo/create", "POST", "Your dojo has been created");
     form_fetch_and_show("dojo-promote-admin", `/pwncollege_api/v1/dojo/${init.dojo}/promote-admin`, "POST", "User has been promoted to admin.", confirm_msg = (form, params) => {
         var user_name = form.find(`#name-for-${params["user_id"]}`)

--- a/dojo_theme/templates/dojo_create.html
+++ b/dojo_theme/templates/dojo_create.html
@@ -38,7 +38,7 @@
                 <div class="input-group-append copy-button">
                     <button class="btn btn-outline-secondary" type="button">
                         <i class="fas fa-clipboard"></i>
-                        </button>
+                    </button>
                 </div>
             </div>
 

--- a/dojo_theme/templates/settings.html
+++ b/dojo_theme/templates/settings.html
@@ -76,32 +76,31 @@
             </div>
 
             <div class="form-group">
-              {{ form.submit(class="btn btn-md btn-primary btn-outlined float-right") }}
+              {{ form.submit(class="btn btn-md btn-primary float-right") }}
             </div>
           </form>
           {% endwith %}
         </div>
 
         <div class="tab-pane fade" id="ssh-key" role="tabpanel">
-          
+
           {% if ssh_keys %}
             <b><label for="enter-name">Current SSH Keys</label></b>
-            <small class="form-text text-muted">SSH Keys Currently Registered to this Account</small>
             <br>
 
             {% for key in ssh_keys %}
             <form method="post" id="delete-ssh-key-{{ loop.index }}-form" autocomplete="off">
                 <div class="form-group">
                     <div class="input-group">
-                        <input class="form-control" id="ssh-key" name="ssh_key" type="text" value="{{ key }}">
-                        <div class="input-group-append">
+                        <input class="form-control" id="ssh-key" name="ssh_key" type="text" value="{{ key }}" readonly>
+                        <div class="input-group-append ml-1" style="margin: -0.1rem">
                             <button type="submit" class="btn btn-danger" id="delete-ssh-key-button-{{ loop.index }}">
                                 <i class="fas fa-times"></i>
                             </button>
                         </div>
                     </div>
                 </div>
-        
+
                 <div id="delete-ssh-key-{{ loop.index }}-results" class="form-group">
                 </div>
             </form>
@@ -112,12 +111,13 @@
               });
             </script>
             {% endfor %}
+            <br>
           {% endif %}
-          
+
           <form method="post" id="ssh-key-form" autocomplete="off">
             <div class="form-group">
-              <b><label for="enter-name">New SSH Key</label></b>
-              <small class="form-text text-muted">Register a new SSH key for this account</small>
+              <b><label for="enter-name">Add New SSH Key</label></b>
+              <small class="form-text text-muted">Required for accessing challenges over SSH</small>
               <br>
               <input class="form-control" id="ssh-key" name="ssh_key" type="text" value="">
             </div>
@@ -126,7 +126,7 @@
             </div>
 
             <div class="form-group text-right">
-              <input class="btn btn-md btn-primary btn-outlined" id="_submit" name="_submit" type="submit" value="Update">
+              <input class="btn btn-md btn-primary btn-outlined" id="_submit" name="_submit" type="submit" value="Add">
             </div>
           </form>
         </div>

--- a/dojo_theme/templates/settings.html
+++ b/dojo_theme/templates/settings.html
@@ -82,29 +82,34 @@
           {% endwith %}
         </div>
 
-
         <div class="tab-pane fade" id="ssh-key" role="tabpanel">
           <b><label for="enter-name">Current SSH Keys</label></b>
           <small class="form-text text-muted">SSH Keys Currently Registered to this Account</small>
           <br>
 
-          {% for key in ssh_key %}
-          <form method="post" id="delete-ssh-key-form" autocomplete="off">
-            <div class="form-group">
-              <div class="input-group">
-                <input class="form-control" id="ssh-key" name="ssh_key" type="text" value="{{ key }}">
-                <div class="input-group-append">
-                  <button type="submit" class="btn btn-danger">
-                    <i class="fas fa-times"></i>
-                  </button>
-                </div>
+          {% for key in ssh_keys %}
+          <form method="post" id="delete-ssh-key-{{ loop.index }}-form" autocomplete="off">
+              <div class="form-group">
+                  <div class="input-group">
+                      <input class="form-control" id="ssh-key" name="ssh_key" type="text" value="{{ key }}">
+                      <div class="input-group-append">
+                          <button type="submit" class="btn btn-danger" id="delete-ssh-key-button-{{ loop.index }}">
+                              <i class="fas fa-times"></i>
+                          </button>
+                      </div>
+                  </div>
               </div>
-            </div>
       
-            <div id="delete-ssh-key-results" class="form-group">
-            </div>
+              <div id="delete-ssh-key-{{ loop.index }}-results" class="form-group">
+              </div>
           </form>
-        {% endfor %}
+
+          <script>
+            document.addEventListener('DOMContentLoaded', function() {
+              form_fetch_and_show("delete-ssh-key-{{ loop.index }}", "/pwncollege_api/v1/ssh_key", "DELETE", "Your public key has been deleted");
+            });
+          </script>
+          {% endfor %}
 
 
           <form method="post" id="ssh-key-form" autocomplete="off">
@@ -123,7 +128,6 @@
             </div>
           </form>
         </div>
-
 
         {% if discord_enabled %}
         <div class="tab-pane fade" id="discord" role="tabpanel">

--- a/dojo_theme/templates/settings.html
+++ b/dojo_theme/templates/settings.html
@@ -121,6 +121,26 @@
           </form>
         </div>
 
+
+        {% if discord_enabled %}
+        <div class="tab-pane fade" id="discord" role="tabpanel">
+          <a href="/discord/connect" class="text-decoration-none">
+            <img src="{{ discord_avatar_asset(discord_user) }}" class="discord-avatar">
+            <br>
+            <h2 class="text-center">
+              {% if discord_user %}
+              {{ discord_user["user"]["username"] }}
+              {% else %}
+              <i>Connect Discord Account</i>
+              {% endif %}
+            </h2>
+            <br>
+            <div id="discord-results" class="form-group">
+            </div>
+          </a>
+        </div>
+        {% endif %}
+
         <div class="tab-pane fade" id="tokens" role="tabpanel">
           {% with form = Forms.self.TokensForm() %}
           <form method="POST" id="user-token-form">

--- a/dojo_theme/templates/settings.html
+++ b/dojo_theme/templates/settings.html
@@ -82,23 +82,31 @@
           {% endwith %}
         </div>
 
+
         <div class="tab-pane fade" id="ssh-key" role="tabpanel">
+          {% if ssh_key %}
+            <b><label for="enter-name">Current SSH Keys</label></b>
+            <small class="form-text text-muted">Current SSH Keys Registered to this Account</small>
+            <br>
+            {% for key in ssh_key %}
+              <input class="form-control" id="ssh-key" name="ssh_key_{{ loop.index }}" type="text" value="{{ key }}">
+            {% endfor %}
+          {% endif %}
           <form method="post" id="ssh-key-form" autocomplete="off">
             <div class="form-group">
-              <b><label for="enter-name">SSH Key</label></b>
-              <small class="form-text text-muted">Required for accessing challenges over SSH</small>
-              <br>
-              <input class="form-control" id="ssh-key" name="ssh_key" type="text" value="{{ ssh_key or "" }}">
-            </div>
-
+            <b><label for="enter-name">SSH Key</label></b>
+            <small class="form-text text-muted">Required for accessing challenges over SSH</small>
+            <br>
+            <input class="form-control" id="ssh-key" name="ssh_key" type="text" value="">
             <div id="ssh-key-results" class="form-group">
             </div>
-
+        
             <div class="form-group text-right">
               <input class="btn btn-md btn-primary btn-outlined" id="_submit" name="_submit" type="submit" value="Update">
             </div>
           </form>
         </div>
+        
 
         {% if discord_enabled %}
         <div class="tab-pane fade" id="discord" role="tabpanel">

--- a/dojo_theme/templates/settings.html
+++ b/dojo_theme/templates/settings.html
@@ -84,48 +84,43 @@
 
 
         <div class="tab-pane fade" id="ssh-key" role="tabpanel">
-          {% if ssh_key %}
-            <b><label for="enter-name">Current SSH Keys</label></b>
-            <small class="form-text text-muted">Current SSH Keys Registered to this Account</small>
-            <br>
-            {% for key in ssh_key %}
-              <input class="form-control" id="ssh-key" name="ssh_key_{{ loop.index }}" type="text" value="{{ key }}">
-            {% endfor %}
-          {% endif %}
+          <b><label for="enter-name">Current SSH Keys</label></b>
+          <small class="form-text text-muted">SSH Keys Currently Registered to this Account</small>
+          <br>
+
+          {% for key in ssh_key %}
+            <form method="post" id="delete-ssh-key-form" autocomplete="off">
+              <div class="form-group">
+                  <input class="form-control" id="ssh-key" name="ssh_key" type="text" value="{{ key }}">
+              </div>
+
+              <div id="delete-ssh-key-results" class="form-group">
+              </div>
+
+              <div class="form-group text-right">
+                <input class="btn btn-md btn-primary btn-outlined" id="_submit" name="_submit" type="submit" value="Update">
+              </div>
+            </form>
+          {% endfor %}
+
+
           <form method="post" id="ssh-key-form" autocomplete="off">
             <div class="form-group">
-            <b><label for="enter-name">SSH Key</label></b>
-            <small class="form-text text-muted">Required for accessing challenges over SSH</small>
-            <br>
-            <input class="form-control" id="ssh-key" name="ssh_key" type="text" value="">
+              <b><label for="enter-name">New SSH Key</label></b>
+              <small class="form-text text-muted">Register a new SSH key for this account</small>
+              <br>
+              <input class="form-control" id="ssh-key" name="ssh_key" type="text" value="">
+            </div>
+
             <div id="ssh-key-results" class="form-group">
             </div>
-        
+
             <div class="form-group text-right">
               <input class="btn btn-md btn-primary btn-outlined" id="_submit" name="_submit" type="submit" value="Update">
             </div>
           </form>
         </div>
-        
 
-        {% if discord_enabled %}
-        <div class="tab-pane fade" id="discord" role="tabpanel">
-          <a href="/discord/connect" class="text-decoration-none">
-            <img src="{{ discord_avatar_asset(discord_user) }}" class="discord-avatar">
-            <br>
-            <h2 class="text-center">
-              {% if discord_user %}
-              {{ discord_user["user"]["username"] }}
-              {% else %}
-              <i>Connect Discord Account</i>
-              {% endif %}
-            </h2>
-            <br>
-            <div id="discord-results" class="form-group">
-            </div>
-          </a>
-        </div>
-        {% endif %}
         <div class="tab-pane fade" id="tokens" role="tabpanel">
           {% with form = Forms.self.TokensForm() %}
           <form method="POST" id="user-token-form">

--- a/dojo_theme/templates/settings.html
+++ b/dojo_theme/templates/settings.html
@@ -89,19 +89,22 @@
           <br>
 
           {% for key in ssh_key %}
-            <form method="post" id="delete-ssh-key-form" autocomplete="off">
-              <div class="form-group">
-                  <input class="form-control" id="ssh-key" name="ssh_key" type="text" value="{{ key }}">
+          <form method="post" id="delete-ssh-key-form" autocomplete="off">
+            <div class="form-group">
+              <div class="input-group">
+                <input class="form-control" id="ssh-key" name="ssh_key" type="text" value="{{ key }}">
+                <div class="input-group-append">
+                  <button type="submit" class="btn btn-danger">
+                    <i class="fas fa-times"></i>
+                  </button>
+                </div>
               </div>
-
-              <div id="delete-ssh-key-results" class="form-group">
-              </div>
-
-              <div class="form-group text-right">
-                <input class="btn btn-md btn-primary btn-outlined" id="_submit" name="_submit" type="submit" value="Update">
-              </div>
-            </form>
-          {% endfor %}
+            </div>
+      
+            <div id="delete-ssh-key-results" class="form-group">
+            </div>
+          </form>
+        {% endfor %}
 
 
           <form method="post" id="ssh-key-form" autocomplete="off">

--- a/dojo_theme/templates/settings.html
+++ b/dojo_theme/templates/settings.html
@@ -83,35 +83,37 @@
         </div>
 
         <div class="tab-pane fade" id="ssh-key" role="tabpanel">
-          <b><label for="enter-name">Current SSH Keys</label></b>
-          <small class="form-text text-muted">SSH Keys Currently Registered to this Account</small>
-          <br>
+          
+          {% if ssh_keys %}
+            <b><label for="enter-name">Current SSH Keys</label></b>
+            <small class="form-text text-muted">SSH Keys Currently Registered to this Account</small>
+            <br>
 
-          {% for key in ssh_keys %}
-          <form method="post" id="delete-ssh-key-{{ loop.index }}-form" autocomplete="off">
-              <div class="form-group">
-                  <div class="input-group">
-                      <input class="form-control" id="ssh-key" name="ssh_key" type="text" value="{{ key }}">
-                      <div class="input-group-append">
-                          <button type="submit" class="btn btn-danger" id="delete-ssh-key-button-{{ loop.index }}">
-                              <i class="fas fa-times"></i>
-                          </button>
-                      </div>
-                  </div>
-              </div>
-      
-              <div id="delete-ssh-key-{{ loop.index }}-results" class="form-group">
-              </div>
-          </form>
+            {% for key in ssh_keys %}
+            <form method="post" id="delete-ssh-key-{{ loop.index }}-form" autocomplete="off">
+                <div class="form-group">
+                    <div class="input-group">
+                        <input class="form-control" id="ssh-key" name="ssh_key" type="text" value="{{ key }}">
+                        <div class="input-group-append">
+                            <button type="submit" class="btn btn-danger" id="delete-ssh-key-button-{{ loop.index }}">
+                                <i class="fas fa-times"></i>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+        
+                <div id="delete-ssh-key-{{ loop.index }}-results" class="form-group">
+                </div>
+            </form>
 
-          <script>
-            document.addEventListener('DOMContentLoaded', function() {
-              form_fetch_and_show("delete-ssh-key-{{ loop.index }}", "/pwncollege_api/v1/ssh_key", "DELETE", "Your public key has been deleted");
-            });
-          </script>
-          {% endfor %}
-
-
+            <script>
+              document.addEventListener('DOMContentLoaded', function() {
+                form_fetch_and_show("delete-ssh-key-{{ loop.index }}", "/pwncollege_api/v1/ssh_key", "DELETE", "Your public key has been deleted");
+              });
+            </script>
+            {% endfor %}
+          {% endif %}
+          
           <form method="post" id="ssh-key-form" autocomplete="off">
             <div class="form-group">
               <b><label for="enter-name">New SSH Key</label></b>


### PR DESCRIPTION
This is a proposal to fix #396. This functionality would be really useful for me so when I saw the issue be created I thought I'd make a start on it. Still WIP as I'm not sure if it could cause a breaking change.

The main difference is a change to the structure of the SSH Keys table. To allow users to have multiple keys, I don't think the user id can be the public key anymore. Since currently public keys must be unique currently, this could become the new primary key, but for now I just made a row id field. Making this change also breaks the current database, but I'm not sure how else to implement the feature.

I've also done the following

- Added a new API endpoint, for deleting an API key.
- Added a form in the settings page for displaying and removing keys, it looks absolutely horrible at the moment though, need to make it prettier.

It looks like `auth.py` is already capable of adding multiple keys to the challenge container, so I didn't make any changes to this.