### PR TITLE
Workspace: Introduce /run/workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ This program must exit (with a status code of `0`) before the workspace is made 
 
 `/run/challenge/bin`
 
-During initialization, the default nix profile at `/nix/var/nix/profiles/default` is symlinked to `/run/current-system/sw`.
-In order to make sure that these standard tools are easily accessible, `PATH` is set to prioritize `/run/current-system/sw/bin` over the default `PATH`.
-This means that when a user runs `gdb`, they will get the standard `gdb` provided by the workspace at `/run/current-system/sw/bin/gdb`, instead of any other `gdb` that might be made available by the challenge image (e.g. `/usr/bin/gdb`).
+During initialization, the default nix profile at `/nix/var/nix/profiles/default` is symlinked into `/run/dojo`.
+In order to make sure that these standard tools are easily accessible, `PATH` is set to prioritize `/run/dojo/bin` over the default `PATH`.
+This means that when a user runs `gdb`, they will get the standard `gdb` provided by the workspace at `/run/dojo/bin/gdb`, instead of any other `gdb` that might be made available by the challenge image (e.g. `/usr/bin/gdb`).
 The workspace provides for *many* tools in this way in order to provide a consistent environment for all challenges, ensuring that students are able to use the tools they are familiar with.
 
 If a challenge wants to instead prioritize its own program(s), this can be done through symlinks in the `/run/challenge/bin` directory.
@@ -91,7 +91,7 @@ This should be done *sparingly*, and only when the challenge really expects a sp
 Unfortunately some of the infrastructure programs might rely on the `PATH` to find their dependencies, and so doing this can sometimes break things (please open an issue if you find this to be the case).
 However, if for example, you want to make sure that your challenge image's `python` (with specific challenge python-dependencies) is used when a student runs `python`, you can symlink `/run/challenge/bin/python` to the desired version of the program.
 
-In other words, `PATH="/run/challenge/bin:/run/current-system/sw/bin:$PATH"`.
+In other words, `PATH="/run/challenge/bin:/run/dojo/bin:$PATH"`.
 
 By default, if there is no `/run/challenge/bin` directory, it is automatically symlinked from `/challenge/bin`.
 This means that you can alternatively place your symlinks in `/challenge/bin` if you prefer; however, the `/challenge` interface is deprecated, and so long-term you should prefer `/run/challenge/bin`.
@@ -103,9 +103,10 @@ For more information about how `PATH` works, see [8.3 Other Environment Variable
 There is no perfect way to marry together a file system that meets the precise needs of the DOJO, the challenge, and the user; however, perfect is the enemy of good.
 
 DOJO owns the following directories:
-- `/nix`
+- `/run/workspace`
 - `/run/dojo`
 - `/run/current-system`
+- `/nix`
 
 The user owns the following directories:
 - `/home/hacker`
@@ -113,8 +114,8 @@ The user owns the following directories:
 The challenge owns everything else subject to the following constraints/understanding:
 - DOJO will ensure `/tmp` exists, with permisisons `root:root 01777`.
 - DOJO will control `/etc/passwd` and `/etc/group` for the `hacker` (UID 1000) and `root` (UID 0) users, with permissions `root:root 0644`.
-- `/bin/sh` must be POSIX compliant; DOJO will symlink `/bin/sh` to `/run/current-system/sw/bin/sh` if it does not exist.
-- `/usr/bin/env` must be POSIX compliant; DOJO will symlink `/usr/bin/env` to `/run/current-system/sw/bin/env` if it does not exist.
+- `/bin/sh` must be POSIX compliant; DOJO will symlink `/bin/sh` to `/run/dojo/bin/sh` if it does not exist.
+- `/usr/bin/env` must be POSIX compliant; DOJO will symlink `/usr/bin/env` to `/run/dojo/bin/env` if it does not exist.
 - Various configuration files may be automatically utilized by the DOJO; please open an issue if you run into issues with this.
 
 ## Local Deployment

--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -73,9 +73,9 @@ COPY .radare2rc /opt/pwn.college/.radare2rc
 COPY .pwn.conf /opt/pwn.college/.pwn.conf
 
 RUN <<EOF
-    ln -sf /run/current-system/sw/bin/python-suid /opt/pwn.college/python
-    ln -sf /run/current-system/sw/bin/bash-suid /opt/pwn.college/bash
-    ln -sf /run/current-system/sw/bin/sh-suid /opt/pwn.college/sh
+    ln -sf /run/dojo/bin/python-suid /opt/pwn.college/python
+    ln -sf /run/dojo/bin/bash-suid /opt/pwn.college/bash
+    ln -sf /run/dojo/bin/sh-suid /opt/pwn.college/sh
 
     ln -sf /opt/pwn.college/vm/vm /usr/local/bin/vm
     ln -sf /opt/pwn.college/windows/windows /usr/local/bin/windows

--- a/dojo_plugin/pages/workspace.py
+++ b/dojo_plugin/pages/workspace.py
@@ -32,7 +32,7 @@ def start_on_demand_service(user, service_name):
         return
     try:
         exec_run(
-            f"/run/current-system/sw/bin/dojo-{service_name}",
+            f"/run/dojo/bin/dojo-{service_name}",
             workspace_user="hacker",
             user_id=user.id,
             assert_success=True,

--- a/sshd/enter.py
+++ b/sshd/enter.py
@@ -41,7 +41,7 @@ def main():
 
         if status == "running":
             try:
-                container.get_archive("/run/dojo/ready")
+                container.get_archive("/run/dojo/var/ready")
             except docker.errors.NotFound:
                 status = "initializing"
 

--- a/workspace/core/init.nix
+++ b/workspace/core/init.nix
@@ -13,24 +13,33 @@ let
     mkdir -p /run/current-system
     ln -sfT $DEFAULT_PROFILE /run/current-system/sw
 
+    mkdir -p /run/dojo
+    for path in /run/current-system/sw/*; do
+      ln -sfT $path /run/dojo/$(basename $path)
+    done
+
+    mkdir -p /run/workspace
+    ln -sfT /run/current-system/sw/bin /run/workspace/bin
+    chmod 005 /run/workspace
+
     if [ ! -e /run/challenge/bin ]; then
       mkdir -p /run/challenge && ln -sfT /challenge/bin /run/challenge/bin
     fi
 
     if [ ! -e /bin/sh ]; then
-      mkdir -p /bin && ln -sfT $DEFAULT_PROFILE/bin/sh /bin/sh
+      mkdir -p /bin && ln -sfT /run/dojo/bin/sh /bin/sh
     fi
 
     mkdir -p /home/hacker /root
     mkdir -p /etc && touch /etc/passwd /etc/group
-    echo "root:x:0:0:root:/root:$DEFAULT_PROFILE/bin/bash" >> /etc/passwd
-    echo "hacker:x:1000:1000:hacker:/home/hacker:$DEFAULT_PROFILE/bin/bash" >> /etc/passwd
+    echo "root:x:0:0:root:/root:/run/dojo/bin/bash" >> /etc/passwd
+    echo "hacker:x:1000:1000:hacker:/home/hacker:/run/dojo/bin/bash" >> /etc/passwd
     echo "root:x:0:" >> /etc/group
     echo "hacker:x:1000:" >> /etc/group
 
-    mkdir -pm 1777 /run/dojo /tmp
-    mkdir /run/dojo/root
-    echo $DOJO_AUTH_TOKEN > /run/dojo/auth_token
+    mkdir -pm 1777 /run/dojo/var /tmp
+    mkdir /run/dojo/var/root
+    echo $DOJO_AUTH_TOKEN > /run/dojo/var/auth_token
 
     read DOJO_FLAG
     echo $DOJO_FLAG | install -m 400 /dev/stdin /flag
@@ -47,7 +56,7 @@ let
         /challenge/.init
     fi
 
-    touch /run/dojo/ready
+    touch /run/dojo/var/ready
 
     exec "$@"
   '';

--- a/workspace/core/suid_interpreter.c
+++ b/workspace/core/suid_interpreter.c
@@ -16,7 +16,7 @@
 #define ERROR_BAD_SHEBANG 6   // Resolved script must indicate it's desire to be run with THIS interpreter (SECURITY: prevent weird-behavior due to running incorrect interpreter via non-shebang forced invocation)
 #define ERROR_BAD_ENV 7       // Resolved script which indicates a clear environment must have a cleared environment (SECURITY: prevent weird-behavior due to running interpreter with environment via non-shebang forced invocation)
 
-#define BIN "/run/current-system/sw/bin/"
+#define BIN "/run/dojo/bin/"
 
 int main(int argc, char **argv, char **envp)
 {

--- a/workspace/services/code.nix
+++ b/workspace/services/code.nix
@@ -33,7 +33,7 @@ let
   serviceScript = pkgs.writeScript "dojo-code" ''
     #!${pkgs.bash}/bin/bash
 
-    until [ -f /run/dojo/ready ]; do sleep 0.1; done
+    until [ -f /run/dojo/var/ready ]; do sleep 0.1; done
 
     ${service}/bin/dojo-service start code-service/code-server \
       ${code-server}/bin/code-server \

--- a/workspace/services/desktop.nix
+++ b/workspace/services/desktop.nix
@@ -20,32 +20,32 @@ let
   serviceScript = pkgs.writeScript "dojo-desktop" ''
     #!${pkgs.bash}/bin/bash
 
-    until [ -f /run/dojo/ready ]; do sleep 0.1; done
+    until [ -f /run/dojo/var/ready ]; do sleep 0.1; done
 
     export DISPLAY=:0
-    export XDG_DATA_DIRS="/run/current-system/sw/share:''${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    export XDG_CONFIG_DIRS="/run/current-system/sw/etc/xdg:''${XDG_CONFIG_DIRS:-/etc/xdg}"
+    export XDG_DATA_DIRS="/run/dojo/share:''${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+    export XDG_CONFIG_DIRS="/run/dojo/etc/xdg:''${XDG_CONFIG_DIRS:-/etc/xdg}"
 
-    auth_token="$(cat /run/dojo/auth_token)"
+    auth_token="$(cat /run/dojo/var/auth_token)"
     password_interact="$(printf 'desktop-interact' | ${pkgs.openssl}/bin/openssl dgst -sha256 -hmac "$auth_token" | awk '{print $2}' | head -c 8)"
     password_view="$(printf 'desktop-view' | ${pkgs.openssl}/bin/openssl dgst -sha256 -hmac "$auth_token" | awk '{print $2}' | head -c 8)"
 
-    mkdir -p /run/dojo/desktop-service
-    printf '%s\n%s\n' "$password_interact" "$password_view" | ${pkgs.tigervnc}/bin/vncpasswd -f > /run/dojo/desktop-service/Xvnc.passwd
+    mkdir -p /run/dojo/var/desktop-service
+    printf '%s\n%s\n' "$password_interact" "$password_view" | ${pkgs.tigervnc}/bin/vncpasswd -f > /run/dojo/var/desktop-service/Xvnc.passwd
 
     ${service}/bin/dojo-service start desktop-service/Xvnc \
       ${pkgs.tigervnc}/bin/Xvnc \
         $DISPLAY \
         -localhost 0 \
-        -rfbunixpath /run/dojo/desktop-service/Xvnc.sock \
-        -rfbauth /run/dojo/desktop-service/Xvnc.passwd \
+        -rfbunixpath /run/dojo/var/desktop-service/Xvnc.sock \
+        -rfbauth /run/dojo/var/desktop-service/Xvnc.passwd \
         -nolisten tcp \
         -geometry 1024x768 \
         -depth 24
 
     ${service}/bin/dojo-service start desktop-service/novnc \
       ${novnc}/bin/novnc \
-        --vnc --unix-target=/run/dojo/desktop-service/Xvnc.sock \
+        --vnc --unix-target=/run/dojo/var/desktop-service/Xvnc.sock \
         --listen 6080
 
     until [ -e /tmp/.X11-unix/X0 ]; do sleep 0.1; done

--- a/workspace/services/desktop/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
+++ b/workspace/services/desktop/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
@@ -4,7 +4,7 @@
     <property name="screen0" type="empty">
       <property name="monitorVNC-0" type="empty">
         <property name="workspace0" type="empty">
-          <property name="last-image" type="string" value="/run/current-system/sw/share/backgrounds/pwncollege-background.png"/>
+          <property name="last-image" type="string" value="/run/dojo/share/backgrounds/pwncollege-background.png"/>
         </property>
       </property>
     </property>

--- a/workspace/services/service.py
+++ b/workspace/services/service.py
@@ -4,7 +4,7 @@ import signal
 import argparse
 from pathlib import Path
 
-RUN_DIR = Path("/run/dojo")
+RUN_DIR = Path("/run/dojo/var")
 
 def daemonize(service_name, exec_command):
     try:


### PR DESCRIPTION
This introduces `/run/workspace`, which is now what will live in PATH (`/run/workspace/bin`, alongside `/run/challenge/bin`). This has been set to have 005 permissions, owned by root, and we have previously removed `CAP_DAC_OVERRIDE` which means that `root` cannot see into it. 

What this means is that the challenge will not be able to see into nix-land, when looking up files through PATH it will _only_ discover challenge-image paths. This means that if a challenge wants to use something in nix-land, it must be explicit, with an absolute path to `/run/dojo/bin`.