### PR TITLE
Fix solver count NaN on submit

### DIFF
--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -76,7 +76,7 @@ function renderSubmissionResponse(response, item) {
         unsolved_flag.addClass("challenge-solved");
 
         total_solves.text(
-            (parseInt(total_solves.text().split(" ")[0]) + 1) + " solves"
+            (parseInt(total_solves.text().trim().split(" ")[0]) + 1) + " solves"
         );
 
         answer_input.val("");


### PR DESCRIPTION
This is both a bug report and it's fix.

**Before my patch**:
When you submit a flag, the solver count changes to NaN as shown in the video below.
https://github.com/pwncollege/dojo/assets/55092742/f9c55c5c-4b81-4a32-acf7-88853a7ddca6

**After my patch**:
When you submit a flag, the solver count correctly increases by one as shown in the video below.
https://github.com/pwncollege/dojo/assets/55092742/e57c2bd8-7a8a-497b-ab8a-0ae698bd180d

I added a .trim() call to remove whitespace before and after the solver count text. It was trying the parse the `\n` character which is why it returned NaN.

