### PR TITLE
Catch and render flag submission errors

### DIFF
--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -203,7 +203,12 @@ function startChallenge(event) {
             item.find("#challenge-submit").removeClass("disabled-button");
             item.find("#challenge-submit").prop("disabled", false);
         }, 10000);
-    });
+    }).catch(function (error) {
+        console.error(error);
+        var result_message = item.find('#result-message');
+        result_message.html("Submission request failed: " + ((error || {}).message || error));
+        result_notification.addClass('alert alert-warning alert-dismissable text-center');
+    })
 }
 
 


### PR DESCRIPTION
If (when?) an internal server error happens in the flag submission code, or the user's network drops out during the middle of flag submission, we get stuck in the loading state. Fix this by handling request errors. 

(Open to wording tweaks this is just a first step)