### PR TITLE
Do not make pwndbg mandatory for root user

### DIFF
--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -217,6 +217,7 @@ RUN <<EOF
     cargo install --path . --root /tmp
     mv /tmp/bin/ropr /usr/bin/kropr
     chmod +x /usr/bin/kropr
+    ln -sf /home/hacker/.gdbinit /root/.gdbinit
 EOF
 
 FROM builder-gdb-${INSTALL_GDB} as builder-gdb


### PR DESCRIPTION
Stop `pwndbg` installation from overwriting `.gdbinit` for root user.