### PR TITLE
Nix-ify windows runtime

### DIFF
--- a/workspace/flake.nix
+++ b/workspace/flake.nix
@@ -21,6 +21,7 @@
         desktop-service = import ./services/desktop.nix { inherit pkgs; };
 
         additional = import ./additional/additional.nix { inherit pkgs; };
+        windows = import ./vm/windows/windows.nix { inherit pkgs; };
 
         corePackages = with pkgs; [
           bashInteractive
@@ -43,7 +44,7 @@
           desktop-service
         ];
 
-        fullPackages = corePackages ++ additional.packages;
+        fullPackages = corePackages ++ additional.packages ++ windows.packages;
 
         buildDojoEnv = name: paths: pkgs.buildEnv {
           name = "dojo-workspace-${name}";

--- a/workspace/vm/windows/windows
+++ b/workspace/vm/windows/windows
@@ -19,8 +19,14 @@ STATEFUL_WORLD_WRITEABLE_PATH = STATEFUL_PATH / "world-writeable"
 virtfs_sock_path = lambda dir_path, tag: dir_path / f"virtfs-{tag}.sock"
 virtfs_pidfile_path = lambda dir_path, tag: dir_path / f"virtfs-{tag}.pid"
 virtfs_log_path = lambda dir_path, tag: dir_path / f"virtfs-{tag}.log"
-VIRTIOFSD_PATH = "/opt/virtiofsd/virtiofsd"
 FLAG_SHARE_PATH = STATEFUL_PATH / "flag-volume"
+
+VIRTIOFSD_PATH = "@virtiofsd@/bin/virtiofsd"
+QEMU_SYSTEM_X86_PATH = "@qemu@/bin/qemu-system-x86_64"
+QEMU_IMG_PATH = "@qemu@/bin/qemu-img"
+SSH_PATH = "@openssh@/bin/ssh"
+START_STOP_DAEMON_PATH = "/usr/sbin/start-stop-daemon"
+TAIL_PATH = "/usr/bin/tail"
 
 
 def error(msg):
@@ -74,7 +80,7 @@ def start_daemon(pidfile, logfile, child_argv, drop_privs=False):
         preexec_fn = preexec_drop_privs
 
     daemon_argv = [
-        "/usr/sbin/start-stop-daemon",
+        START_STOP_DAEMON_PATH,
         "--start",
         "--pidfile",
         str(pidfile),
@@ -194,7 +200,7 @@ def start():
     mem = "2048M"
     # fmt: off
     qemu_argv = [
-        "/usr/bin/qemu-system-x86_64",
+        QEMU_SYSTEM_X86_PATH,
         "-name", "dojo",
         "-machine", "type=pc,accel=kvm",
         "-m", mem,
@@ -261,20 +267,20 @@ def wait():
 
 def connect():
     wait()
-    execve(["/usr/bin/ssh", vm_hostname()])
+    execve([SSH_PATH, vm_hostname()])
 
 
 def exec_(*args):
     wait()
     if sys.stdout.isatty():
-        execve(["/usr/bin/ssh", "-t", vm_hostname(), "--", *args])
+        execve([SSH_PATH, "-t", vm_hostname(), "--", *args])
     else:
-        execve(["/usr/bin/ssh", vm_hostname(), "--", *args])
+        execve([SSH_PATH, vm_hostname(), "--", *args])
 
 
 def logs():
     argv = [
-        "/usr/bin/tail",
+        TAIL_PATH,
         "-F",
         "-n+1",
         str(VM_LOGFILE),

--- a/workspace/vm/windows/windows-script.nix
+++ b/workspace/vm/windows/windows-script.nix
@@ -1,0 +1,22 @@
+with import <nixpkgs> { };
+# { virtiofsd, qemu, openssh }:
+
+stdenv.mkDerivation {
+  name = "windows-script";
+  version = 0.1;
+
+  src = ./windows;
+  dontUnpack = true;
+
+  # leave /opt/pwn.college shebangs intact
+  dontPatchShebangs = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    substitute $src $out/bin/windows \
+      --subst-var-by virtiofsd "${virtiofsd}" \
+      --subst-var-by qemu "${qemu}" \
+      --subst-var-by openssh "${openssh}"
+    chmod +x $out/bin/windows
+  '';
+}

--- a/workspace/vm/windows/windows.nix
+++ b/workspace/vm/windows/windows.nix
@@ -1,0 +1,10 @@
+{ pkgs }:
+
+let
+  windows-script = pkgs.callPackage ./windows-script.nix { };
+in
+{
+  packages = [
+    windows-script
+  ];
+}


### PR DESCRIPTION
- fixup windows script
- package the windows script and its dependencies with nix: `windows-script.nix`
- add windows packages (right now just the windows script): `windows.nix`
- add windows script to "full" environment in flake
  - do we need a separate attribute to enable windows related stuff?
    could pass through env variable if needed