### PR TITLE
[navbar] Fix challenge ordering and optimize queries

### DIFF
--- a/dojo_plugin/pages/dojo.py
+++ b/dojo_plugin/pages/dojo.py
@@ -67,7 +67,7 @@ def active_module():
     import json
     user = get_current_user()
     active = get_current_dojo_challenge()
-    challs = get_prev_cur_next_dojo_challenge()
+    challs = get_prev_cur_next_dojo_challenge(active=active)
     if active:
     #return a json of the active challenge
         return {


### PR DESCRIPTION
## What?
Fixing this issue (https://github.com/pwncollege/dojo/issues/544) by reusing `get_current_dojo_challenge()` and the already created `challenge.module` and `module.challenges` (which helpfully sorts by challenge_index!)

This should also reduce the number of queries made to the DB, so hopefully we melt like 1% less or something.

## How was this tested?
Comparison of local dojo to prod:
Local:
<img width="921" alt="image" src="https://github.com/user-attachments/assets/55b07408-1995-48cd-a988-0d9ca543cbe5">
Production:
<img width="916" alt="image" src="https://github.com/user-attachments/assets/4c05a214-1c95-407c-984e-b7a65b99bb36">

cc @ConnorNelson