### PR TITLE
Enhance/canvas sync

### DIFF
--- a/dojo_plugin/pages/canvas.py
+++ b/dojo_plugin/pages/canvas.py
@@ -11,6 +11,8 @@ from ..models import Dojos, DojoChallenges, DojoStudents, DojoStudents
 from .course import grade
 from ..utils.dojo import dojo_route
 
+SUCCESS_STATUS_CODES = [200, 201, 204]
+
 canvas = Blueprint("canvas", __name__)
 
 log=logging.getLogger(__name__)
@@ -25,8 +27,8 @@ def canvas_sync_all(dojo):
 
     if not dojo.is_admin():
         abort(403)
-    
-    posting_results = do_canvas_sync(dojo)
+    ignore_pending = request.args.get("ignore_pending") is not None
+    posting_results = do_canvas_sync(dojo, ignore_pending=ignore_pending)
         
     return json.dumps(posting_results, indent=2)
 
@@ -35,38 +37,45 @@ def canvas_sync_all(dojo):
 This is called from the the DojoFlag class on a successful flag submission.
 It updates a single user's Canvas grade for the module that the the user just sucessfully submitted 
 """
-@authed_only
-def sync_challenge_to_canvas(challenge_id, user_id):
-    dojo_chal = DojoChallenges.query.filter(DojoChallenges.challenge_id == challenge_id).first()
-    if dojo_chal:
-        dojo = Dojos.query.filter(Dojos.dojo_id == dojo_chal.dojo_id).first()
+def sync_challenge_to_canvas(challenge_id, user_id, app):
+    # delay long enough for database updates to occur
+    with app.app_context():
+        time.sleep(5)  
+        
+        dojo_chal = DojoChallenges.query.filter(DojoChallenges.challenge_id == challenge_id).first()
+        if dojo_chal:
+            dojo = Dojos.query.filter(Dojos.dojo_id == dojo_chal.dojo_id).first()
 
-        posting_results = do_canvas_sync(dojo, user_id=user_id, module_id=dojo_chal.module.id)
-    
-        log.info("Result from post", json.dumps(posting_results, indent=2))
+            posting_results = do_canvas_sync(dojo, user_id=user_id, module_id=dojo_chal.module.id)
+            student_id = posting_results.get('student_id',-1)
+            prj=posting_results.get('json',{})
+            log.info(f" Canvas post result: Id={student_id}, dojo_user_id={user_id}, chal_id={challenge_id}, assn_id={prj.get('assignment_id',-1)} grade={prj.get('score',-1) }")
 
 
 """ 
 This function will retrieve the grade information, format it, and send to canvas
 However, if both user_id and module_id are supplied it will do a single user/module update 
 """
-def do_canvas_sync(dojo, user_id=None, module_id=None):
+def do_canvas_sync(dojo, user_id=None, module_id=None, ignore_pending=False):
     
     canvas_token = dojo.course.get("canvas_token","")
     
     canvas_api_host = dojo.course.get("canvas_api_host","")
     canvas_course_id = dojo.course.get("canvas_course_id",0)
     if len(canvas_token) == 0:
-        return {"status": "completed", "message": "Missing canvas_token in course.xml"}
+        return {"status": "completed", "message": "Missing canvas_token in course.yml"}
     if len(canvas_api_host) == 0:
-        return {"status": "completed", "message": "Missing canvas_api_host in course.xml"}
+        return {"status": "completed", "message": "Missing canvas_api_host in course.yml"}
     if canvas_course_id == 0:
-        return {"status": "completed", "message": "Missing canvas_course_id in course.xml"}
+        return {"status": "completed", "message": "Missing canvas_course_id in course.yml"}
     
+    json_auth_header = {
+        'Authorization': f"Bearer {canvas_token}",
+        "Content-Type": "application/json"
+    }
+
     canvas_grade_data = {}
-    
-    ignore_pending = request.args.get("ignore_pending") is not None
-        
+            
     students = {student.user_id: student.token for student in dojo.students}
     course_students = dojo.course.get("students", [])
     missing_students = list(set(course_students) - set(students.values()))
@@ -110,13 +119,20 @@ def do_canvas_sync(dojo, user_id=None, module_id=None):
             continue 
                     
         canvas_assignment_id = assessment["canvas_assignment_id"]
-        for grade_res in grades:                
-            grade_credit_percent = f"{grade_res['assessment_grades'][aindex]['credit'] * 100:.2f}%"
+        for grade_res in grades:
+            
+            # checkpoints will have a pass/fail boolean coming from the grade function
+            credit = grade_res['assessment_grades'][aindex]['credit']
+            if credit is bool:
+                credit = 1 if credit else 0
+            
+            #%2f is the same used by grades_admin.html and course.html templates
+            grade_credit_percent = f"{credit * 100:.2f}%"
 
             # this is a single module sync, submit to canvas and return
             if module_id is not None and module_id == assessment["id"]:   
                 
-                res = post_grade_to_canvas(canvas_token, canvas_api_host, canvas_course_id, assessment["canvas_assignment_id"], 
+                res = post_grade_to_canvas(json_auth_header, canvas_api_host, canvas_course_id, assessment["canvas_assignment_id"], 
                                         students[grade_res["user_id"]], grade_credit_percent)
                 
                 return res
@@ -132,63 +148,55 @@ def do_canvas_sync(dojo, user_id=None, module_id=None):
                     return {"status": "failed", "message": f"The following did not align in list, {grade_res['assessment_grades'][aindex]['module_id']=}   {assessment['id']=}, this shouldn't happen."}
 
         if (len(canvas_grade_data) > 0):
-            submission_results = post_bulk_grade_data_to_canvas(canvas_token, canvas_api_host, canvas_course_id, canvas_assignment_id, canvas_grade_data)
+            submission_results = post_bulk_grade_data_to_canvas(json_auth_header, canvas_api_host, canvas_course_id, canvas_assignment_id, canvas_grade_data)
             if submission_results["status"] == "success":
                 progress_urls.append(submission_results["url"])
             else:
                 posting_results.append(submission_results)            
         
     if len(progress_urls) > 0 :
-        check_results = check_progress(progress_urls, canvas_token, interval=2)
+        check_results = check_progress(json_auth_header, progress_urls, interval=2)
         posting_results.extend(check_results)
         posting_results.append(assessment_student_counter)
 
     return posting_results
 
 
-def post_grade_to_canvas(canvas_token, canvas_api_host, canvas_course_id, assignment_id, student_id, students_grade):
+def post_grade_to_canvas(json_auth_header, canvas_api_host, canvas_course_id, assignment_id, student_id, students_grade):
     url = f"https://{canvas_api_host}/api/v1/courses/{canvas_course_id}/assignments/{assignment_id}/submissions/sis_user_id:{student_id}"
     payload = {'submission': {'posted_grade': students_grade}}
     
-    header = {'Authorization': 'Bearer ' + canvas_token}
     
-    r = requests.put(url, headers=header, json=payload)
     
-    if r.status_code == 200:
+    r = requests.put(url, headers=json_auth_header, json=payload)
+    
+    if r.status_code in SUCCESS_STATUS_CODES:
         return {"status": "success", "student_id": student_id, "json": r.json()}
     else:
-        return {"student_id": student_id, "code": r.status_code, "text": r.text, "url": url, "canvas_token": canvas_token}
+        return {"student_id": student_id, "status": "fail", "code": r.status_code, "text": r.text, "url": url}
     
 
-def post_bulk_grade_data_to_canvas(canvas_token, canvas_api_host, canvas_course_id, assignment_id, canvas_grade_data):
+def post_bulk_grade_data_to_canvas(json_auth_header, canvas_api_host, canvas_course_id, assignment_id, canvas_grade_data):
     url = f"https://{canvas_api_host}/api/v1/courses/{canvas_course_id}/assignments/{assignment_id}/submissions/update_grades"
     payload = {'grade_data': canvas_grade_data}
     
-    header = {
-                'Authorization': 'Bearer ' + canvas_token,
-                "Content-Type": "application/json"
-            }
-    
-    r = requests.post(url, headers=header, json=payload)
+    r = requests.post(url, headers=json_auth_header, json=payload)
     
     r_json = r.json()
     
-    if r.status_code == 200:
+    if r.status_code in SUCCESS_STATUS_CODES:
         r_json["status"] = "success"
         return r_json
     else:
         r_json.update({"status": "failed", "code": r.status_code, "text": r.text, "url": url})
         return  r_json
     
+    
 """ 
 For bulk submissions we do not get an immediate result, but instead get a progress url 
 This function checks the progress up to 20 times and reports back to user on completion or failure to complete
 """
-def check_progress(progress_urls, access_token, interval=5):
-    headers = {
-        "Authorization": f"Bearer {access_token}",
-        "Content-Type": "application/json"
-    }
+def check_progress(json_auth_header, progress_urls, interval=5):    
     completed = []
     check_count = 0
     max_checks = 10
@@ -197,8 +205,8 @@ def check_progress(progress_urls, access_token, interval=5):
         
         for url in progress_urls:
             if url not in completed:
-                response = requests.get(url, headers=headers)
-                if response.status_code == 200:
+                response = requests.get(url, headers=json_auth_header)
+                if response.status_code in SUCCESS_STATUS_CODES:
                     progress_data = response.json()
                     if progress_data.get('workflow_state') == 'completed':
                         completed.append({"status": "success", "url": url, "completion": progress_data.get('completion',0)})                    


### PR DESCRIPTION
Small upgrade to the sync that will, by default, ignore 0's and only sync them to canvas after Canvas's due date has past. 
Unless the creator chooses to enable "canvas_always_sync_zeros" in the course.yml file.

It was tested against asu.beta.instructure.com with a prior course.