### PR TITLE
Add functionality to reset home directory

### DIFF
--- a/dojo_plugin/api/v1/docker.py
+++ b/dojo_plugin/api/v1/docker.py
@@ -28,7 +28,7 @@ from ...utils import (
     user_ipv4,
 )
 from ...utils.dojo import dojo_accessible, get_current_dojo_challenge
-from ...utils.workspace import exec_run, zip_home_directory, wipe_home_directory, move_zip_to_home
+from ...utils.workspace import exec_run
 
 logger = logging.getLogger(__name__)
 

--- a/dojo_plugin/api/v1/docker.py
+++ b/dojo_plugin/api/v1/docker.py
@@ -391,24 +391,3 @@ class RunDocker(Resource):
             "module": dojo_challenge.module.id,
             "challenge": dojo_challenge.id,
         }
-
-@docker_namespace.route("/reset_home")
-class ResetHome(Resource):
-    @authed_only
-    @docker_locked
-    def post(self):
-        user = get_current_user()
-
-        # Ensure the container is stopped before performing the action
-        remove_container(user)
-
-        # Zip the user's home directory
-        zip_file = zip_home_directory(user.id)
-
-        # Wipe everything else in the home directory
-        wipe_home_directory(user.id)
-
-        # Move the zip file back to the home directory
-        move_zip_to_home(user.id, zip_file)
-
-        return {"success": True, "message": "Home directory reset successfully"}

--- a/dojo_plugin/api/v1/workspace.py
+++ b/dojo_plugin/api/v1/workspace.py
@@ -78,3 +78,27 @@ class view_desktop(Resource):
            "service": service,
            "active": True
            }
+
+
+@workspace_namespace.route("/reset_home")
+class ResetHome(Resource):
+    @authed_only
+    @docker_locked
+    def post(self):
+        user = get_current_user()
+
+        # Check if a container is running
+        container = get_current_container(user)
+        if not container:
+            return {"success": False, "message": "No running container found. Please start a container and try again."}
+
+        # Zip the user's home directory
+        zip_file = zip_home_directory(user.id)
+
+        # Wipe everything else in the home directory
+        wipe_home_directory(user.id)
+
+        # Move the zip file back to the home directory
+        move_zip_to_home(user.id, zip_file)
+
+        return {"success": True, "message": "Home directory reset successfully"}

--- a/dojo_plugin/api/v1/workspace.py
+++ b/dojo_plugin/api/v1/workspace.py
@@ -83,7 +83,6 @@ class view_desktop(Resource):
 @workspace_namespace.route("/reset_home")
 class ResetHome(Resource):
     @authed_only
-    @docker_locked
     def post(self):
         user = get_current_user()
 

--- a/dojo_plugin/api/v1/workspace.py
+++ b/dojo_plugin/api/v1/workspace.py
@@ -86,9 +86,7 @@ class ResetHome(Resource):
     def post(self):
         user = get_current_user()
 
-        # Check if a container is running
-        container = get_current_container(user)
-        if not container:
+        if not get_current_container(user):
             return {"success": False, "error": "No running container found. Please start a container and try again."}
 
         try:

--- a/dojo_plugin/api/v1/workspace.py
+++ b/dojo_plugin/api/v1/workspace.py
@@ -3,7 +3,7 @@ from flask import request, render_template, url_for, abort
 from CTFd.utils.user import get_current_user
 from CTFd.utils.decorators import authed_only
 from ...utils import get_current_container, container_password
-from ...utils.workspace import exec_run, start_on_demand_service, zip_home_directory, wipe_home_directory, move_zip_to_home
+from ...utils.workspace import exec_run, start_on_demand_service, reset_home
 
 
 workspace_namespace = Namespace(
@@ -89,15 +89,11 @@ class ResetHome(Resource):
         # Check if a container is running
         container = get_current_container(user)
         if not container:
-            return {"success": False, "message": "No running container found. Please start a container and try again."}
+            return {"success": False, "error": "No running container found. Please start a container and try again."}
 
-        # Zip the user's home directory
-        zip_file = zip_home_directory(user.id)
-
-        # Wipe everything else in the home directory
-        wipe_home_directory(user.id)
-
-        # Move the zip file back to the home directory
-        move_zip_to_home(user.id, zip_file)
+        try:
+            reset_home(user.id)
+        except AssertionError as e:
+            return {"success": False, "error": f"Reset failed with error: {e}"}
 
         return {"success": True, "message": "Home directory reset successfully"}

--- a/dojo_plugin/api/v1/workspace.py
+++ b/dojo_plugin/api/v1/workspace.py
@@ -3,7 +3,7 @@ from flask import request, render_template, url_for, abort
 from CTFd.utils.user import get_current_user
 from CTFd.utils.decorators import authed_only
 from ...utils import get_current_container, container_password
-from ...utils.workspace import exec_run, start_on_demand_service
+from ...utils.workspace import exec_run, start_on_demand_service, zip_home_directory, wipe_home_directory, move_zip_to_home
 
 
 workspace_namespace = Namespace(

--- a/dojo_plugin/utils/workspace.py
+++ b/dojo_plugin/utils/workspace.py
@@ -39,3 +39,19 @@ def exec_run(cmd, *, shell=False, assert_success=True, workspace_user="root", us
     if assert_success:
         assert exit_code in (0, None), output
     return exit_code, output
+
+def zip_home_directory(user_id):
+    home_dir = f"/home/hacker"
+    zip_file = f"/tmp/{user_id}_home.zip"
+    exec_run(f"zip -r --symlinks {zip_file} {home_dir}", user_id=user_id)
+    move_zip_to_home(user_id, zip_file)
+    return zip_file
+
+def wipe_home_directory(user_id):
+    home_dir = f"/home/hacker"
+    exec_run(f"find {home_dir} -mindepth 1 -delete", user_id=user_id)
+
+def move_zip_to_home(user_id, zip_file):
+    home_dir = f"/home/hacker"
+    exec_run(f"mv {zip_file} {home_dir}", user_id=user_id)
+    return f"{home_dir}/{user_id}_home.zip"

--- a/dojo_plugin/utils/workspace.py
+++ b/dojo_plugin/utils/workspace.py
@@ -40,18 +40,8 @@ def exec_run(cmd, *, shell=False, assert_success=True, workspace_user="root", us
         assert exit_code in (0, None), output
     return exit_code, output
 
-def zip_home_directory(user_id):
-    home_dir = f"/home/hacker"
-    zip_file = f"/tmp/{user_id}_home.zip"
-    exec_run(f"zip -r --symlinks {zip_file} {home_dir}", user_id=user_id)
-    move_zip_to_home(user_id, zip_file)
-    return zip_file
-
-def wipe_home_directory(user_id):
-    home_dir = f"/home/hacker"
-    exec_run(f"find {home_dir} -mindepth 1 -delete", user_id=user_id)
-
-def move_zip_to_home(user_id, zip_file):
-    home_dir = f"/home/hacker"
-    exec_run(f"mv {zip_file} {home_dir}", user_id=user_id)
-    return f"{home_dir}/{user_id}_home.zip"
+def reset_home(user_id):
+    exec_run(f"/bin/tar cvzf /tmp/home-backup.tar.gz /home/hacker", user_id=user_id, shell=True, workspace_user="hacker")
+    exec_run(f"find /home/hacker -mindepth 1 -delete", user_id=user_id, shell=True, workspace_user="root")
+    exec_run(f"chown hacker:hacker /home/hacker", user_id=user_id, shell=True, workspace_user="root")
+    exec_run(f"cp /tmp/home-backup.tar.gz /home/hacker/", user_id=user_id, shell=True, workspace_user="hacker")

--- a/dojo_theme/static/js/dojo/settings.js
+++ b/dojo_theme/static/js/dojo/settings.js
@@ -93,6 +93,9 @@ $(() => {
         var confirmation = prompt(`Are you sure you want to delete the dojo?\nEnter the dojo name\n\n${x.dojo}\n\nto confirm this action.\nThis action cannot be undone.`);
         return confirmation === x.dojo
     });
+    button_fetch_and_show("reset-home", "/pwncollege_api/v1/workspace/reset_home", "POST", {}, "Home directory reset successfully", "Home directory reset canceled", function() {
+      return confirm("Are you sure you want to reset your home directory?");
+    });
     $(".copy-button").click((event) => {
         let input = $(event.target).parents(".input-group").children("input")[0];
         input.select();

--- a/dojo_theme/static/js/dojo/settings.js
+++ b/dojo_theme/static/js/dojo/settings.js
@@ -12,6 +12,13 @@ var success_template =
     '  <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>\n' +
     '</div>';
 
+var loading_template =
+    '<div class="alert alert-warning alert-dismissable submit-row" role="alert">\n' +
+    '  <strong>Loading...</strong>\n' +
+    '  <span id="message"></span>' +
+    '  <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>\n' +
+    '</div>';
+
 function form_fetch_and_show(name, endpoint, method, success_message, confirm_msg=null) {
     const form = $(`#${name}-form`);
     const results = $(`#${name}-results`);
@@ -20,6 +27,7 @@ function form_fetch_and_show(name, endpoint, method, success_message, confirm_ms
         results.empty();
         const params = form.serializeJSON();
         if (confirm_msg && !confirm(confirm_msg(form, params))) return;
+        results.html(loading_template);
         CTFd.fetch(endpoint, {
             method: method,
             credentials: "same-origin",
@@ -53,6 +61,7 @@ function button_fetch_and_show(name, endpoint, method,data, success_message, abo
             results.find("#message").html(abort_message);
             return
         };
+        results.html(loading_template);
         CTFd.fetch(endpoint, {
             method: method,
             credentials: "same-origin",

--- a/dojo_theme/templates/settings.html
+++ b/dojo_theme/templates/settings.html
@@ -201,8 +201,9 @@
             <h2>Reset Home Directory</h2>
             <p>Click the button below to reset your home directory. This will zip your current home directory and wipe everything else.</p>
             <button id="reset-home-button" class="btn btn-danger">Reset Home Directory</button>
-            <div id="reset-home-results" class="form-group"></div>
           </div>
+          <br>
+          <div id="reset-home-results" class="form-group"></div>
         </div>
 
       </div>
@@ -217,11 +218,4 @@
 
 {% block scripts %}
 <script defer src="{{ url_for('views.themes', path='js/dojo/settings.js') }}"></script>
-<script>
-  document.addEventListener('DOMContentLoaded', function() {
-    button_fetch_and_show("reset-home", "/pwncollege_api/v1/docker/reset_home", "POST", {}, "Home directory reset successfully", "Home directory reset canceled", function() {
-      return confirm("Are you sure you want to reset your home directory?");
-    });
-  });
-</script>
 {% endblock %}

--- a/dojo_theme/templates/settings.html
+++ b/dojo_theme/templates/settings.html
@@ -16,6 +16,7 @@
         <a class="nav-link" id="settings-discord-tab" data-toggle="pill" href="#discord" role="tab">Discord</a>
         {% endif %}
 	      <a class="nav-link" id="settings-tokens-tab" data-toggle="pill" href="#tokens" role="tab">Access Tokens</a>
+        <a class="nav-link" id="settings-reset-home-tab" data-toggle="pill" href="#reset-home" role="tab">Reset Home</a>
       </div>
     </div>
     <div class="col-md-8">
@@ -194,6 +195,16 @@
           </table>
           {% endif %}
         </div>
+
+        <div class="tab-pane fade" id="reset-home" role="tabpanel">
+          <div class="text-center">
+            <h2>Reset Home Directory</h2>
+            <p>Click the button below to reset your home directory. This will zip your current home directory and wipe everything else.</p>
+            <button id="reset-home-button" class="btn btn-danger">Reset Home Directory</button>
+            <div id="reset-home-results" class="form-group"></div>
+          </div>
+        </div>
+
       </div>
     </div>
   </div>
@@ -206,4 +217,11 @@
 
 {% block scripts %}
 <script defer src="{{ url_for('views.themes', path='js/dojo/settings.js') }}"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    button_fetch_and_show("reset-home", "/pwncollege_api/v1/docker/reset_home", "POST", {}, "Home directory reset successfully", "Home directory reset canceled", function() {
+      return confirm("Are you sure you want to reset your home directory?");
+    });
+  });
+</script>
 {% endblock %}

--- a/test/test_running.py
+++ b/test/test_running.py
@@ -486,17 +486,15 @@ def test_reset_home_directory(random_user):
     workspace_run("touch /home/hacker/testfile", user=user)
 
     # Reset the home directory
-    response = session.post(f"{DOJO_URL}/pwncollege_api/v1/workspace/reset_home")
+    response = session.post(f"{DOJO_URL}/pwncollege_api/v1/workspace/reset_home", json={})
     assert response.status_code == 200, f"Expected status code 200, but got {response.status_code}"
-    assert response.json()["success"], f"Failed to reset home directory: {response.json()['message']}"
+    assert response.json()["success"], f"Failed to reset home directory: {response.json()['error']}"
 
-    # Check that the zip file is moved back to the home directory
     try:
         workspace_run("[ -f '/home/hacker/home-backup.tar.gz' ]", user=user)
     except subprocess.CalledProcessError as e:
         assert False, f"Expected zip file to exist, but got: {(e.stdout, e.stderr)}"
 
-    # Check that the home directory is wiped before moving the zip file
     try:
         workspace_run("[ ! -f '/home/hacker/testfile' ]", user=user)
     except subprocess.CalledProcessError as e:

--- a/test/test_running.py
+++ b/test/test_running.py
@@ -492,7 +492,7 @@ def test_reset_home_directory(random_user):
 
     # Check that the zip file is moved back to the home directory
     try:
-        workspace_run("[ -f '/home/hacker/{user}_home.zip' ]", user=user)
+        workspace_run("[ -f '/home/hacker/home-backup.tar.gz' ]", user=user)
     except subprocess.CalledProcessError as e:
         assert False, f"Expected zip file to exist, but got: {(e.stdout, e.stderr)}"
 

--- a/test/test_running.py
+++ b/test/test_running.py
@@ -486,7 +486,7 @@ def test_reset_home_directory(random_user):
     workspace_run("touch /home/hacker/testfile", user=user)
 
     # Reset the home directory
-    response = session.post(f"{DOJO_URL}/pwncollege_api/v1/docker/reset_home")
+    response = session.post(f"{DOJO_URL}/pwncollege_api/v1/workspace/reset_home")
     assert response.status_code == 200, f"Expected status code 200, but got {response.status_code}"
     assert response.json()["success"], f"Failed to reset home directory: {response.json()['message']}"
 

--- a/test/test_running.py
+++ b/test/test_running.py
@@ -476,3 +476,28 @@ def test_workspace_as_user(admin_user, random_user):
         workspace_run("[ ! -e '/home/hacker/test3' ]", user=random_user)
     except subprocess.CalledProcessError as e:
         assert False, f"Expected overlay file to not exist, but got: {(e.stdout, e.stderr)}"
+
+@pytest.mark.dependency(depends=["test_start_challenge"])
+def test_reset_home_directory(random_user):
+    user, session = random_user
+
+    # Create a file in the home directory
+    start_challenge("example", "hello", "apple", session=session)
+    workspace_run("touch /home/hacker/testfile", user=user)
+
+    # Reset the home directory
+    response = session.post(f"{DOJO_URL}/pwncollege_api/v1/docker/reset_home")
+    assert response.status_code == 200, f"Expected status code 200, but got {response.status_code}"
+    assert response.json()["success"], f"Failed to reset home directory: {response.json()['message']}"
+
+    # Check that the zip file is moved back to the home directory
+    try:
+        workspace_run("[ -f '/home/hacker/{user}_home.zip' ]", user=user)
+    except subprocess.CalledProcessError as e:
+        assert False, f"Expected zip file to exist, but got: {(e.stdout, e.stderr)}"
+
+    # Check that the home directory is wiped before moving the zip file
+    try:
+        workspace_run("[ ! -f '/home/hacker/testfile' ]", user=user)
+    except subprocess.CalledProcessError as e:
+        assert False, f"Expected test file to be wiped, but got: {(e.stdout, e.stderr)}"


### PR DESCRIPTION
Closes #652

This is a result of playing around with copilot (so all the description and code and tests are autogenerated; beware).

----

Implement a reset button functionality to handle the user's home directory reset.

* **API Endpoint**: Add a new endpoint `/reset_home` in `dojo_plugin/api/v1/docker.py` to handle the reset button functionality. Zip the user's home directory, wipe everything else, and move the zip file back to the home directory.
* **User Interface**: Add a reset button to the user settings page in `dojo_theme/templates/settings.html`. Ensure the button triggers the new endpoint when clicked.
* **Utility Functions**: Add functions `zip_home_directory`, `wipe_home_directory`, and `move_zip_to_home` in `dojo_plugin/utils/workspace.py` to handle the zipping, wiping, and moving of the user's home directory.
* **Test Case**: Add a test case in `test/test_running.py` to verify the reset button functionality. Ensure the test case checks that the zip file is moved back to the home directory and that the home directory is wiped before moving the zip file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pwncollege/dojo/pull/656?shareId=bea4ba9d-508e-4b64-b4e3-d9d7ba853313).