### PR TITLE
Workspace: Support overlays and incremental sends in homefs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,12 +70,12 @@ services:
       context: ./homefs
     environment:
       - STORAGE_ROOT=/run/homefs
-      - STORAGE_HOST=http://192.168.42.1:8001
+      - STORAGE_HOST=192.168.42.1
     volumes:
       - /run/homefs:/run/homefs:shared
       - /var/run/docker/plugins:/var/run/docker/plugins
     ports:
-      - "8001:80"
+      - "4201:4201"
 
   ctfd:
     container_name: ctfd

--- a/dojo/dojo-node
+++ b/dojo/dojo-node
@@ -102,7 +102,7 @@ case "$ACTION" in
             mv /data/workspace_nodes.json.tmp /data/workspace_nodes.json
             dojo-node refresh
         else
-            echo "Usage: $0 remove NODE_ID"
+            echo "Usage: $0 del NODE_ID"
         fi
         ;;
 

--- a/dojo_plugin/api/v1/docker.py
+++ b/dojo_plugin/api/v1/docker.py
@@ -45,18 +45,22 @@ def remove_container(user):
     known_image_name = cache.get(f"user_{user.id}-running-image")
     images = [None, known_image_name]
     for image_name in images:
+        docker_client = user_docker_client(user, image_name)
         try:
-            docker_client = user_docker_client(user, image_name)
             container = docker_client.containers.get(container_name(user))
             container.remove(force=True)
             container.wait(condition="removed")
         except docker.errors.NotFound:
             pass
+        try:
+            overlay_volume = docker_client.volumes.get(f"{user.id}-overlay")
+            overlay_volume.remove()
+        except docker.errors.NotFound:
+            pass
 
 
-def start_container(docker_client, user, as_user, mounts, dojo_challenge, practice):
-    assert user == as_user, "Support for running as a different user is currently disabled"  # TODO: Re-implement this
 
+def start_container(docker_client, user, as_user, user_mounts, dojo_challenge, practice):
     hostname = "~".join(
         (["practice"] if practice else [])
         + [
@@ -79,90 +83,87 @@ def start_container(docker_client, user, as_user, mounts, dojo_challenge, practi
     image_path = next((env_var[len("PATH="):].split(":") for env_var in image_env if env_var.startswith("PATH=")), [])
     env_path = ":".join([challenge_bin_path, workspace_bin_path, *image_path])
 
+    mounts = [
+        docker.types.Mount(
+            "/nix",
+            f"{HOST_DATA_PATH}/workspace/nix",
+            "bind",
+            read_only=True,
+        ),
+        docker.types.Mount(
+            "/run/workspace",
+            f"{HOST_DATA_PATH}/workspacefs",
+            "bind",
+            read_only=True,
+            propagation="shared",
+        ),
+        docker.types.Mount(
+            "/run/dojo/sys",
+            "/run/dojofs",
+            "bind",
+            read_only=True,
+            propagation="slave",
+        ),
+        *user_mounts,
+    ]
+
     devices = []
     if os.path.exists("/dev/kvm"):
         devices.append("/dev/kvm:/dev/kvm:rwm")
     if os.path.exists("/dev/net/tun"):
         devices.append("/dev/net/tun:/dev/net/tun:rwm")
 
-        container = docker_client.containers.create(
-            dojo_challenge.image,
-            entrypoint=[
-                "/nix/var/nix/profiles/default/bin/dojo-init",
-                f"{dojo_bin_path}/sleep",
-                "6h",
-            ],
-            name=container_name(user),
-            hostname=hostname,
-            user="0",
-            working_dir="/home/hacker",
-            environment={
-                "HOME": "/home/hacker",
-                "PATH": env_path,
-                "SHELL": f"{dojo_bin_path}/bash",
-                "DOJO_AUTH_TOKEN": auth_token,
-            },
-            labels={
-                "dojo.dojo_id": dojo_challenge.dojo.reference_id,
-                "dojo.module_id": dojo_challenge.module.id,
-                "dojo.challenge_id": dojo_challenge.id,
-                "dojo.challenge_description": dojo_challenge.description,
-                "dojo.user_id": str(user.id),
-                "dojo.as_user_id": str(as_user.id),
-                "dojo.auth_token": auth_token,
-                "dojo.mode": "privileged" if practice else "standard",
-            },
-            mounts=[
-                docker.types.Mount(
-                    "/nix",
-                    f"{HOST_DATA_PATH}/workspace/nix",
-                    "bind",
-                    read_only=True,
-                ),
-                docker.types.Mount(
-                    "/run/workspace",
-                    f"{HOST_DATA_PATH}/workspacefs",
-                    "bind",
-                    read_only=True,
-                    propagation="shared",
-                ),
-                docker.types.Mount(
-                    "/run/dojo/sys",
-                    "/run/dojofs",
-                    "bind",
-                    read_only=True,
-                    propagation="slave",
-                ),
-                docker.types.Mount(
-                    "/home/hacker",
-                    str(as_user.id),
-                    "volume",
-                    driver_config=docker.types.DriverConfig("homefs"),
-                ),
-            ],
-            devices=devices,
-            network=None,
-            extra_hosts={
-                hostname: "127.0.0.1",
-                "vm": "127.0.0.1",
-                f"vm_{hostname}"[:64]: "127.0.0.1",
-                "challenge.localhost": "127.0.0.1",
-                "hacker.localhost": "127.0.0.1",
-                "dojo-user": user_ipv4(user),
-                **USER_FIREWALL_ALLOWED,
-            },
-            init=True,
-            cap_add=["SYS_PTRACE"],
-            security_opt=[f"seccomp={SECCOMP}"],
-            sysctls={"net.ipv4.ip_unprivileged_port_start": 1024},
-            cpu_period=100000,
-            cpu_quota=400000,
-            pids_limit=1024,
-            mem_limit="4G",
-            detach=True,
-            stdin_open=True,
-            auto_remove=True,
-        )
+    container = docker_client.containers.create(
+        dojo_challenge.image,
+        entrypoint=[
+            "/nix/var/nix/profiles/default/bin/dojo-init",
+            f"{dojo_bin_path}/sleep",
+            "6h",
+        ],
+        name=container_name(user),
+        hostname=hostname,
+        user="0",
+        working_dir="/home/hacker",
+        environment={
+            "HOME": "/home/hacker",
+            "PATH": env_path,
+            "SHELL": f"{dojo_bin_path}/bash",
+            "DOJO_AUTH_TOKEN": auth_token,
+        },
+        labels={
+            "dojo.dojo_id": dojo_challenge.dojo.reference_id,
+            "dojo.module_id": dojo_challenge.module.id,
+            "dojo.challenge_id": dojo_challenge.id,
+            "dojo.challenge_description": dojo_challenge.description,
+            "dojo.user_id": str(user.id),
+            "dojo.as_user_id": str(as_user.id),
+            "dojo.auth_token": auth_token,
+            "dojo.mode": "privileged" if practice else "standard",
+        },
+        mounts=mounts,
+        devices=devices,
+        network=None,
+        extra_hosts={
+            hostname: "127.0.0.1",
+            "vm": "127.0.0.1",
+            f"vm_{hostname}"[:64]: "127.0.0.1",
+            "challenge.localhost": "127.0.0.1",
+            "hacker.localhost": "127.0.0.1",
+            "dojo-user": user_ipv4(user),
+            **USER_FIREWALL_ALLOWED,
+        },
+        init=True,
+        cap_add=["SYS_PTRACE"],
+        security_opt=[f"seccomp={SECCOMP}"],
+        sysctls={"net.ipv4.ip_unprivileged_port_start": 1024},
+        cpu_period=100000,
+        cpu_quota=400000,
+        pids_limit=1024,
+        mem_limit="4G",
+        detach=True,
+        stdin_open=True,
+        auto_remove=True,
+    )
 
     workspace_net = docker_client.networks.get("workspace_net")
     workspace_net.connect(
@@ -223,24 +224,42 @@ def insert_flag(container, flag):
 
 
 def start_challenge(user, dojo_challenge, practice, *, as_user=None):
-    as_user = as_user or user
     docker_client = user_docker_client(user, image_name=dojo_challenge.image)
     remove_container(user)
 
-    mounts = [("/home/hacker", HOST_HOMES_MOUNTS / str(as_user.id), None)]
-    if as_user != user:
-        mounts = [
-            # ("/home/hacker", HOST_HOMES_OVERLAYS / f"{user.id}-{as_user.id}"),
-            # ("/home/me", HOST_HOMES_MOUNTS / str(user.id), None),
-            ("/home/hacker", HOST_HOMES_MOUNTS / str(user.id), None),
-            ("/home/other", HOST_HOMES_MOUNTS / str(as_user.id), dict(read_only=True)),
-        ]
+    user_mounts = []
+    if as_user is None:
+        user_mounts.append(
+            docker.types.Mount(
+                "/home/hacker",
+                str(user.id),
+                "volume",
+                driver_config=docker.types.DriverConfig("homefs"),
+            )
+        )
+    else:
+        user_mounts.extend([
+            docker.types.Mount(
+                "/home/hacker",
+                f"{user.id}-overlay",
+                "volume",
+                driver_config=docker.types.DriverConfig("homefs", options=dict(overlay=str(as_user.id))),
+            ),
+            docker.types.Mount(
+                "/home/me",
+                str(user.id),
+                "volume",
+                driver_config=docker.types.DriverConfig("homefs"),
+            ),
+        ])
+
+    as_user = as_user or user
 
     container = start_container(
         docker_client=docker_client,
         user=user,
         as_user=as_user,
-        mounts=mounts,
+        user_mounts=user_mounts,
         dojo_challenge=dojo_challenge,
         practice=practice,
     )
@@ -321,12 +340,7 @@ class RunDocker(Resource):
                 as_user = student.user
 
         try:
-            try:
-                start_challenge(user, dojo_challenge, practice, as_user=as_user)
-            except (RuntimeError, docker.errors.APIError):
-                # just try a second time after a pause
-                time.sleep(5)
-                start_challenge(user, dojo_challenge, practice, as_user=as_user)
+            start_challenge(user, dojo_challenge, practice, as_user=as_user)
         except RuntimeError as e:
             logger.exception(f"ERROR: Docker failed for {user.id}:")
             return {"success": False, "error": str(e)}

--- a/dojo_plugin/utils/mac_docker.py
+++ b/dojo_plugin/utils/mac_docker.py
@@ -40,6 +40,7 @@ class MacDockerClient:
         self.containers = MacContainerCollection(self)
         self.images = MacImageCollection(self)
         self.networks = MacNetworkCollection(self)
+        self.volumes = MacVolumeCollection(self)
 
     def close(self):
         pass  # No persistent connection to close
@@ -67,14 +68,14 @@ class MacDockerClient:
         else:
             stdout_loc = None
             stderr_loc = None
-            
+
         result = subprocess.run(ssh_command, stdout=stdout_loc, stderr=stderr_loc, input=input, timeout=timeout_seconds)
         if result.returncode != 0:
             if exception_on_fail:
                 error_msg = result.stdout.strip()
                 raise Exception(f'SSH {ssh_command=} {self.username=} {self.key_filename=} {self.hostname=} {result=} {result.returncode=} failed: {error_msg}')
         return result.returncode, result.stdout.strip() if result.stdout else b""
-    
+
 
 
 class MacContainerCollection:
@@ -221,7 +222,7 @@ class MacContainer:
         class MySendall:
             def __init__(self, container):
                 self.sendall = lambda flag: container.send_flag(flag)
-                
+
         class MySock:
             def __init__(self, container):
                 self._sock = MySendall(container)
@@ -237,8 +238,8 @@ class MacContainer:
         if exitcode != 0:
             raise docker.errors.NotFound(f'Getting archive {path=} failed {exitcode=} {output=}')
         return output
-        
-    
+
+
 
 class MacImageCollection:
     def __init__(self, client):
@@ -283,4 +284,23 @@ class MacNetwork:
 
     def disconnect(self, container):
         # Simulate network disconnection
+        pass
+
+
+
+class MacVolumeCollection:
+    def __init__(self, client):
+        self.client = client
+
+    def get(self, volume_name):
+        # Simulate volume operations
+        return MacVolume(volume_name)
+
+
+class MacVolume:
+    def __init__(self, name):
+        self.name = name
+
+    def remove(self):
+        # Simulate volume removal
         pass

--- a/homefs/Dockerfile
+++ b/homefs/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     pip install \
         flask \
+        flask_sqlalchemy \
         gunicorn \
         requests
 
@@ -16,7 +17,7 @@ EXPOSE 80
 CMD ["gunicorn", \
      "homefs:create_app()", \
      "--bind=unix:/run/docker/plugins/homefs.sock", \
-     "--bind=0.0.0.0:80", \
+     "--bind=0.0.0.0:4201", \
      "--workers=32", \
      "--access-logfile=-", \
      "--timeout=300"]

--- a/homefs/btrfs_volume.py
+++ b/homefs/btrfs_volume.py
@@ -56,9 +56,7 @@ class BTRFSVolume:
         if self.active:
             return
 
-        print(f"[DEBUG] Fetching volume {self.name} from {host}", flush=True)
         snapshot_path = self.fetch(host)
-        print(f"[DEBUG] FETCHED {self.name}", flush=True)
 
         response = requests.post(f"http://{host}:4201/volume/{self.name}/activate")
         try:
@@ -157,9 +155,7 @@ class BTRFSVolume:
         headers = {}
         if self.latest_snapshot_path:
             headers["If-None-Match"] = self.latest_snapshot_path.name
-        print(f"[DEBUG] Requesting volume {self.name} from {host}", flush=True)
         response = requests.get(f"http://{host}:4201/volume/{self.name}", headers=headers)
-        print(f"[DEBUG] RECEIVED {self.name} {response.status_code}", flush=True)
         etag_path = self.snapshots_path / response.headers["ETag"]
         if response.status_code == 304 or etag_path.exists():
             # We already have the latest snapshot (we may have requested the volume from ourselves)

--- a/homefs/homefs.py
+++ b/homefs/homefs.py
@@ -1,23 +1,40 @@
+import os
+from pathlib import Path
+
 from flask import Flask
 from werkzeug.routing import BaseConverter
 
-from volume import check_volume_storage, Volume
+from models import db
+from btrfs_volume import check_volume_storage, BTRFSVolume
 from volume_server import volume_server
 from volume_driver import volume_driver
+from utils import file_lock
+
+
+STORAGE_ROOT = Path(os.environ.get("STORAGE_ROOT", "/data"))
 
 
 class VolumeConverter(BaseConverter):
     def to_python(self, value):
-        return Volume(value)
+        return BTRFSVolume(value)
 
     def to_url(self, value):
         return value.name
 
 
+@file_lock("/run/homefs.lock")
 def create_app():
     check_volume_storage()
 
     app = Flask(__name__)
+
+    homefs_db_path= STORAGE_ROOT / "homefs.db"
+    app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{homefs_db_path}"
+
+    db.init_app(app)
+
+    with app.app_context():
+        db.create_all()
 
     app.url_map.converters["volume"] = VolumeConverter
 

--- a/homefs/models.py
+++ b/homefs/models.py
@@ -1,0 +1,30 @@
+from flask_sqlalchemy import SQLAlchemy
+
+from btrfs_volume import BTRFSVolume
+
+
+db = SQLAlchemy()
+
+
+class ActiveVolumes(db.Model):
+    name = db.Column(db.String, primary_key=True)
+    host = db.Column(db.String)
+    created = db.Column(db.DateTime, server_default=db.func.now())
+    modified = db.Column(db.DateTime, server_default=db.func.now(), onupdate=db.func.now())
+
+
+class DockerVolumes(db.Model):
+    __tablename__ = "docker_volumes"
+    name = db.Column(db.String, primary_key=True)
+    created = db.Column(db.DateTime, server_default=db.func.now())
+    modified = db.Column(db.DateTime, server_default=db.func.now(), onupdate=db.func.now())
+    mounts = db.Column(db.Integer, default=0)
+    overlay = db.Column(db.String, default=None)
+
+    @property
+    def btrfs(self):
+        return BTRFSVolume(self.name) if not self.overlay else BTRFSVolume(self.overlay)
+
+    @property
+    def mountpoint(self):
+        return self.btrfs.active_path if not self.overlay else self.btrfs.overlays_path / self.name

--- a/homefs/models.py
+++ b/homefs/models.py
@@ -10,7 +10,6 @@ class ActiveVolumes(db.Model):
     name = db.Column(db.String, primary_key=True)
     host = db.Column(db.String)
     created = db.Column(db.DateTime, server_default=db.func.now())
-    modified = db.Column(db.DateTime, server_default=db.func.now(), onupdate=db.func.now())
 
 
 class DockerVolumes(db.Model):

--- a/homefs/utils.py
+++ b/homefs/utils.py
@@ -1,0 +1,24 @@
+import fcntl
+import os
+import time
+from contextlib import contextmanager
+
+
+@contextmanager
+def file_lock(path, *, timeout=None):
+    lock_fd = os.open(path, os.O_CREAT | os.O_RDWR)
+    try:
+        if timeout is None:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        else:
+            start_time = time.time()
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                if timeout >= 0 and time.time() - start_time > timeout:
+                    raise TimeoutError
+                time.sleep(0.1)
+        yield
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)

--- a/homefs/volume_driver.py
+++ b/homefs/volume_driver.py
@@ -1,18 +1,14 @@
 import functools
 import inspect
-import io
-import logging
 import os
 
-import requests
 from flask import Blueprint, jsonify, request
+from sqlalchemy.exc import IntegrityError
 
-from volume import Volume
+from models import DockerVolumes, db
 
 
-STORAGE_HOST = os.environ.get("STORAGE_HOST", "http://localhost")
-
-logger = logging.getLogger(__name__)
+STORAGE_HOST = os.environ.get("STORAGE_HOST", "localhost")
 volume_driver = Blueprint("volume_driver", __name__)
 
 
@@ -29,71 +25,122 @@ def driver_route(method_name):
             data = request.get_json(force=True)
             signature = inspect.signature(func)
             kwargs = {k.lower(): v for k, v in data.items() if k.lower() in signature.parameters}
-            if "volume" in signature.parameters and "Name" in data:
-                kwargs["volume"] = Volume(data["Name"])
             return func(**kwargs)
         return wrapped
     return decorator
 
 
 @driver_route("Get")
-def get(volume):
+def get(name):
+    docker_volume = DockerVolumes.query.filter_by(name=name).first()
+    if not docker_volume:
+        return jsonify({"Err": f"Volume {name} not found"}), 404
     return jsonify({
         "Volume": {
-            "Name": volume.name,
-            "Mountpoint": str(volume.active_path),
+            "Name": docker_volume.name,
+            "Mountpoint": str(docker_volume.mountpoint),
             "Status": {}
         },
-        "Err": ""
+        "Err": "",
     })
 
 
 @driver_route("Create")
-def create_volume(volume, opts=None):
-    return jsonify({"Err": ""})
+def create_volume(name, opts=None):
+    if opts is None:
+        opts = {}
+    docker_volume = DockerVolumes(name=name, overlay=opts.get("overlay"))
+    try:
+        db.session.add(docker_volume)
+        db.session.commit()
+    except IntegrityError:
+        return jsonify({"Err": f"Volume {name} already exists"}), 409
+    return jsonify({"Err": ""}), 200
 
 
 @driver_route("Mount")
-def mount_volume(volume, id):
-    logger.info("Mounting %s %s", volume.name, id)
-    with volume.active_lock():
-        if not volume.active:
-            headers = {}
-            if volume.latest_snapshot_path:
-                headers["If-None-Match"] = volume.latest_snapshot_path.name
-            response = requests.get(f"{STORAGE_HOST}/volume/{volume.name}", headers=headers)
-            if response.status_code == 304:
-                snapshot_path = volume.latest_snapshot_path
-            elif (volume.snapshots_path / response.headers["ETag"]).exists():
-                snapshot_path = volume.snapshots_path / response.headers["ETag"]
-            elif response.status_code == 200:
-                snapshot_path = volume.receive(io.BytesIO(response.content))
+def mount_volume(name, id):
+    docker_volume = DockerVolumes.query.filter_by(name=name).first()
+    if not docker_volume:
+        return jsonify({"Err": f"Volume {name} not found"}), 404
+
+    DockerVolumes.query.filter_by(name=name).update({
+        DockerVolumes.mounts: DockerVolumes.mounts + 1
+    })
+    db.session.commit()
+
+    volume = docker_volume.btrfs
+
+    if not docker_volume.overlay:
+        with volume.active_lock(host=STORAGE_HOST):
+            if not volume.active:
+                snapshot_path = volume.fetch(STORAGE_HOST)
+                volume.activate(snapshot_path, locked=True)
             else:
-                raise RuntimeError(f"Failed to get snapshot: {response.status_code}")
-            volume.activate(snapshot_path, locked=True)
-        else:
-            volume.snapshot(locked=True)
-    return jsonify({"Mountpoint": str(volume.active_path), "Err": ""})
+                volume.snapshot(locked=True)
+
+    elif not docker_volume.mountpoint.exists():
+        snapshot_path = volume.fetch(STORAGE_HOST)
+        volume.overlay(docker_volume.name, snapshot_path)
+
+    return jsonify({"Mountpoint": str(docker_volume.mountpoint), "Err": ""})
 
 
 @driver_route("Unmount")
-def unmount_volume(volume, id):
-    logger.info("Unmounting %s %s", volume.name, id)
-    with volume.active_lock():
-        volume.snapshot(locked=True)
+def unmount_volume(name, id):
+    docker_volume = DockerVolumes.query.filter_by(name=name).first()
+    if not docker_volume:
+        return jsonify({"Err": f"Volume {name} not found"}), 404
+
+    if not docker_volume.overlay:
+        volume = docker_volume.btrfs
+        with volume.active_lock():
+            volume.snapshot(locked=True)
+
+    DockerVolumes.query.filter_by(name=name).update({
+        DockerVolumes.mounts: DockerVolumes.mounts - 1
+    })
+    db.session.commit()
+
     return jsonify({"Err": ""})
 
 
 @driver_route("Remove")
-def remove_volume(volume):
+def remove_volume(name):
+    docker_volume = DockerVolumes.query.filter_by(name=name).first()
+    if not docker_volume:
+        return jsonify({"Err": f"Volume {name} not found"}), 404
+
+    if docker_volume.overlay:
+        volume = docker_volume.btrfs
+        volume.remove_overlay(docker_volume.name)
+
+    # TODO: deactivate non-overlay volumes
+
+    db.session.delete(docker_volume)
+    db.session.commit()
     return jsonify({"Err": ""})
 
 
 @driver_route("Path")
-def volume_path(volume):
-    return jsonify({"Mountpoint": str(volume.active_path), "Err": ""})
+def volume_path(name):
+    docker_volume = DockerVolumes.query.filter_by(name=name).first()
+    if not docker_volume:
+        return jsonify({"Err": f"Volume {name} not found"}), 404
+    return jsonify({"Mountpoint": str(docker_volume.mountpoint), "Err": ""})
 
 
 @driver_route("List")
 def list_volumes():
-    return jsonify({"Volumes": [], "Err": ""})
+    return jsonify({
+        "Volumes": [
+            {"Name": docker_volume.name, "Mountpoint": str(docker_volume.mountpoint)}
+            for docker_volume in DockerVolumes.query.all()
+        ],
+        "Err": ""
+    })
+
+
+@driver_route("Capabilities")
+def volume_capabilities():
+    return jsonify({"Capabilities": {"Scope": "local"}})

--- a/homefs/volume_driver.py
+++ b/homefs/volume_driver.py
@@ -72,11 +72,9 @@ def mount_volume(name, id):
     volume = docker_volume.btrfs
 
     if not docker_volume.overlay:
-        with volume.active_lock(host=STORAGE_HOST):
+        with volume.active_lock():
             if not volume.active:
-                # TODO: but we just made ourslves the active host, so we will fetch from ourselves? Is this correct?
-                snapshot_path = volume.fetch(STORAGE_HOST)
-                volume.activate(snapshot_path, locked=True)
+                volume.activate(STORAGE_HOST, locked=True)
             else:
                 volume.snapshot(locked=True)
 

--- a/homefs/volume_driver.py
+++ b/homefs/volume_driver.py
@@ -74,6 +74,7 @@ def mount_volume(name, id):
     if not docker_volume.overlay:
         with volume.active_lock(host=STORAGE_HOST):
             if not volume.active:
+                # TODO: but we just made ourslves the active host, so we will fetch from ourselves? Is this correct?
                 snapshot_path = volume.fetch(STORAGE_HOST)
                 volume.activate(snapshot_path, locked=True)
             else:

--- a/homefs/volume_server.py
+++ b/homefs/volume_server.py
@@ -1,19 +1,34 @@
-from flask import Blueprint, request, Response
+from flask import Blueprint, Response, jsonify, request
+from sqlalchemy.exc import IntegrityError
+
+from models import ActiveVolumes, db
+from btrfs_volume import all_active_volumes
 
 
 volume_server = Blueprint("volume", __name__)
 
 
+@volume_server.route("/", methods=["GET"])
+def list_volumes():
+    return jsonify(dict(volumes=all_active_volumes())), 200
+
+
 @volume_server.route("/<volume:volume>", methods=["GET"])
 def get_volume(volume):
+    with volume.active_lock():
+        # If it active here, do not fetch it (infinite recursive loop)
+        if not volume.active:
+            active_volume = ActiveVolumes.query.filter_by(name=volume.name).first()
+            if active_volume:
+                volume.fetch(active_volume.host)
+
     snapshot_path = volume.snapshot()
     if request.headers.get("If-None-Match") == snapshot_path.name:
-        return "", 304
+        return Response(status=304, headers={"ETag": snapshot_path.name})
+
     parents = request.args.getlist("from")
     stream = volume.send(snapshot_path, parents)
-    response = Response(stream, mimetype="application/octet-stream")
-    response.headers["ETag"] = snapshot_path.name
-    return response
+    return Response(stream, mimetype="application/octet-stream", headers={"ETag": snapshot_path.name})
 
 
 @volume_server.route("/<volume:volume>", methods=["PUT"])
@@ -22,4 +37,27 @@ def put_volume(volume):
         volume.receive(request.stream)
     except RuntimeError as e:
         return str(e), 400
-    return "Volume successfully received\n", 200
+    return "Volume successfully received\n", 201
+
+
+@volume_server.route("/<volume:volume>/activate", methods=["POST"])
+def activate_volume(volume):
+    active_volume = ActiveVolumes.query.filter_by(name=volume.name).first()
+    if active_volume:
+        if active_volume.host != request.remote_addr:
+            return "Volume already active\n", 409
+        else:
+            active_volume.modified = db.func.now()
+            db.session.commit()
+            return "Volume activated\n", 201
+
+    active_volume = ActiveVolumes(name=volume.name, host=request.remote_addr)
+    try:
+        # Someone else might have activated the volume in the meantime
+        db.session.add(active_volume)
+        db.session.commit()
+    except IntegrityError:
+        # Error even if the remote host is the same (this shouldn't happen)
+        return "Volume already active\n", 409
+
+    return "Volume activated\n", 201

--- a/homefs/volume_server.py
+++ b/homefs/volume_server.py
@@ -39,8 +39,6 @@ def activate_volume(volume):
         if active_volume.host != request.remote_addr:
             return "Volume already active\n", 409
         else:
-            active_volume.modified = db.func.now()
-            db.session.commit()
             return "Volume activated\n", 201
 
     active_volume = ActiveVolumes(name=volume.name, host=request.remote_addr)

--- a/homefs/volume_server.py
+++ b/homefs/volume_server.py
@@ -9,12 +9,11 @@ volume_server = Blueprint("volume", __name__)
 
 @volume_server.route("/<volume:volume>", methods=["GET"])
 def get_volume(volume):
-    with volume.active_lock():
-        # If it active on this node, do not fetch it (infinite recursive loop)
-        if not volume.active:
-            active_volume = ActiveVolumes.query.filter_by(name=volume.name).first()
-            if active_volume:
-                volume.fetch(active_volume.host)
+    # If it active on this node, do not fetch it (infinite recursive loop)
+    if not volume.active:
+        active_volume = ActiveVolumes.query.filter_by(name=volume.name).first()
+        if active_volume:
+            volume.fetch(active_volume.host)
 
     snapshot_path = volume.snapshot()
     if request.headers.get("If-None-Match") == snapshot_path.name:


### PR DESCRIPTION
This PR adds overlays to homefs.

This requires us to track state about the homes. All home state shall be tracked by homefs (not ctfd / our main database).

The state that must be tracked is: **Who currently owns the home?**

Only one node may make the home active at a time. This is done by registering with the primary "STORAGE_HOST" (e.g. the main node on production). If this fails, we fail to setup the "active" subvolume, and fail to mount / start the container. We track this with `ActiveVolumes` on the main node.

We also track the current homefs volumes. This just seems like the correct thing to do, and allows us to support, for example, `docker volume ls`. We track this with `DockerVolumes` on the workspace nodes.

