### PR TITLE
Site: Support progression locked challenges

### DIFF
--- a/dojo_plugin/api/v1/docker.py
+++ b/dojo_plugin/api/v1/docker.py
@@ -359,7 +359,7 @@ class RunDocker(Resource):
         
         # Check to make sure a user doesn't start a locked challenge
         challenge_index = dojo_challenge.challenge_index
-        if dojo_challenge.data["progression_locked"] and challenge_index != 0 and not dojo.is_admin():
+        if dojo_challenge.progression_locked and challenge_index != 0 and not dojo.is_admin():
             previous_dojo_challenge = (
                 DojoChallenges.query.filter_by(challenge_index=challenge_index-1)
                 .join(DojoModules.query.filter_by(dojo=dojo, id=module_id).subquery()) # Makes sure we are fetching from the current module in the current dojo

--- a/dojo_plugin/api/v1/docker.py
+++ b/dojo_plugin/api/v1/docker.py
@@ -365,7 +365,10 @@ class RunDocker(Resource):
                 .join(DojoModules.query.filter_by(dojo=dojo, id=module_id).subquery()) # Makes sure we are fetching from the current module in the current dojo
                 .first()
             )
-            if not Solves.query.filter_by(user=user, challenge=previous_dojo_challenge.challenge).first(): # Check to see if user hasn't solved the previous challenge
+            if (
+                not Solves.query.filter_by(user=user, challenge=previous_dojo_challenge.challenge).first() # Check to see if user hasn't solved the previous challenge
+                and not Solves.query.filter_by(user=user, challenge=dojo_challenge.challenge).first() # Check to see if user hasn't solved the current challenge
+            ):
                 return {
                     "success": False,
                     "error": "This challenge is locked"

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -465,10 +465,11 @@ class DojoChallenges(db.Model):
     description = db.Column(db.Text)
 
     data = db.Column(db.JSON)
-    data_fields = ["image", "path_override", "importable", "allow_privileged"]
+    data_fields = ["image", "path_override", "importable", "allow_privileged", "progression_locked"]
     data_defaults = {
         "importable": True,
-        "allow_privileged": True
+        "allow_privileged": True,
+        "progression_locked": False
     }
 
     dojo = db.relationship("Dojos",

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -469,7 +469,7 @@ class DojoChallenges(db.Model):
     data_defaults = {
         "importable": True,
         "allow_privileged": True,
-        "progression_locked": False
+        "progression_locked": False,
     }
 
     dojo = db.relationship("Dojos",

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -334,7 +334,7 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
                     challenge=challenge(
                         module_data.get("id"), challenge_data.get("id"), transfer=challenge_data.get("transfer", None)
                     ) if "import" not in challenge_data else None,
-                    progression_locked=challenge_data.get('progression_locked'),
+                    progression_locked=challenge_data.get("progression_locked"),
                     visibility=visibility(DojoChallengeVisibilities, dojo_data, module_data, challenge_data),
                     default=(assert_import_one(DojoChallenges.from_id(*import_ids(["dojo", "module", "challenge"], dojo_data, module_data, challenge_data)),
                                         f"Import challenge `{'/'.join(import_ids(['dojo', 'module', 'challenge'], dojo_data, module_data, challenge_data))}` does not exist")

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -334,7 +334,7 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
                     challenge=challenge(
                         module_data.get("id"), challenge_data.get("id"), transfer=challenge_data.get("transfer", None)
                     ) if "import" not in challenge_data else None,
-                    progression_locked=True if challenge_data.get('progression_locked') else False,
+                    progression_locked=challenge_data.get('progression_locked'),
                     visibility=visibility(DojoChallengeVisibilities, dojo_data, module_data, challenge_data),
                     default=(assert_import_one(DojoChallenges.from_id(*import_ids(["dojo", "module", "challenge"], dojo_data, module_data, challenge_data)),
                                         f"Import challenge `{'/'.join(import_ids(['dojo', 'module', 'challenge'], dojo_data, module_data, challenge_data))}` does not exist")

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -89,6 +89,7 @@ DOJO_SPEC = Schema({
             Optional("image"): IMAGE_REGEX,
             Optional("allow_privileged"): bool,
             Optional("importable"): bool,
+            Optional("progression_locked"): bool,
             Optional("auxiliary", default={}, ignore_extra_keys=True): dict,
             # Optional("path"): Regex(r"^[^\s\.\/][^\s\.]{,255}$"),
 
@@ -333,6 +334,7 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
                     challenge=challenge(
                         module_data.get("id"), challenge_data.get("id"), transfer=challenge_data.get("transfer", None)
                     ) if "import" not in challenge_data else None,
+                    progression_locked=True if challenge_data.get('progression_locked') else False,
                     visibility=visibility(DojoChallengeVisibilities, dojo_data, module_data, challenge_data),
                     default=(assert_import_one(DojoChallenges.from_id(*import_ids(["dojo", "module", "challenge"], dojo_data, module_data, challenge_data)),
                                         f"Import challenge `{'/'.join(import_ids(['dojo', 'module', 'challenge'], dojo_data, module_data, challenge_data))}` does not exist")

--- a/dojo_theme/static/css/custom.css
+++ b/dojo_theme/static/css/custom.css
@@ -221,6 +221,56 @@ p[data-hide="true"] {
     display: none;
 }
 
+.challenge-icon {
+    width: 2.5rem;
+}
+
+/* Styles for greying out the challenges button if it is disabled */
+.accordion-item-header:has(.disabled)  {
+    opacity: 0.6 !important;
+}
+
+.btn.disabled .accordion-item-name {
+    color: #aaa;
+}
+
+/* Styles for switching the text on hover for disabled buttons */
+.challenge-button-2 {
+    display: flex;
+}
+
+.challenge-text-wrapper {
+    position: relative;
+}
+
+.challenge-name-text, .challenge-locked-text {
+    transition: opacity 0.4s ease-in-out;
+}
+
+.challenge-name-text {
+    opacity: 1;
+    position: absolute;
+}
+
+.challenge-locked-text {
+    opacity: 0;
+    position: absolute;
+    white-space: nowrap;
+}
+
+.invisible-placeholder {
+    opacity: 0;
+    display: relative;
+}
+
+.button-wrapper:hover .disabled .challenge-name-text {
+    opacity: 0;
+}
+
+.button-wrapper:hover .disabled .challenge-locked-text {
+    opacity: 1;
+}
+
 .jumbotron, .nav-link.active, .form-control {
     background-color: inherit !important;
 }
@@ -346,6 +396,9 @@ p[data-hide="true"] {
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
+    display: flex;
+    align-items: center;
+    flex-grow: 1;
 }
 
 .challenge-active {
@@ -364,7 +417,6 @@ p[data-hide="true"] {
 }
 
 .challenge-header-right {
-    float: right;
     font-size: 0.75em;
     color: #ddd;
 }

--- a/dojo_theme/static/css/custom.css
+++ b/dojo_theme/static/css/custom.css
@@ -399,6 +399,7 @@ p[data-hide="true"] {
     display: flex;
     align-items: center;
     flex-grow: 1;
+    flex-wrap: wrap;
 }
 
 .challenge-active {

--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -30,6 +30,12 @@ function renderSubmissionResponse(response, item) {
     const unsolved_flag = item.find(".challenge-unsolved");
     const total_solves = item.find(".total-solves");
 
+    const header = item.find('[id^="challenges-header-"]'); //Finds the header item
+    const current_challenge_id = parseInt(header.attr('id').match(/(\d+)$/)[1]); //Extracts the number in the header id. E.g 'challenges-header-7' would return 7
+    const next_button_id = `#challenges-header-button-${current_challenge_id + 1}` //Finds the id of the next challenge button
+    const next_challenge_button = $(next_button_id); //Finds the next button html element
+
+
     result_notification.removeClass();
     result_message.text(result.message);
 
@@ -82,6 +88,7 @@ function renderSubmissionResponse(response, item) {
         answer_input.val("");
         answer_input.removeClass("wrong");
         answer_input.addClass("correct");
+        unlockChallenge(next_challenge_button);
         checkUserAwards()
         .then(handleAwardPopup)
         .catch(error => console.error("Award check failed:", error));
@@ -116,6 +123,15 @@ function renderSubmissionResponse(response, item) {
         item.find("#challenge-submit").removeClass("disabled-button");
         item.find("#challenge-submit").prop("disabled", false);
     }, 10000);
+}
+
+function unlockChallenge(challenge_button) {
+    if (challenge_button.length && challenge_button.hasClass('disabled')) {
+        challenge_button.removeClass('disabled');
+        const icon = challenge_button.find('.fa-lock');
+        icon.removeClass('fa-lock')
+        icon.addClass('fa-flag')
+    }
 }
 
 

--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -30,10 +30,9 @@ function renderSubmissionResponse(response, item) {
     const unsolved_flag = item.find(".challenge-unsolved");
     const total_solves = item.find(".total-solves");
 
-    const header = item.find('[id^="challenges-header-"]'); //Finds the header item
-    const current_challenge_id = parseInt(header.attr('id').match(/(\d+)$/)[1]); //Extracts the number in the header id. E.g 'challenges-header-7' would return 7
-    const next_button_id = `#challenges-header-button-${current_challenge_id + 1}` //Finds the id of the next challenge button
-    const next_challenge_button = $(next_button_id); //Finds the next button html element
+    const header = item.find('[id^="challenges-header-"]');
+    const current_challenge_id = parseInt(header.attr('id').match(/(\d+)$/)[1]);
+    const next_challenge_button = $(`#challenges-header-button-${current_challenge_id + 1}`);
 
 
     result_notification.removeClass();

--- a/dojo_theme/templates/macros/widgets.html
+++ b/dojo_theme/templates/macros/widgets.html
@@ -45,11 +45,11 @@
   </a>
 {%- endmacro %}
 
-{% macro accordion_item(accordion_id, item_id) %}
+{% macro accordion_item(accordion_id, item_id, is_disabled) %}
   <div class="accordion-item">
     <div class="accordion-item-header" id="{{ accordion_id }}-header-{{ item_id }}">
-      <h2 class="mb-0">
-        <button id="{{ accordion_id }}-header-button-{{ item_id }}" class="btn btn-link text-decoration-none w-100 collapsed" type="button" data-toggle="collapse" data-target="#{{ accordion_id }}-body-{{ item_id }}" aria-expanded="false" aria-controls="{{ accordion_id }}-body-{{ item_id }}">
+      <h2 class="mb-0 button-wrapper">
+        <button id="{{ accordion_id }}-header-button-{{ item_id }}" class="btn btn-link text-decoration-none w-100 challenge-button-2 collapsed {% if is_disabled %}disabled{% endif %}" type="button" data-toggle="collapse" data-target="#{{ accordion_id }}-body-{{ item_id }}" aria-expanded="false" aria-controls="{{ accordion_id }}-body-{{ item_id }}">
           {{ caller(True) }}
         </button>
       </h2>

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -64,32 +64,41 @@
   <h2>Challenges</h2>
 
   <div class="accordion" id="challenges">
-    {% for i in range(0, challenges|length) %}
-      {% set challenge = challenges[i] %}
+    {% for challenge in challenges %}
 
       {% set solved = "challenge-solved" if challenge.challenge_id in user_solves else "challenge-unsolved" %}
       {% set active = "challenge-active" if challenge.challenge_id == current_dojo_challenge.challenge_id else "" %}
-      {% set previous_challenge = challenges[i - 1] %}
-      {% set locked = challenge.visible() and challenge.data['progression_locked'] and previous_challenge.challenge_id not in user_solves and solved == "challenge-unsolved" %}
-      {% set icon = "fa-lock" if locked else "fa-flag" %}
+      {% set previous_challenge = challenges[loop.index0 - 1] %}
+      {% set progression_locked = challenge.progression_locked and not loop.first %}
+      {% set lock_challenge = progression_locked
+        and previous_challenge.challenge_id not in user_solves
+        and solved == "challenge-unsolved"
+        and not dojo.is_admin() %}
+      {% set hidden = not challenge.visible() %}
+      {% set icon = "fa-lock" if lock_challenge else "fa-flag" %}
 
-      {% call(header) accordion_item("challenges", loop.index, locked) %}
+      {% call(header) accordion_item("challenges", loop.index, lock_challenge) %}
         {% if header %}
           <h4 class="accordion-item-name challenge-name {{ active }}">
               <i class="challenge-icon pr-3 fas {{ icon }} {{ solved }} "></i>
-              {% if locked %}
+              {% if lock_challenge %}
               <div class="challenge-text-wrapper">
                 <span class="challenge-name-text">{{ challenge.name or challenge.id }}</span>
                 <span class="challenge-locked-text">Solve <strong></string><span style="color: white">{{ previous_challenge.name or previous_challenge.id }}</span></strong> to unlock this challenge</span>
                 <!-- Invisible placeholder has the same text as challenge-name-text and is used so that the button is sized to fit the text properly -->
-                <span class="invisible-placeholder">{{ challenge.name or challenge.id }}</span>
+                <span class="invisible-placeholder pr-2">{{ challenge.name or challenge.id }}</span>
               </div>
               {% else %}
               <span class="pr-2">{{ challenge.name or challenge.id }}</span>
               {% endif %}
-              {% if not challenge.visible() %}
+              {% if dojo.is_admin() and (progression_locked or hidden) %}
               <small><small><small>
-                    <i>hidden</i> &mdash; you can see this because you are this dojo's administrator
+                    <i>
+                      {% if progression_locked %}progression locked{% endif %}
+                      {% if progression_locked and hidden %} & {% endif %}
+                      {% if hidden %}hidden{% endif %}
+                    </i>
+                    &mdash; this challenge is accessible because you are this dojo's administrator
               </small></small></small>
               {% endif %}
           </h4>

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -64,20 +64,34 @@
   <h2>Challenges</h2>
 
   <div class="accordion" id="challenges">
-    {% for challenge in challenges %}
+    {% for i in range(0, challenges|length) %}
+      {% set challenge = challenges[i] %}
+
       {% set solved = "challenge-solved" if challenge.challenge_id in user_solves else "challenge-unsolved" %}
       {% set active = "challenge-active" if challenge.challenge_id == current_dojo_challenge.challenge_id else "" %}
-      {% call(header) accordion_item("challenges", loop.index) %}
+      {% set previous_challenge = challenges[i - 1] %}
+      {% set locked = challenge.visible() and challenge.data['progression_locked'] and previous_challenge.challenge_id not in user_solves and solved == "challenge-unsolved" %}
+      {% set icon = "fa-lock" if locked else "fa-flag" %}
+
+      {% call(header) accordion_item("challenges", loop.index, locked) %}
         {% if header %}
           <h4 class="accordion-item-name challenge-name {{ active }}">
-            <span class="d-sm-block d-md-block d-lg-block">
-              <i class="fas fa-flag pr-3 {{ solved }}"></i>{{ challenge.name or challenge.id }}
+              <i class="challenge-icon pr-3 fas {{ icon }} {{ solved }} "></i>
+              {% if locked %}
+              <div class="challenge-text-wrapper">
+                <span class="challenge-name-text">{{ challenge.name or challenge.id }}</span>
+                <span class="challenge-locked-text">Solve <strong></string><span style="color: white">{{ previous_challenge.name or previous_challenge.id }}</span></strong> to unlock this challenge</span>
+                <!-- Invisible placeholder has the same text as challenge-name-text and is used so that the button is sized to fit the text properly -->
+                <span class="invisible-placeholder">{{ challenge.name or challenge.id }}</span>
+              </div>
+              {% else %}
+              <span class="pr-2">{{ challenge.name or challenge.id }}</span>
+              {% endif %}
               {% if not challenge.visible() %}
               <small><small><small>
                     <i>hidden</i> &mdash; you can see this because you are this dojo's administrator
               </small></small></small>
               {% endif %}
-            </span>
           </h4>
           <span class="challenge-header-right">
             {% if challenge_container_counts.get(challenge.id, 0) > 0 %}


### PR DESCRIPTION
# Features added

Dojo creators will now be able to set an optional flag "progression_locked" under each challenge inside the module.yml. "progression_locked" takes a boolean as its value like so:

![image](https://github.com/user-attachments/assets/bf735210-e496-4fed-ad02-03fcb7ba8af0)

Challenges with "progression_locked: true" will appear as locked to the user if the user has not solved the immediately prior challenge. Once the user solves the prior challenge, it will unlock via javascript (no need to refresh the page).

# Notes

- Users will not be able to start progression locked challenges prematurely, even if they remove the disabled attribute inside the html, or even if they forge a start challenge request.
- Dojo admins will see progression locked challenges as unlocked, with small text indicating that the challenge is progression locked. 
- If the first challenge in the module is progression locked, it will ignore the lock completely. In essence, the first challenge of the module will always be unlocked.

# Limitations

- The locking functionality is done client-side to some extent, meaning the descriptions of locked challenge are still sent to the user. There is nothing preventing the user from removing the "disabled" class from the challenge button html element, enabling the user to read the challenge descriptions. However, the user is barred from actually starting the challenge.