### PR TITLE
accept ecdsa-sha2-nistp256 public keys

### DIFF
--- a/dojo_plugin/api/v1/ssh_key.py
+++ b/dojo_plugin/api/v1/ssh_key.py
@@ -23,7 +23,7 @@ class UpdateKey(Resource):
         key_value = data.get("ssh_key", "")
 
         if key_value:
-            key_re = "ssh-(rsa|ed25519|dss) AAAA[0-9A-Za-z+/]{1,730}[=]{0,2}"
+            key_re = "(ssh-(rsa|ed25519|dss)|ecdsa-sha2-nistp256) AAAA[0-9A-Za-z+/]{1,730}[=]{0,2}"
             key_match = re.match(key_re, key_value)
             if not key_match:
                 return (


### PR DESCRIPTION
The SSH server seems to support ecdsa-sha2-nistp256 keys, based on the output of `ssh -G`:

```
hostbasedacceptedalgorithms ssh-ed25519-cert-v01@openssh.com,...,ecdsa-sha2-nistp256,
..
kexalgorithms sntrup761x25519-sha512@openssh.com,..,ecdsa-sha2-nistp256
```

Modified the regular expression to allow ecdsa-sha2-nistp256 keys to be set in the UI.

This would be very useful because Secretive agent (which uses SSH keys stored in the TPM of Macs) only generates this key type - ecdsa-sha2-nistp256.

Hope this is the right place to make this change. 

Thank you!