### PR TITLE
Hide text in dojo description

### DIFF
--- a/dojo_plugin/utils/__init__.py
+++ b/dojo_plugin/utils/__init__.py
@@ -143,6 +143,7 @@ def render_markdown(s):
         "b", "i", "strong", "em", "tt",
         "p", "br",
         "span", "div", "blockquote", "code", "pre", "hr",
+        "hide",
         "ul", "ol", "li", "dd", "dt",
         "img",
         "a",
@@ -152,6 +153,7 @@ def render_markdown(s):
         "*": ["id"],
         "img": ["src", "alt", "title"],
         "a": ["href", "alt", "title"],
+        "p": ["data-hide"]
     }
     clean_html = bleach.clean(raw_html, tags=markdown_tags, attributes=markdown_attrs)
     return Markup(clean_html)

--- a/dojo_plugin/utils/__init__.py
+++ b/dojo_plugin/utils/__init__.py
@@ -143,7 +143,6 @@ def render_markdown(s):
         "b", "i", "strong", "em", "tt",
         "p", "br",
         "span", "div", "blockquote", "code", "pre", "hr",
-        "hide",
         "ul", "ol", "li", "dd", "dt",
         "img",
         "a",

--- a/dojo_theme/static/css/custom.css
+++ b/dojo_theme/static/css/custom.css
@@ -36,6 +36,11 @@ h4 {
     text-shadow: rgba(104, 182, 255, 0.15) 0px 0px 5px;
 }
 
+p[data-hide="true"] {
+  font-size: 1px;                
+  opacity: 0;                    
+} 
+
 .close-link {
     border: none;
     background-color: inherit;


### PR DESCRIPTION
The html filter for model and challenge descriptions now allows the "data-hide" attribute.
When <p "data-hide"="true">the text will not be visible but the text inside will be included in a copy of the text.
 