### PR TITLE
DM users upon successful discord linking

### DIFF
--- a/dojo_plugin/pages/discord.py
+++ b/dojo_plugin/pages/discord.py
@@ -69,4 +69,12 @@ def discord_redirect():
         db.session.rollback()
         return {"success": False, "error": "Discord user already in use"}, 400
 
+    # DM the user the flag for white belt
+    discord_dojo = Dojos.from_id("discord-dojo").first()
+    if discord_dojo:
+        discord_challenge == discord_dojo.modules[0].challenges[0]
+        flag = serialize_user_flag(user_id, discord_challenge.challenge_id)
+        send_dm("""You have linked your pwn.college account with this discord account! You may now submit the flag: {flag}.""", discord_id)
+        send_dm("""**NOTE:** This is the ONLY communication from pwn.college that you will receive over discord DMs. Assume any other communication is a phishing attempt!""", discord_id)
+
     return redirect("/settings#discord")

--- a/dojo_plugin/utils/discord.py
+++ b/dojo_plugin/utils/discord.py
@@ -24,6 +24,9 @@ def discord_request(endpoint, method="GET", **json):
 def guild_request(endpoint, method="GET", **json):
     return discord_request(f"/guilds/{DISCORD_GUILD_ID}{endpoint}", method=method, **json)
 
+def bot_request(endpoint, method="GET", **json):
+    return discord_request(f"/users/@me{endpoint}", method=method, **json)
+
 
 def get_bot_join_server_url():
     # "Server Members Intent" also required
@@ -91,6 +94,11 @@ def send_message(message, channel_name):
     channel_ids = [channel["id"] for channel in guild_request("/channels") if channel["name"] == channel_name]
     assert len(channel_ids) == 1
     channel_id = channel_ids[0]
+    discord_request(f"/channels/{channel_id}/messages", method="POST", content=message)
+
+
+def send_dm(message, recipient_id):
+    channel_id = bot_request("/channels", method="POST", recipient_id=recipient_id)["id"]
     discord_request(f"/channels/{channel_id}/messages", method="POST", content=message)
 
 


### PR DESCRIPTION
This lays the groundwork for a hypothetical `Discord Dojo` with an actual flag challenge. Opening this PR for discussion.

Not sure how I feel about this versus just having the bot grant the White Belt role right upon linking. It's thematically nicer this way, but you can already see the potential for later phishing shenanigans once we inadvertently train users that we DM them from mysterious "pwn.college" accounts (as you can see from my warning in discord.py).