### PR TITLE
Cap capstone version to 5.0.2 to avoid any kind of linking errors for freshly deployed pwncol instances 

### DIFF
--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -240,7 +240,7 @@ FROM builder-tcpdump-${INSTALL_TCPDUMP} as builder-tcpdump
 FROM scratch as builder-capstone-no
 FROM builder as builder-capstone-yes
 RUN <<EOF
-    git clone --branch 5.0.2 --depth 1 https://github.com/capstone-engine/capstone /opt/capstone
+    git clone --branch 5.0.3 --depth 1 https://github.com/capstone-engine/capstone /opt/capstone
     cd /opt/capstone
     make
     make install

--- a/challenge/Dockerfile
+++ b/challenge/Dockerfile
@@ -240,7 +240,7 @@ FROM builder-tcpdump-${INSTALL_TCPDUMP} as builder-tcpdump
 FROM scratch as builder-capstone-no
 FROM builder as builder-capstone-yes
 RUN <<EOF
-    git clone --depth 1 https://github.com/capstone-engine/capstone /opt/capstone
+    git clone --branch 5.0.2 --depth 1 https://github.com/capstone-engine/capstone /opt/capstone
     cd /opt/capstone
     make
     make install


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d0dd88c5-7516-4e42-94b6-9be9b1590138)

capstone v6 alpha had likely messed up capstone linking for many dojos. This issue often occurs when the instance is built from scratch 