### PR TITLE
Simplify headings in some pages

### DIFF
--- a/dojo_theme/templates/dojo.html
+++ b/dojo_theme/templates/dojo.html
@@ -61,7 +61,7 @@
 
   <br>
 
-  <h2 class="row">Dojo Modules</h2>
+  <h2 class="row">Modules</h2>
   <br>
   <ul class="card-list">
     {% for module in dojo.modules %}
@@ -81,7 +81,7 @@
 
   <br>
 
-  <h2 class="row">Dojo Rankings:</h2>
+  <h2 class="row">Rankings:</h2>
   <br>
   {% from "macros/scoreboard.html" import scoreboard %}
   {{ scoreboard() }}

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -129,7 +129,7 @@
 
   <br>
 
-  <h2>Module Ranking</h2>
+  <h2>Ranking</h2>
   <p>This scoreboard reflects solves for challenges in this module after the module launched in this dojo.</p>
   {% from "macros/scoreboard.html" import scoreboard %}
   {{ scoreboard() }}


### PR DESCRIPTION
This simplifies some of the headings:

"Dojo Modules" -> "Modules" on the dojo page
"Dojo Rankings" -> "Rankings" on the dojo page
"Module Rankings" -> "Rankings" on the module page