### PR TITLE
Refactor challenge ID comparison to use challenge index…

### DIFF
--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -500,16 +500,16 @@ def get_prev_cur_next_dojo_challenge(user=None):
         DojoChallenges.query
         .filter(DojoChallenges.module == DojoModules.from_id(container.labels.get("dojo.dojo_id"), container.labels.get("dojo.module_id")).first(),
                 DojoChallenges.dojo == Dojos.from_id(container.labels.get("dojo.dojo_id")).first(),
-                DojoChallenges.challenge_id < current.challenge_id)
-        .order_by(DojoChallenges.challenge_id.desc())
+                DojoChallenges.challenge_index < current.challenge_index)
+        .order_by(DojoChallenges.challenge_index.desc())
         .first()
     )
     next = (
         DojoChallenges.query
         .filter(DojoChallenges.module == DojoModules.from_id(container.labels.get("dojo.dojo_id"), container.labels.get("dojo.module_id")).first(),
                 DojoChallenges.dojo == Dojos.from_id(container.labels.get("dojo.dojo_id")).first(),
-                DojoChallenges.challenge_id > current.challenge_id)
-        .order_by(DojoChallenges.challenge_id.asc())
+                DojoChallenges.challenge_index > current.challenge_index)
+        .order_by(DojoChallenges.challenge_index.asc())
         .first()
     )
     return {


### PR DESCRIPTION
 …in `get_pre cur_next_dojo_challenge`

- Updated the query filters to compare `challenge_index` instead of `challenge_id`.
- Adjusted the order_by clauses to use `challenge_index` for sorting.

related to  Navbar flag input keys off of challenge id instead of challenge index #544 