### PR TITLE
Add a share-by-link solves csv/json endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 ENV LC_CTYPE=C.UTF-8
 
 RUN apt-get update && \

--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -27,7 +27,7 @@ FROM ubuntu:${UBUNTU_VERSION} as essentials
 
 SHELL ["/bin/bash", "-ceov", "pipefail"]
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 ENV LC_CTYPE=C.UTF-8
 
 RUN <<EOF

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -181,6 +181,10 @@ class Dojos(db.Model):
             deferred=True)
 
     @property
+    def solves_code(self):
+        return hashlib.md5(self.private_key.encode() + b"SOLVES").hexdigest()
+
+    @property
     def path(self):
         if hasattr(self, "_path"):
             return self._path

--- a/dojo_plugin/pages/dojo.py
+++ b/dojo_plugin/pages/dojo.py
@@ -1,17 +1,22 @@
 import collections
+import traceback
 import datetime
 import docker
-import pytz
+import sys
 
-from flask import Blueprint, render_template, abort, send_file
-from CTFd.models import db, Solves, Challenges, Users, Awards
-from CTFd.utils.user import get_current_user
+from flask import Blueprint, render_template, abort, send_file, redirect, url_for, Response, stream_with_context
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.sql import and_
+from CTFd.plugins import bypass_csrf_protection
+from CTFd.models import db, Solves, Users
+from CTFd.utils.decorators import authed_only
+from CTFd.utils.user import get_current_user, is_admin
 from CTFd.utils.helpers import get_infos
 from CTFd.cache import cache
 
-from ..utils import render_markdown, module_visible, module_challenges_visible, is_dojo_admin
-from ..utils.dojo import dojo_route, get_current_dojo_challenge
-from ..models import Dojos, DojoUsers, DojoStudents, DojoModules
+from ..utils import render_markdown
+from ..utils.dojo import dojo_route, get_current_dojo_challenge, dojo_update, dojo_admins_only
+from ..models import Dojos, DojoUsers, DojoStudents, DojoModules, DojoMembers, DojoChallenges
 
 dojo = Blueprint("pwncollege_dojo", __name__)
 
@@ -66,6 +71,138 @@ def view_dojo_path(dojo, path):
         return view_page(dojo, path)
     else:
         abort(404)
+
+@dojo.route("/dojo/<dojo>")
+@dojo_route
+def view_dojo(dojo):
+    return redirect(url_for("pwncollege_dojo.listing", dojo=dojo.reference_id))
+
+
+@dojo.route("/dojo/<dojo>/join")
+@dojo.route("/dojo/<dojo>/join/")
+@dojo.route("/dojo/<dojo>/join/<password>")
+@authed_only
+def join_dojo(dojo, password=None):
+    dojo = Dojos.from_id(dojo).first()
+    if not dojo:
+        abort(404)
+
+    if dojo.password and dojo.password != password:
+        abort(403)
+
+    try:
+        member = DojoMembers(dojo=dojo, user=get_current_user())
+        db.session.add(member)
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+
+    return redirect(url_for("pwncollege_dojo.listing", dojo=dojo.reference_id))
+
+
+@dojo.route("/dojo/<dojo>/update/", methods=["GET", "POST"])
+@dojo.route("/dojo/<dojo>/update/<update_code>", methods=["GET", "POST"])
+@bypass_csrf_protection
+def update_dojo(dojo, update_code=None):
+    dojo = Dojos.from_id(dojo).first()
+    if not dojo:
+        return {"success": False, "error": "Not Found"}, 404
+
+    if dojo.update_code != update_code:
+        return {"success": False, "error": "Forbidden"}, 403
+
+    try:
+        dojo_update(dojo)
+        db.session.commit()
+    except Exception as e:
+        print(f"ERROR: Dojo failed for {dojo}", file=sys.stderr, flush=True)
+        traceback.print_exc(file=sys.stderr)
+        return {"success": False, "error": str(e)}, 400
+    return {"success": True}
+
+@dojo.route("/dojo/<dojo>/delete/", methods=["POST"])
+@authed_only
+def delete_dojo(dojo):
+    dojo = Dojos.from_id(dojo).first()
+    if not dojo:
+        return {"success": False, "error": "Not Found"}, 404
+
+    # Check if the current user is an admin of the dojo
+    if not is_admin():
+        abort(403)
+
+    try:
+        DojoUsers.query.filter(DojoUsers.dojo_id == dojo.dojo_id).delete()
+        Dojos.query.filter(Dojos.dojo_id == dojo.dojo_id).delete()
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        print(f"ERROR: Dojo failed for {dojo}", file=sys.stderr, flush=True)
+        traceback.print_exc(file=sys.stderr)
+        return {"success": False, "error": str(e)}, 400
+    return {"success": True}
+
+@dojo.route("/dojo/<dojo>/admin/")
+@dojo_route
+@dojo_admins_only
+def view_dojo_admin(dojo):
+    return render_template("dojo_admin.html", dojo=dojo, is_admin=is_admin)
+
+
+@dojo.route("/dojo/<dojo>/admin/activity")
+@dojo_route
+@dojo_admins_only
+def view_dojo_activity(dojo):
+    docker_client = docker.from_env()
+    filters = {
+        "name": "user_",
+        "label": f"dojo.dojo_id={dojo.reference_id}"
+    }
+    containers = docker_client.containers.list(filters=filters, ignore_removed=True)
+
+    actives = []
+    now = datetime.datetime.now()
+    for container in containers:
+        user_id = container.labels["dojo.user_id"]
+        dojo_id = container.labels["dojo.dojo_id"]
+        module_id = container.labels["dojo.module_id"]
+        challenge_id = container.labels["dojo.challenge_id"]
+
+        user = Users.query.filter_by(id=user_id).first()
+        challenge = DojoChallenges.from_id(dojo_id, module_id, challenge_id).first()
+
+        created = datetime.datetime.fromisoformat(container.attrs["Created"].split(".")[0])
+        uptime = now - created
+
+        actives.append(dict(user=user, challenge=challenge, uptime=uptime))
+    actives.sort(key=lambda active: active["uptime"])
+
+    solves = dojo.solves().order_by(Solves.date).all()
+
+    return render_template("dojo_activity.html", dojo=dojo, actives=actives, solves=solves)
+
+
+@dojo.route("/dojo/<dojo>/admin/solves.csv")
+@dojo_route
+@dojo_admins_only
+def view_dojo_solves(dojo):
+    def stream():
+        yield "user,module,challenge,time\n"
+        solves = (
+            dojo
+            .solves(ignore_visibility=True)
+            .join(DojoModules, and_(
+                DojoModules.dojo_id == DojoChallenges.dojo_id,
+                DojoModules.module_index == DojoChallenges.module_index))
+            .filter(DojoUsers.user_id != None)
+            .order_by(DojoChallenges.module_index, DojoChallenges.challenge_index, Solves.date)
+            .with_entities(Solves.user_id, DojoModules.id, DojoChallenges.id, Solves.date)
+        )
+        for user, module, challenge, time in solves:
+            time = time.replace(tzinfo=datetime.timezone.utc)
+            yield f"{user},{module},{challenge},{time}\n"
+    headers = {"Content-Disposition": "attachment; filename=data.csv"}
+    return Response(stream_with_context(stream()), headers=headers, mimetype="text/csv")
 
 
 def view_module(dojo, module):

--- a/dojo_plugin/pages/dojo.py
+++ b/dojo_plugin/pages/dojo.py
@@ -19,6 +19,7 @@ from ..utils.dojo import dojo_route, get_current_dojo_challenge, dojo_update, do
 from ..models import Dojos, DojoUsers, DojoStudents, DojoModules, DojoMembers, DojoChallenges
 
 dojo = Blueprint("pwncollege_dojo", __name__)
+#pylint:disable=redefined-outer-name
 
 
 @cache.memoize(timeout=60)

--- a/dojo_plugin/pages/dojos.py
+++ b/dojo_plugin/pages/dojos.py
@@ -1,19 +1,10 @@
-import datetime
-import sys
-import traceback
-
-import docker
-from flask import Blueprint, Response, stream_with_context, render_template, redirect, url_for, abort
-from sqlalchemy.sql import and_
-from sqlalchemy.exc import IntegrityError
-from CTFd.models import db, Solves, Users
-from CTFd.utils.user import get_current_user, is_admin
+from flask import Blueprint, render_template, redirect, url_for
+from CTFd.models import db
+from CTFd.utils.user import get_current_user
 from CTFd.utils.decorators import authed_only, admins_only
-from CTFd.plugins import bypass_csrf_protection
 
-from ..models import DojoAdmins, DojoChallenges, DojoMembers, DojoModules, DojoUsers, Dojos
-from ..utils import user_dojos
-from ..utils.dojo import dojo_route, generate_ssh_keypair, dojo_update, dojo_admins_only
+from ..models import DojoChallenges, Dojos
+from ..utils.dojo import generate_ssh_keypair
 
 
 dojos = Blueprint("pwncollege_dojos", __name__)
@@ -75,137 +66,6 @@ def dojo_create():
     )
 
 
-@dojos.route("/dojo/<dojo>")
-@dojo_route
-def view_dojo(dojo):
-    return redirect(url_for("pwncollege_dojo.listing", dojo=dojo.reference_id))
-
-
-@dojos.route("/dojo/<dojo>/join")
-@dojos.route("/dojo/<dojo>/join/")
-@dojos.route("/dojo/<dojo>/join/<password>")
-@authed_only
-def join_dojo(dojo, password=None):
-    dojo = Dojos.from_id(dojo).first()
-    if not dojo:
-        abort(404)
-
-    if dojo.password and dojo.password != password:
-        abort(403)
-
-    try:
-        member = DojoMembers(dojo=dojo, user=get_current_user())
-        db.session.add(member)
-        db.session.commit()
-    except IntegrityError:
-        db.session.rollback()
-
-    return redirect(url_for("pwncollege_dojo.listing", dojo=dojo.reference_id))
-
-
-@dojos.route("/dojo/<dojo>/update/", methods=["GET", "POST"])
-@dojos.route("/dojo/<dojo>/update/<update_code>", methods=["GET", "POST"])
-@bypass_csrf_protection
-def update_dojo(dojo, update_code=None):
-    dojo = Dojos.from_id(dojo).first()
-    if not dojo:
-        return {"success": False, "error": "Not Found"}, 404
-
-    if dojo.update_code != update_code:
-        return {"success": False, "error": "Forbidden"}, 403
-
-    try:
-        dojo_update(dojo)
-        db.session.commit()
-    except Exception as e:
-        print(f"ERROR: Dojo failed for {dojo}", file=sys.stderr, flush=True)
-        traceback.print_exc(file=sys.stderr)
-        return {"success": False, "error": str(e)}, 400
-    return {"success": True}
-
-@dojos.route("/dojo/<dojo>/delete/", methods=["POST"])
-@authed_only
-def delete_dojo(dojo):
-    dojo = Dojos.from_id(dojo).first()
-    if not dojo:
-        return {"success": False, "error": "Not Found"}, 404
-
-    # Check if the current user is an admin of the dojo
-    if not is_admin():
-        abort(403)
-
-    try:
-        DojoUsers.query.filter(DojoUsers.dojo_id == dojo.dojo_id).delete()
-        Dojos.query.filter(Dojos.dojo_id == dojo.dojo_id).delete()
-        db.session.commit()
-    except Exception as e:
-        db.session.rollback()
-        print(f"ERROR: Dojo failed for {dojo}", file=sys.stderr, flush=True)
-        traceback.print_exc(file=sys.stderr)
-        return {"success": False, "error": str(e)}, 400
-    return {"success": True}
-
-@dojos.route("/dojo/<dojo>/admin/")
-@dojo_route
-@dojo_admins_only
-def view_dojo_admin(dojo):
-    return render_template("dojo_admin.html", dojo=dojo, is_admin=is_admin)
-
-
-@dojos.route("/dojo/<dojo>/admin/activity")
-@dojo_route
-@dojo_admins_only
-def view_dojo_activity(dojo):
-    docker_client = docker.from_env()
-    filters = {
-        "name": "user_",
-        "label": f"dojo.dojo_id={dojo.reference_id}"
-    }
-    containers = docker_client.containers.list(filters=filters, ignore_removed=True)
-
-    actives = []
-    now = datetime.datetime.now()
-    for container in containers:
-        user_id = container.labels["dojo.user_id"]
-        dojo_id = container.labels["dojo.dojo_id"]
-        module_id = container.labels["dojo.module_id"]
-        challenge_id = container.labels["dojo.challenge_id"]
-
-        user = Users.query.filter_by(id=user_id).first()
-        challenge = DojoChallenges.from_id(dojo_id, module_id, challenge_id).first()
-
-        created = datetime.datetime.fromisoformat(container.attrs["Created"].split(".")[0])
-        uptime = now - created
-
-        actives.append(dict(user=user, challenge=challenge, uptime=uptime))
-    actives.sort(key=lambda active: active["uptime"])
-
-    solves = dojo.solves().order_by(Solves.date).all()
-
-    return render_template("dojo_activity.html", dojo=dojo, actives=actives, solves=solves)
-
-
-@dojos.route("/dojo/<dojo>/admin/solves.csv")
-@dojo_route
-@dojo_admins_only
-def view_dojo_solves(dojo):
-    def stream():
-        yield "user,module,challenge,time\n"
-        solves = (
-            dojo
-            .solves(ignore_visibility=True)
-            .join(DojoModules, and_(
-                DojoModules.dojo_id == DojoChallenges.dojo_id,
-                DojoModules.module_index == DojoChallenges.module_index))
-            .filter(DojoUsers.user_id != None)
-            .order_by(DojoChallenges.module_index, DojoChallenges.challenge_index, Solves.date)
-            .with_entities(Solves.user_id, DojoModules.id, DojoChallenges.id, Solves.date)
-        )
-        for user, module, challenge, time in solves:
-            time = time.replace(tzinfo=datetime.timezone.utc)
-            yield f"{user},{module},{challenge},{time}\n"
-    headers = {"Content-Disposition": "attachment; filename=data.csv"}
-    return Response(stream_with_context(stream()), headers=headers, mimetype="text/csv")
 
 
 @dojos.route("/admin/dojos")

--- a/dojo_theme/templates/admin_dojos.html
+++ b/dojo_theme/templates/admin_dojos.html
@@ -8,7 +8,7 @@
 </div>
 <div class="container">
     {% for dojo in dojos %}
-    <h2><a href="{{ url_for('pwncollege_dojos.view_dojo', dojo=dojo.reference_id) }}">{{ dojo.name }}</a></h2>
+    <h2><a href="{{ url_for('pwncollege_dojo.view_dojo', dojo=dojo.reference_id) }}">{{ dojo.name }}</a></h2>
     <b>Reference ID: </b><code>{{ dojo.reference_id }}</code>
     <br>
     <b>Dojo ID: </b><code>{{ dojo.hex_dojo_id }}</code>

--- a/dojo_theme/templates/dojo.html
+++ b/dojo_theme/templates/dojo.html
@@ -28,7 +28,7 @@
     {% if dojo_user.type == "admin" or user.type == "admin" %}
     <div class="col-lg-auto m-3">
       <figure>
-        <a class="text-decoration-none" href="{{ url_for('pwncollege_dojos.view_dojo_admin', dojo=dojo.reference_id) }}">
+        <a class="text-decoration-none" href="{{ url_for('pwncollege_dojo.view_dojo_admin', dojo=dojo.reference_id) }}">
           <i class="fas fa-users-cog fa-3x"></i>
           <figcaption><b style="font-family: 'Courier New', Courier, monospace">Admin</b></figcaption>
         </a>

--- a/dojo_theme/templates/dojo_admin.html
+++ b/dojo_theme/templates/dojo_admin.html
@@ -14,7 +14,7 @@
     <div class="col-lg-auto m-3">
       <figure>
       <a class="text-decoration-none" href="#"
-        data-copy="{{ url_for('pwncollege_dojos.join_dojo', dojo=dojo.reference_id, password=dojo.password, _external=True) }}"
+        data-copy="{{ url_for('pwncollege_dojo.join_dojo', dojo=dojo.reference_id, password=dojo.password, _external=True) }}"
         onclick="copyToClipboard(event)">
         <i class="fas fa-share fa-3x"></i>
         <figcaption><b style="font-family: 'Courier New', Courier, monospace" id="tooltip">&nbsp;Share&nbsp;</b></figcaption>
@@ -23,7 +23,7 @@
     </div>
     <div class="col-lg-auto m-3">
       <figure>
-      <a class="text-decoration-none" href="{{ url_for('pwncollege_dojos.update_dojo', dojo=dojo.reference_id, update_code=dojo.update_code) }}" target="_blank">
+      <a class="text-decoration-none" href="{{ url_for('pwncollege_dojo.update_dojo', dojo=dojo.reference_id, update_code=dojo.update_code) }}" target="_blank">
         <i class="fas fa-upload fa-3x"></i>
         <figcaption><b style="font-family: 'Courier New', Courier, monospace">Update</b></figcaption>
       </a>
@@ -41,7 +41,7 @@
     {% endif %}
     <div class="col-lg-auto m-3">
       <figure>
-      <a class="text-decoration-none" href="{{ url_for('pwncollege_dojos.view_dojo_solves', dojo=dojo.reference_id) }}">
+      <a class="text-decoration-none" href="{{ url_for('pwncollege_dojo.dojo_solves', dojo=dojo.reference_id, solves_code=dojo.solves_code, format="csv") }}">
         <i class="fas fa-file-csv fa-3x"></i>
         <figcaption><b style="font-family: 'Courier New', Courier, monospace">Solves</b></figcaption>
       </a>

--- a/dojo_theme/templates/dojo_create.html
+++ b/dojo_theme/templates/dojo_create.html
@@ -11,7 +11,7 @@
   <p>pwn.college dojos are defined in a git repository. You can use the example repositories listed below, or our <a href="https://github.com/pwncollege/official-dojos">official dojo repositories</a>, for examples on how to build a dojo!</p>
     <ul class="card-list">
       {% for dojo in example_dojos %}
-      {{ card(url_for("pwncollege_dojos.view_dojo", dojo=dojo.reference_id),
+      {{ card(url_for("pwncollege_dojo.view_dojo", dojo=dojo.reference_id),
       title=dojo.name,
       text="{} Modules : ".format(dojo.modules | length) + "{} / {}".format(dojo.solves(user=user, ignore_visibility=True, ignore_admins=False).count() if user else 0, dojo.challenges | length),
       icon="/themes/dojo_theme/static/img/dojo/{}.svg".format(dojo.award.belt) if (dojo.award.belt and dojo.official) else None,

--- a/dojo_theme/templates/macros/widgets.html
+++ b/dojo_theme/templates/macros/widgets.html
@@ -61,7 +61,7 @@
       {% set text = "{} Modules : {} / {}".format(dojo.modules_count, solves, dojo.challenges_count) %}
       {% set icon = "/themes/dojo_theme/static/img/dojo/{}.svg".format(dojo.award.belt) if (dojo.award.belt and dojo.official) else None %}
       {{ card(
-        url_for("pwncollege_dojos.view_dojo", dojo=dojo.reference_id),
+        url_for("pwncollege_dojo.view_dojo", dojo=dojo.reference_id),
         title=dojo.name or dojo.id,
         text=text,
         icon=icon,

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -6,7 +6,7 @@
   <div class="container">
     <h1>{{ module.name or module.id }}</h1>
     <br>
-    <h2 class="module-dojo"><a href="{{ url_for('pwncollege_dojos.view_dojo', dojo=dojo.reference_id) }}">{{ dojo.name or dojo.id }}</a></h2>
+    <h2 class="module-dojo"><a href="{{ url_for('pwncollege_dojo.view_dojo', dojo=dojo.reference_id) }}">{{ dojo.name or dojo.id }}</a></h2>
 
     {% if assessments %}
     <br>


### PR DESCRIPTION
Changing the solves endpoint to be link-shareable like the update endpoint for better integration. For the secret, I'm using a hash of the private key for the dojo's deploy key (didn't want to reuse the update code because granting update permissions shouldn't necessarily be the same as granting solves access).