### PR TITLE
Infrastructure: Fix codespaces docker networking

### DIFF
--- a/dojo/dojo-init
+++ b/dojo/dojo-init
@@ -114,6 +114,10 @@ if [ ! -e /sys/module/nf_tables ]; then
     echo '[+] Could not load nf_tables module. Switching to legacy iptables.'
     update-alternatives --set iptables /usr/sbin/iptables-legacy
     update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+elif hostname | grep -q 'codespaces'; then
+    echo '[+] Running in Codespaces. Switching to legacy iptables.'
+    update-alternatives --set iptables /usr/sbin/iptables-legacy
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 fi
 
 dojo-node refresh
@@ -127,3 +131,5 @@ iptables -I DOCKER-USER -i workspace_net -s 10.0.0.0/24 -m conntrack --ctstate N
 iptables -I DOCKER-USER -i workspace_net -d 10.0.0.0/8 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 iptables -I DOCKER-USER -i workspace_net -s 192.168.42.0/24 -m conntrack --ctstate NEW -j ACCEPT
 iptables -I DOCKER-USER -i workspace_net -d 192.168.42.0/24 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+iptables -I DOCKER-USER -i workspace_net -m conntrack --ctstate NEW,ESTABLISHED,RELATED -j ACCEPT

--- a/dojo/dojo-init
+++ b/dojo/dojo-init
@@ -109,15 +109,17 @@ then
     openssl rand 214 > "${BACKUP_AES_KEY_FILE}"
 fi
 
-nft list tables > /dev/null 2>&1  # This will load the nf_tables module, if it's not already loaded and is available
-if [ ! -e /sys/module/nf_tables ]; then
-    echo '[+] Could not load nf_tables module. Switching to legacy iptables.'
+if [ -n "$(cat /proc/net/ip_tables_names)" ]; then
+    echo "[+] Pre-existing iptables-legacy tables detected. Switching to iptables-legacy."
     update-alternatives --set iptables /usr/sbin/iptables-legacy
     update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
-elif hostname | grep -q 'codespaces'; then
-    echo '[+] Running in Codespaces. Switching to legacy iptables.'
-    update-alternatives --set iptables /usr/sbin/iptables-legacy
-    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+else
+    nft list tables > /dev/null 2>&1  # This will load the nf_tables module, if it's not already loaded and is available
+    if [ ! -e /sys/module/nf_tables ]; then
+        echo '[+] Could not load nf_tables module. Switching to iptables-legacy.'
+        update-alternatives --set iptables /usr/sbin/iptables-legacy
+        update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+    fi
 fi
 
 dojo-node refresh


### PR DESCRIPTION
For some reason, codespaces has an issue where networking does not work in the subcontainers.

This is quickly obvious when `workspace-builder` never completes, and so the infrastructure does not start.

It's not clear why. We have `nf_tables` correctly loaded, so I'd assume it would work, and yet it doesn't.

Switching to legacy iptables (and restarting docker service, if it's already running) resolves this.