### PR TITLE
Add API endpoint to list available dojos

### DIFF
--- a/dojo_plugin/api/v1/dojo.py
+++ b/dojo_plugin/api/v1/dojo.py
@@ -150,6 +150,19 @@ class CreateDojo(Resource):
 
         return result
 
+
+@dojo_namespace.route("/list")
+class GetDojos(Resource):
+    def get(self):
+        dojos = [
+            dict(id=dojo.id,
+                 name=dojo.name,
+                 description=dojo.description,
+                 official=dojo.official)
+            for dojo in Dojos.viewable(user=get_current_user())
+        ]
+        return {"success": True, "dojos": dojos}
+
 @dojo_namespace.route("/<dojo>/modules")
 class GetDojoModules(Resource):
     @dojo_route


### PR DESCRIPTION
Adds a `/pwncollege_api/v1/dojo/list` endpoint that returns the list of available dojos.

To follow REST API best practices it might be better to use this path for the resource: `/pwncollege_api/v1/dojos`
