### PR TITLE
Discord: Award white belt for linking

### DIFF
--- a/dojo_plugin/pages/discord.py
+++ b/dojo_plugin/pages/discord.py
@@ -11,7 +11,7 @@ from CTFd.utils.decorators import authed_only
 
 from ..models import DiscordUsers
 from ..config import DISCORD_CLIENT_ID
-from ..utils.discord import OAUTH_ENDPOINT, get_discord_id, get_discord_user
+from ..utils.discord import OAUTH_ENDPOINT, get_discord_id, get_discord_user, add_role
 
 
 discord = Blueprint("discord", __name__)
@@ -65,6 +65,7 @@ def discord_redirect():
             existing_discord_user.discord_id = discord_id
         db.session.commit()
         cache.delete_memoized(get_discord_user, user_id)
+        add_role(discord_id, "White Belt")
     except IntegrityError:
         db.session.rollback()
         return {"success": False, "error": "Discord user already in use"}, 400


### PR DESCRIPTION
The goal here is to add a "verified" to the Discord. The primary purpose would be to reduce spam.

We should also manually assign white belts to users who have:
- Already linked
- Been already assigned any other role in the Discord
- MAYBE: Sent a message before in the Discord

We have a couple options surrounding what we do with this:
- Unverified users can't see anything except some sort of "welcome" channel that says "hey, here's how you get verified".
- Unverified users can see everything still, they just can't communicate. This allows for passive people interested in getting info from the discord; but maybe there are bots just collecting all interactions lurking, and we want to do a little to help prevent that?
- One of the prior two options, but we also let them chat in some single channel. Technically this would still allow spam in that channel, but also allows us to see someone interested in pwn.college, but struggling to link their account (maybe the Discord bot is down). It might also be possible to make it so verified users can no longer see that channel automatically?
