### PR TITLE
Fix 404 when viewing your own hidden profile

### DIFF
--- a/dojo_plugin/pages/users.py
+++ b/dojo_plugin/pages/users.py
@@ -18,8 +18,8 @@ from ..utils.awards import get_belts, get_viewable_emojis
 users = Blueprint("pwncollege_users", __name__)
 
 
-def view_hacker(user):
-    if user.hidden:
+def view_hacker(user, bypass_hidden=False):
+    if user.hidden and not bypass_hidden:
         abort(404)
 
     dojos = (Dojos
@@ -51,4 +51,4 @@ def view_other_name(user_name):
 @users.route("/hacker/")
 @authed_only
 def view_self():
-    return view_hacker(get_current_user())
+    return view_hacker(get_current_user(), bypass_hidden=True)


### PR DESCRIPTION
Fixes https://github.com/pwncollege/dojo/issues/593, allows users to still view their own profile when it's marked as hidden.