### PR TITLE
Make "Modules" singular if there is only one module in the dojo.

### DIFF
--- a/dojo_theme/templates/macros/widgets.html
+++ b/dojo_theme/templates/macros/widgets.html
@@ -66,7 +66,7 @@
         title=dojo.name or dojo.id,
         text_lines=[
           "{} Hacking".format(dojo_container_counts.get(dojo.reference_id, 0)) if dojo_container_counts.get(dojo.reference_id, 0) else "",
-          "{} Modules : {} / {}".format(dojo.modules_count, solves, dojo.challenges_count)
+          "{} Module{} : {} / {}".format(dojo.modules_count, "" if dojo.modules_count == 1 else "s", solves, dojo.challenges_count)
         ],
         icon=icon,
         emoji=dojo.award.emoji,


### PR DESCRIPTION
before:
<img width="259" alt="ARM Dojo" src="https://github.com/user-attachments/assets/ee3f5712-5bda-4501-8893-8a5d67cac758">

after:
<img width="265" alt="ARM Dojo" src="https://github.com/user-attachments/assets/4be6d673-911d-431d-85d5-4cf95a9e2f54">
