### PR TITLE
Workspace: Fix .config permissions

### DIFF
--- a/workspace/core/init.nix
+++ b/workspace/core/init.nix
@@ -50,7 +50,9 @@ let
     exec > /run/dojo/var/root/init.log 2>&1
     chmod 600 /run/dojo/var/root/init.log
 
-    chown 1000:1000 /home/hacker && chmod 755 /home/hacker
+    for path in /home/hacker /home/hacker/.config; do
+      mkdir -p "$path" && chown 1000:1000 "$path" && chmod 755 "$path"
+    done
 
     if [ -x "/challenge/.init" ]; then
         PATH="/run/challenge/bin:$IMAGE_PATH" /challenge/.init


### PR DESCRIPTION
Hopefully this fixes "Unable to load a failsafe session" from the desktop. I am sure there are other files though that could cause this.

We have seen this as `.config` being 0:1000.

My best guess is a scapy challenge running as suid is automatically creating `.config` with its permissions; or something like this.