### PR TITLE
UI: Prevent lingering loading message from overflowing

### DIFF
--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -141,9 +141,18 @@ function startChallenge(event) {
     result_notification.addClass('alert alert-warning alert-dismissable text-center');
     result_message.html("Loading.");
     result_notification.slideDown();
+    var dot_max = 5;
+    var dot_counter = 0;
     setTimeout(function loadmsg() {
         if (result_message.html().startsWith("Loading")) {
-            result_message.append(".");
+            if (dot_counter < dot_max - 1){
+                result_message.append(".");
+                dot_counter++;
+            }
+            else {
+                result_message.html("Loading.");
+                dot_counter = 0;
+            }
             setTimeout(loadmsg, 500);
         }
     }, 500);

--- a/dojo_theme/static/js/dojo/navbar.js
+++ b/dojo_theme/static/js/dojo/navbar.js
@@ -66,9 +66,18 @@ function DropdownStartChallenge(event) {
     result_notification.addClass('alert alert-warning alert-dismissable text-center');
     result_message.html("Loading.");
     result_notification.slideDown();
+    var dot_max = 5;
+    var dot_counter = 0;
     setTimeout(function loadmsg() {
         if (result_message.html().startsWith("Loading")) {
-            result_message.append(".");
+            if (dot_counter < dot_max - 1){
+                result_message.append(".");
+                dot_counter++;
+            }
+            else {
+                result_message.html("Loading.");
+                dot_counter = 0;
+            }
             setTimeout(loadmsg, 500);
         }
     }, 500);


### PR DESCRIPTION
The current loading message animation just adds dots to "Loading." until the challenge spins up successfully or an error message is shown. There is nothing stopping it from adding dots until it overflows past the UI. This often happens when the dojo is seeing heavy usage and challenge instances are slow to spin up. 

The updated code just adds up to five dots then starts back at "Loading." continuously.



