### PR TITLE
Resolve symlinks in a subdir of challenge dir

### DIFF
--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -511,8 +511,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         gdb-multiarch
         gedit
         genisoimage
-        gprolog
         gnupg-utils
+        gprolog
         hexedit
         icdiff
         iproute2

--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -102,7 +102,7 @@ RUN <<EOF
     code-server --extensions-dir=/opt/code-server/extensions \
         --install-extension ms-python.python \
         --install-extension /tmp/ms-vscode-cpptools.vsix
-    chmod +x /opt/code-server/extensions/ms-vscode.cpptools-*/bin/{cpptools*,libc.so}
+    chmod +x /opt/code-server/extensions/ms-vscode.cpptools-*/{bin/cpptools*,bin/libc.so,debugAdapters/bin/OpenDebugAD7,LLVM/bin/clang-*}
     rm -rf /root/.cache/code-server /root/.local/share/code-server /tmp/ms-vscode-cpptools.vsix
 EOF
 
@@ -300,7 +300,8 @@ FROM builder-gdb-${INSTALL_GDB} as builder-gdb
 
 ################################################################################
 
-FROM scratch as builder-tcpdump-no
+
+FROM builder as builder-tcpdump-no
 FROM builder as builder-tcpdump-yes
 RUN <<EOF
     git clone --depth 1 https://github.com/the-tcpdump-group/tcpdump /opt/tcpdump

--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -510,12 +510,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         gdb-multiarch
         gedit
         genisoimage
+        gprolog
         gnupg-utils
         hexedit
         icdiff
         iproute2
         iputils-ping
         ipython3
+        jq
         keyutils
         kmod
         less
@@ -542,10 +544,12 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         qemu-system-x86
         qemu-user
         qemu-utils
+        racket
         rsync
         screen
         silversearcher-ag
         socat
+        sqlite3
         strace
         tmux
         valgrind

--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -301,7 +301,7 @@ FROM builder-gdb-${INSTALL_GDB} as builder-gdb
 ################################################################################
 
 
-FROM builder as builder-tcpdump-no
+FROM scratch as builder-tcpdump-no
 FROM builder as builder-tcpdump-yes
 RUN <<EOF
     git clone --depth 1 https://github.com/the-tcpdump-group/tcpdump /opt/tcpdump

--- a/dojo_plugin/api/v1/docker.py
+++ b/dojo_plugin/api/v1/docker.py
@@ -158,7 +158,7 @@ def start_challenge(user, dojo_challenge, practice):
 
     def insert_challenge(user, dojo_challenge):
         option_paths = sorted(path for path in dojo_challenge.path.iterdir() if path.name.startswith("_"))
-        challenge_tar = resolved_tar("/challenge",
+        challenge_tar = resolved_tar(dojo_challenge.path,
                                      root_dir=dojo_challenge.dojo.path,
                                      filter=lambda path: path not in option_paths)
         container.put_archive("/challenge", challenge_tar)

--- a/dojo_plugin/api/v1/docker.py
+++ b/dojo_plugin/api/v1/docker.py
@@ -158,16 +158,15 @@ def start_challenge(user, dojo_challenge, practice):
 
     def insert_challenge(user, dojo_challenge):
         option_paths = sorted(path for path in dojo_challenge.path.iterdir() if path.name.startswith("_"))
-        challenge_tar = resolved_tar(dojo_challenge.path,
-                                     root_dir=dojo_challenge.dojo.path,
-                                     filter=lambda path: path not in option_paths)
+        root_dir = dojo_challenge.path.parent.parent
+        challenge_tar = resolved_tar(dojo_challenge.path, root_dir=root_dir, filter=lambda path: path not in option_paths)
         container.put_archive("/challenge", challenge_tar)
 
         if option_paths:
             secret = current_app.config["SECRET_KEY"]
             option_hash = hashlib.sha256(f"{secret}_{user.id}_{dojo_challenge.challenge_id}".encode()).digest()
             option = option_paths[int.from_bytes(option_hash[:8], "little") % len(option_paths)]
-            container.put_archive("/challenge", resolved_tar(option, root_dir=dojo_challenge.dojo.path))
+            container.put_archive("/challenge", resolved_tar(option, root_dir=root_dir))
 
         exec_run("chown -R root:root /challenge", container=container)
         exec_run("chmod -R 4755 /challenge", container=container)

--- a/dojo_plugin/api/v1/docker.py
+++ b/dojo_plugin/api/v1/docker.py
@@ -156,8 +156,9 @@ def start_challenge(user, dojo_challenge, practice):
         )
 
     def insert_challenge(user, dojo_challenge):
-        for path in dojo_challenge.challenge_paths(user):
-            with simple_tar(path, f"/challenge/{path.name}") as tar:
+        for path, relative_path in dojo_challenge.challenge_paths(user):
+            archive_path = os.path.join("/challenge", relative_path)
+            with simple_tar(path, archive_path) as tar:
                 container.put_archive("/", tar)
         exec_run("chown -R root:root /challenge", container=container)
         exec_run("chmod -R 4755 /challenge", container=container)

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -559,28 +559,6 @@ class DojoChallenges(db.Model):
             return self.data["image"]
         return "pwncollege-challenge"
 
-    def challenge_paths(self, user):
-        secret = current_app.config["SECRET_KEY"]
-
-        for path in self.path.iterdir():
-            if path.name.startswith("_"):
-                continue
-            if path.is_dir() and not path.is_symlink():
-                for subpath in path.iterdir():
-                    relative_path = subpath.relative_to(self.path)
-                    yield subpath.resolve(), relative_path
-            else:
-                relative_path = path.relative_to(self.path)
-                yield path.resolve(), relative_path
-
-        option_paths = sorted(path for path in self.path.iterdir() if path.name.startswith("_"))
-        if option_paths:
-            option_hash = hashlib.sha256(f"{secret}_{user.id}_{self.challenge_id}".encode()).digest()
-            option = option_paths[int.from_bytes(option_hash[:8], "little") % len(option_paths)]
-            for path in option.iterdir():
-                relative_path = path.relative_to(self.path)
-                yield path.resolve(), relative_path
-
     __repr__ = columns_repr(["module", "id", "challenge_id"])
 
 

--- a/dojo_plugin/utils/__init__.py
+++ b/dojo_plugin/utils/__init__.py
@@ -123,18 +123,17 @@ def unserialize_user_flag(user_flag, *, secret=None):
     return account_id, challenge_id
 
 
-def resolved_tar(root_dir, filter=None):
+def resolved_tar(dir, *, root_dir, filter=None):
     tar_buffer = io.BytesIO()
     tar = tarfile.open(fileobj=tar_buffer, mode='w')
-    resolved_root_path = root_dir.resolve()
-    for path in root_dir.rglob("*"):
+    resolved_root_dir = root_dir.resolve()
+    for path in dir.rglob("*"):
         if filter is not None and not filter(path):
             continue
-        relative_path = path.relative_to(root_dir)
+        relative_path = path.relative_to(dir)
         if path.is_symlink():
             resolved_path = path.resolve()
-            # TODO: is_relative_to is wrong; we need to be relative to the dojo directory, not the root directory
-            assert resolved_path.is_relative_to(resolved_root_path), f"The symlink {path} points outside of the root directory"
+            assert resolved_path.is_relative_to(resolved_root_dir), f"The symlink {path} points outside of the root directory"
             tar.add(resolved_path, arcname=relative_path, recursive=False)
         else:
             tar.add(path, arcname=relative_path, recursive=False)


### PR DESCRIPTION
Modified DojoChallenges.challenge_paths to return an absolute and relative path to support 1 level deeper symlinks.

The challenge_paths method is used by insert_challenge, which now creates the archive path using /challenge and the relative_path returned by challenge_paths.

