### PR TITLE
Use pwninit to Patch Challenges Requiring glibc 2.34

### DIFF
--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -591,6 +591,9 @@ EOF
 
 RUN ln -sf /usr/bin/ipython3 /usr/bin/ipython
 
+RUN wget -q -O /usr/local/bin/pwninit https://github.com/io12/pwninit/releases/download/3.3.1/pwninit && \
+    chmod +x /usr/local/bin/pwninit
+
 FROM builder-tools-pip-${INSTALL_TOOLS_PIP} as builder-tools-pip
 
 ################################################################################


### PR DESCRIPTION
`pwninit` is used to automatically patch challenges that require glibc 2.34 to run. By using `pwninit` we can ensure compatibility with the required GLIBC version making execution and testing of the challenges possible.