### PR TITLE
adding assessment.countdown_date to show students an alternative target date to the due date

### DIFF
--- a/dojo_plugin/pages/dojo.py
+++ b/dojo_plugin/pages/dojo.py
@@ -267,7 +267,8 @@ def view_module(dojo, module):
     if student or dojo.is_admin(user):
         now = datetime.datetime.now(datetime.timezone.utc)
         for assessment in module.assessments:
-            date = datetime.datetime.fromisoformat(assessment["date"])
+            assessment_date = assessment.get("countdown_date") if "countdown_date" in assessment else assessment["date"]
+            date = datetime.datetime.fromisoformat(assessment_date)
             until = date.astimezone(datetime.timezone.utc) - now
             if until < datetime.timedelta(0):
                 continue


### PR DESCRIPTION
This is a slight change from what I discussed with Connor, but I think it's more flexible because I do like the countdown timer.

With the integration with Canvas, I have a due date in Canvas and a pwn.college due date that comes two days later. Building in a slight grace period, with the intent, that they will treat the Canvas deadline as the target deadline. This gives them a bit of a grace period if something comes up; however, pwn.college counts down to the secondary date deadline and as the semester has gone on some students have started focusing on the pwn.college date and the countdown instead of the Canvas due date. 

 To prevent those students from doing that in the future, I have added a countdown_date functionality that will show the countdown date instead of the assessment date.  I plan to have the assessment's countdown_date match the Canvas date and make the pwn.college penalty date an unknown and random date that occurs after the Canvas date that way they'll focus on completing assignments by the due date listed in Canvas and have a bit of a grace period when things come up. 

-Erik 