### PR TITLE
Infrastructure: Automatically create workspace net

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,6 +236,12 @@ services:
       - acme:/etc/acme.sh
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
+  create-workspace-net:
+    image: busybox:uclibc
+    command: /bin/true
+    networks:
+      - workspace_net
+
 volumes:
   conf:
   html:


### PR DESCRIPTION
Workspace nodes have no reason to create `workspace_net`; we need to make sure this network is created.