### PR TITLE
Add open slides in new window button

### DIFF
--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -44,6 +44,7 @@
           <div class="embed-responsive embed-responsive-16by9">
             <iframe class="embed-responsive-item" data-src="{{ src }}"></iframe>
           </div>
+          <button onclick="window.open('{{ src }}', '_blank')" class="btn btn-primary">Open Slides in New Window</button>
           {% endif %}
 
           {% elif resource.type == "markdown" %}

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -44,7 +44,7 @@
           <div class="embed-responsive embed-responsive-16by9">
             <iframe class="embed-responsive-item" data-src="{{ src }}"></iframe>
           </div>
-          <button onclick="window.open('{{ src }}', '_blank')" class="btn btn-primary">Open Slides in New Window</button>
+          <button onclick="window.open('{{ src.replace('/embed', '') }}', '_blank')" class="btn btn-primary">Open Slides in New Window</button>
           {% endif %}
 
           {% elif resource.type == "markdown" %}


### PR DESCRIPTION
Use case: open lecture slides on different tabs instead of viewing them in the related module page. 