### PR TITLE
Workspace: Remove angr

### DIFF
--- a/workspace/additional/additional.nix
+++ b/workspace/additional/additional.nix
@@ -2,7 +2,6 @@
 
 let
   pythonEnv = pkgs.python3.withPackages (ps: with ps; [
-    angr
     asteval
     flask
     ipython


### PR DESCRIPTION
Bringing `angr` back is blocked by https://github.com/angr/angr/pull/5160.