### PR TITLE
added fastecdsa

### DIFF
--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -134,6 +134,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         upx-ucl
 EOF
 
+RUN pip install fastecdsa
+
 ################################################################################
 
 FROM scratch as builder-kernel-no

--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -510,6 +510,7 @@ RUN xargs pip install --force-reinstall <<EOF
     r2pipe
     requests
     selenium
+    fastecdsa
 EOF
 
 RUN ln -sf /usr/bin/ipython3 /usr/bin/ipython


### PR DESCRIPTION
Adding fastecdsa which is a tool used for fast elliptic curve cryptography like digital signatures, it is being used to run the challenges in CTF Archive's cryptoctf2020, corctf2021, angstromctf2024, and corctf2022. 

PyPI link: [fastecdsa](https://pypi.org/project/fastecdsa/)

Github: [fastecdsa](https://github.com/AntonKueltz/fastecdsa)
