### PR TITLE
Infrastructure: Fix MacOS support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ RUN cd /tmp && \
 
 RUN git clone --branch 3.6.0 https://github.com/CTFd/CTFd /opt/CTFd
 
+RUN rm /lib/binfmt.d/*
+
 RUN ln -s /opt/pwn.college/etc/systemd/system/pwn.college.service /etc/systemd/system/pwn.college.service && \
     ln -s /opt/pwn.college/etc/systemd/system/pwn.college.backup.service /etc/systemd/system/pwn.college.backup.service && \
     ln -s /opt/pwn.college/etc/systemd/system/pwn.college.backup.timer /etc/systemd/system/pwn.college.backup.timer && \


### PR DESCRIPTION
Based on discussions in https://github.com/docker/for-mac/issues/7168#issuecomment-1935284120 and https://github.com/kubernetes/minikube/issues/17700 it is clear that systemd is our enemy.

Default behavior of systemd is, for some reason, to perform destructive operations on `/proc/sys/fs/binfmt_misc`, and we ultimately lose `/proc/sys/fs/binfmt_misc/rosetta`, which means no more emulation.

This systemd behavior destructively interferes all the way up to the docker vm host. It will literally brick host MacOS docker rosetta support until docker is restarted:
```
$ docker run --platform linux/amd64 -it --rm --privileged ubuntu:latest bash
exec /usr/bin/bash: exec format error
```

It is no surprise this also bricks our inner docker support.

Removing the files inside `/lib/binfmt.d` has the behavior of disabling the binfmt_misc systemd service. This just removes some python3.12 binfmt_misc config, that doesn't seem to have any impact that affects us.