### PR TITLE
Workspace: Use login shell

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -20,7 +20,7 @@ ARG DOJO_WORKSPACE="default"
 ENV DOJO_WORKSPACE="$DOJO_WORKSPACE"
 
 RUN cat > /docker-entrypoint.sh <<'EOF'
-#!/bin/sh
+#!/bin/sh -e
 if [ ! -d /out ]; then
     echo "Missing /out directory; mount a directory to /out!" >&2
     exit 1

--- a/workspace/core/init.nix
+++ b/workspace/core/init.nix
@@ -31,14 +31,14 @@ let
     fi
 
     mkdir -p /home/hacker /root
-    mkdir -p /etc && touch /etc/passwd /etc/group
+    mkdir -p /etc /etc/profile.d && touch /etc/passwd /etc/group
     echo "root:x:0:0:root:/root:/run/dojo/bin/bash" >> /etc/passwd
     echo "hacker:x:1000:1000:hacker:/home/hacker:/run/dojo/bin/bash" >> /etc/passwd
     echo "sshd:x:112:65534::/run/sshd:/usr/sbin/nologin" >> /etc/passwd
     echo "root:x:0:" >> /etc/group
     echo "hacker:x:1000:" >> /etc/group
-
     echo "PATH=\"/run/challenge/bin:/run/workspace/bin:$IMAGE_PATH\"" > /etc/environment
+    ln -sfT /run/dojo/etc/profile.d/99-dojo-workspace.sh /etc/profile.d/99-dojo-workspace.sh
 
     echo $DOJO_AUTH_TOKEN > /run/dojo/var/auth_token
 
@@ -61,6 +61,10 @@ let
     exec "$@"
   '';
 
+  profile = pkgs.writeText "dojo-profile" ''
+    export PATH="/run/challenge/bin:/run/workspace/bin:$PATH"
+  '';
+
 in pkgs.stdenv.mkDerivation {
   name = "init";
   buildInputs = [ pkgs.bash ];
@@ -68,8 +72,9 @@ in pkgs.stdenv.mkDerivation {
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/bin
+    mkdir -p $out/bin $out/etc/profile.d
     cp ${initScript} $out/bin/dojo-init
+    cp ${profileScript} $out/etc/profile.d/99-dojo-workspace.sh
     runHook postInstall
   '';
 }

--- a/workspace/core/init.nix
+++ b/workspace/core/init.nix
@@ -74,7 +74,7 @@ in pkgs.stdenv.mkDerivation {
     runHook preInstall
     mkdir -p $out/bin $out/etc/profile.d
     cp ${initScript} $out/bin/dojo-init
-    cp ${profileScript} $out/etc/profile.d/99-dojo-workspace.sh
+    cp ${profile} $out/etc/profile.d/99-dojo-workspace.sh
     runHook postInstall
   '';
 }

--- a/workspace/core/ssh-entrypoint.nix
+++ b/workspace/core/ssh-entrypoint.nix
@@ -1,6 +1,13 @@
 { pkgs }:
 
-pkgs.stdenv.mkDerivation {
+let
+  sshEntryPoint = pkgs.writeScript "ssh-entrypoint" ''
+    #!${pkgs.bashInteractive}/bin/bash
+
+    $SHELL --login
+  '';
+
+in pkgs.stdenv.mkDerivation {
   name = "ssh-entrypoint";
   propagatedBuildInputs = with pkgs; [ bashInteractive ];
   dontUnpack = true;
@@ -8,7 +15,7 @@ pkgs.stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin
-    ln -s ${pkgs.bashInteractive}/bin/bash $out/bin/ssh-entrypoint
+    cp ${sshEntryPoint} $out/bin/ssh-entrypoint
     runHook postInstall
   '';
 }

--- a/workspace/services/desktop/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-terminal.xml
+++ b/workspace/services/desktop/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-terminal.xml
@@ -7,5 +7,6 @@
   <property name="color-cursor-use-default" type="bool" value="false"/>
   <property name="color-cursor" type="string" value="#cccccc"/>
   <property name="color-selection-use-default" type="bool" value="false"/>
-  <property name="color-selection-background" type="string" value="#264f78"/>  
+  <property name="color-selection-background" type="string" value="#264f78"/>
+  <property name="command-login-shell" type="bool" value="true"/>
 </channel>


### PR DESCRIPTION
It looks like vscode uses a login shell when it creates its terminal (technically it doens't, but it mimics the behavior [^1]), which leads me to believe that we should also be using login shells for desktop/ssh.

This is not just aesthetic, it has implications on which `/etc` (and more) config files are used by bash.

https://wiki.archlinux.org/title/Bash

[^1]: https://github.com/microsoft/vscode/blob/07f8b09e2fc8309f3c333223efff1901e33c472d/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh#L20

---

The issue that lead me down this path is that in the `python:3.13-slim` image (which `pwncollege/challenge-simple` is, probably, reasonably based on), `/etc/profile` explicitly sets `$PATH`. This causes our default-vscode-login-shell to lose the workspace `PATH` components, and ultimately fail our welcome practice test-case because it can't find the workspace `sudo` (it definitely needs *that* sudo).

I'm sure other custom images could get bitten by this sort of thing easily. Workspace PATH components should always (or at least by default) be in the `$PATH`.

And so now, we start login shells, which causes `/etc/profile` to be used (which still loads `/etc/bash.bashrc`). It now also loads in `/etc/profile.d/*` (lexicographically sorted), and we use that to fix up the `$PATH`.

---

If we decide to do more in this profile.d, we may have issues with images that do not actually have an `/etc/profile` defined and/or do not load `/etc/profile.d`.

A possible better solution would be figuring out how to get `/run/dojo/bin/bash` to target `/run/dojo/etc/profile` (which loads `/etc/profile`, etc), to be less at the mercy of the image. But hopefully we just don't face an issue with some weird image that causes us to need to go down this path...