### PR TITLE
Reword scoreboard to be clearer to some students

### DIFF
--- a/dojo_theme/static/js/dojo/scoreboard.js
+++ b/dojo_theme/static/js/dojo/scoreboard.js
@@ -17,9 +17,18 @@ function loadScoreboard(duration, page) {
     $("#scoreboard-control-week").removeClass("scoreboard-page-selected");
     $("#scoreboard-control-month").removeClass("scoreboard-page-selected");
     $("#scoreboard-control-all").removeClass("scoreboard-page-selected");
-    if (duration == 7) $("#scoreboard-control-week").addClass("scoreboard-page-selected");
-    if (duration == 30) $("#scoreboard-control-month").addClass("scoreboard-page-selected");
-    if (duration == 0) $("#scoreboard-control-all").addClass("scoreboard-page-selected");
+    if (duration == 7) {
+        $("#scoreboard-control-week").addClass("scoreboard-page-selected");
+        $("#scoreboard-heading").text("7-Day Scoreboard:");
+    }
+    if (duration == 30) {
+        $("#scoreboard-control-month").addClass("scoreboard-page-selected");
+        $("#scoreboard-heading").text("30-Day Scoreboard:");
+    }
+    if (duration == 0) {
+        $("#scoreboard-control-all").addClass("scoreboard-page-selected");
+        $("#scoreboard-heading").text("All-Time Scoreboard:");
+    }
 
     CTFd.fetch(endpoint, {
         method: "GET",

--- a/dojo_theme/templates/dojo.html
+++ b/dojo_theme/templates/dojo.html
@@ -117,7 +117,7 @@
 
   <br>
 
-  <h2 class="row">Rankings:</h2>
+  <h2 class="row" id="scoreboard-heading">30-Day Scoreboard:</h2>
   <br>
   {% from "macros/scoreboard.html" import scoreboard %}
   {{ scoreboard() }}

--- a/dojo_theme/templates/macros/scoreboard.html
+++ b/dojo_theme/templates/macros/scoreboard.html
@@ -1,9 +1,9 @@
 {% macro scoreboard() -%}
 <div class="scoreboard-controls row">
   <p>
-  <span id="scoreboard-control-week"><a href="javascript:loadScoreboard(7, 1)">Week</a></span> |
-  <span id="scoreboard-control-month"><a href="javascript:loadScoreboard(30, 1)">Month</a></span> |
-  <span id="scoreboard-control-all"><a href="javascript:loadScoreboard(0, 1)">All Time</a></span>
+  <span id="scoreboard-control-week"><a href="javascript:loadScoreboard(7, 1)">7-Day</a></span> |
+  <span id="scoreboard-control-month"><a href="javascript:loadScoreboard(30, 1)">30-Day</a></span> |
+  <span id="scoreboard-control-all"><a href="javascript:loadScoreboard(0, 1)">All-Time</a></span>
   </p>
 </div>
 <div class="scoreboard row">

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -138,7 +138,7 @@
 
   <br>
 
-  <h2>Ranking</h2>
+  <h2 class="row" id="scoreboard-heading">30-Day Scoreboard:</h2>
   <p>This scoreboard reflects solves for challenges in this module after the module launched in this dojo.</p>
   {% from "macros/scoreboard.html" import scoreboard %}
   {{ scoreboard() }}


### PR DESCRIPTION
## What?
At the request of @zardus , reword the scoreboard to be clearer that it is the past 7 days/30 days. Also change the heading based on what time frame we have selected.

## How was this tested?
Spinning up a local instance:
![Screenshot 2024-10-02 191135](https://github.com/user-attachments/assets/ddb238d5-2cc1-4d3f-9210-6fa93aa30629)
![Screenshot 2024-10-02 191132](https://github.com/user-attachments/assets/f5ad862f-184a-45ae-835b-ae6f939a19d0)
![Screenshot 2024-10-02 191127](https://github.com/user-attachments/assets/cade4e32-f5c6-498d-ae98-430ec4f232d0)

cc @ConnorNelson @robwaz @zardus 