### PR TITLE
Fixed challenge name overflow when using a small viewport

### DIFF
--- a/dojo_theme/static/css/custom.css
+++ b/dojo_theme/static/css/custom.css
@@ -250,6 +250,10 @@ h4 {
     margin: 0px;
     padding: 0px !important;
     float: left;
+    white-space: normal;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .challenge-active {


### PR DESCRIPTION
Currently a lot of stuff displays slightly funny if the site is viewed on mobile, as a part of my efforts to fix that, this first contribution from me fixes text overflow in challenge names.

If you would prefer this change not cause the challenge name text to wrap around and instead just cut off with a "...", remove the "white-space: normal;" line from .accordion-item-name class.