### PR TITLE
Fixed Bugs Introduced in Recent Refactor of Canvas Sync

### DIFF
--- a/dojo_plugin/pages/canvas.py
+++ b/dojo_plugin/pages/canvas.py
@@ -1,19 +1,20 @@
 import json
-import requests
-from datetime import datetime
 import logging
+from datetime import datetime
 
+import requests
 from flask import request, Blueprint, abort, url_for
 from CTFd.models import Users
 from CTFd.utils.decorators import authed_only
 
-from ..models import DojoChallenges, DojoStudents, DojoStudents
 from .course import grade
+from ..models import DojoChallenges, DojoStudents, DojoStudents
 from ..utils.dojo import dojo_route
+
 
 canvas = Blueprint("canvas", __name__)
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def canvas_request(endpoint, method="GET", *, dojo, **kwargs):
@@ -124,6 +125,6 @@ def sync_canvas(dojo, module=None, user_id=None, ignore_pending=False):
         response = canvas_course_request(f"/assignments/{assignment_id}/submissions/update_grades", method="POST", dojo=dojo, json=grade_data)
         progress_url = url_for("canvas.canvas_progress", dojo=dojo.reference_id, progress_id=response["id"], _external=True)
         progress_info[assignment_id] = progress_url
-        log.info(f"Posted {len(grade_data)} grade(s) to Canvas assignment {assignment_id}: {progress_url}")
+        logger.info(f"Posted {len(grade_data)} grade(s) to Canvas assignment {assignment_id}: {progress_url}")
 
     return progress_info

--- a/dojo_plugin/pages/canvas.py
+++ b/dojo_plugin/pages/canvas.py
@@ -12,23 +12,31 @@ from ..utils.dojo import dojo_route
 
 canvas = Blueprint("canvas", __name__)
 
-
-def canvas_request(endpoint, method="GET", *, dojo, **kwargs):
+def canvas_request(endpoint, method="GET", *, dojo, is_canvas_course_endpoint=True, **kwargs):
     missing = [attr for attr in ["canvas_token", "canvas_api_host", "canvas_course_id"] if not (dojo.course or {}).get(attr)]
     if missing:
         raise RuntimeError(f"Canvas not configured: missing {', '.join(missing)}")
+    
     canvas_token = dojo.course["canvas_token"]
     canvas_api_host = dojo.course["canvas_api_host"]
     canvas_course_id = dojo.course["canvas_course_id"]
 
     headers = {"Authorization": f"Bearer {canvas_token}"}
-    canvas_course_endpoint = f"https://{canvas_api_host}/api/v1/courses/{canvas_course_id}"
-    response = requests.request(method, f"{canvas_course_endpoint}{endpoint}", headers=headers, **kwargs)
+    
+    if is_canvas_course_endpoint:
+        canvas_course_endpoint = f"https://{canvas_api_host}/api/v1/courses/{canvas_course_id}"
+        full_url = f"{canvas_course_endpoint}{endpoint}"
+    else:
+        full_url = f"https://{canvas_api_host}/api/v1{endpoint}"
+    
+    response = requests.request(method, full_url, headers=headers, **kwargs)
     response.raise_for_status()
+    
     if "application/json" in response.headers.get("Content-Type", ""):
         return response.json()
     else:
         return response.content
+
 
 
 @canvas.route("/dojo/<dojo>/admin/canvas/sync")
@@ -56,7 +64,7 @@ def canvas_progress(dojo, progress_id):
     if not (dojo.course and dojo.course.get("canvas_token")):
         abort(404)
 
-    response = canvas_request(f"/progress/{progress_id}", dojo=dojo)
+    response = canvas_request(f"/progress/{progress_id}", is_canvas_course_endpoint=False, dojo=dojo)
     return json.dumps(response, indent=2)
 
 
@@ -77,7 +85,7 @@ def sync_canvas(dojo, module=None, user_id=None, ignore_pending=False):
     )
     if user_id is not None:
         users = users.filter(DojoStudents.user_id == user_id)
-
+    students_map = {student.user_id: student.token for student in dojo.students}
     assessments = dojo.course.get("assessments", [])
     canvas_assignments = {
         assignment["id"]: dict(
@@ -91,7 +99,9 @@ def sync_canvas(dojo, module=None, user_id=None, ignore_pending=False):
     assignment_submissions = {}
 
     grades = grade(dojo, users, ignore_pending=ignore_pending)
+
     for user_grades in grades:
+        
         for assessment, assessment_grade in zip(assessments, user_grades["assessment_grades"]):
             canvas_assignment = canvas_assignments.get(assessment.get("canvas_assignment_id"))
 
@@ -104,13 +114,14 @@ def sync_canvas(dojo, module=None, user_id=None, ignore_pending=False):
 
             student_submissions = assignment_submissions.setdefault(canvas_assignment["id"], {})
             grade_data = student_submissions.setdefault("grade_data", {})
-            student_user_id = f"sis_user_id:{user_grades['user_id']}"
+            student_user_id = f"sis_user_id:{students_map[user_grades['user_id']]}"
             grade_credit = f"{assessment_grade['credit'] * 100:.2f}%"
             grade_data[student_user_id] = {"posted_grade": grade_credit}
-
+                    
     progress_info = {}
     for assignment_id, grade_data in assignment_submissions.items():
         response = canvas_request(f"/assignments/{assignment_id}/submissions/update_grades", method="POST", dojo=dojo, json=grade_data)
+        response["url"] = request.base_url.replace("sync",f"progress/{response.get('id',0)}")  # make a url for pwn.college progress check
         progress_info[assignment_id] = response
 
     return progress_info


### PR DESCRIPTION
Fixed 2 bugs with recent update, 
1) The `grade_data` was returning wrong student id (pwn.college user id instead of student id)
2) The progress api url for canvas was incorrect.
3) Fixed incorrect key for assessment, it should have been `id` instead of `module_id`
Also, fixed the `response["url"]` so that it now uses the pwn.college end point instead of the Canvas endpoint
