### PR TITLE
Minor UI Bug Fix: double click when adding student id for first time 

### DIFF
--- a/dojo_plugin/pages/course.py
+++ b/dojo_plugin/pages/course.py
@@ -296,7 +296,8 @@ def update_identity(dojo):
     db.session.commit()
 
     student = DojoStudents.query.filter_by(dojo=dojo, user=user).first()
-    if not student.official:
+    # FIX: not returning official after initially added on new user, it's not seeing user as student and thus it doesn't have the property
+    if  not hasattr(student, 'official') or not student.official:
         identity_name = dojo.course.get("student_id", "Identity")
         return {"success": True, "warning": f"Your {identity_name} is not on the official student roster"}
 


### PR DESCRIPTION
Minor bug where the button does not submit on the first attempt when setting student id on the identity page.

This occurs because the user is not a student yet and the page dies because it tries to access official, which is only returned when the user is a student in the Dojo.