### PR TITLE
Site: Hide locked challenge descriptions until unlocked

### DIFF
--- a/dojo_plugin/api/v1/dojos.py
+++ b/dojo_plugin/api/v1/dojos.py
@@ -10,6 +10,7 @@ from CTFd.utils.decorators import authed_only, admins_only, ratelimit
 from CTFd.utils.user import get_current_user, is_admin, get_ip
 
 from ...models import DojoStudents, Dojos, DojoModules, DojoChallenges, DojoUsers, Emojis, SurveyResponses
+from ...utils import render_markdown
 from ...utils.dojo import dojo_route, dojo_admins_only, dojo_create
 
 
@@ -277,3 +278,37 @@ class DojoCourseSolveList(Resource):
         ]
 
         return {"success": True, "solves": solves}
+
+@dojos_namespace.route("/<dojo>/<module_id>/<challenge_id>/description")
+class ChallengeResource(Resource):
+    @authed_only
+    @dojo_route
+    def get(self, dojo, module_id, challenge_id):
+        user = get_current_user()
+
+        module = next((m for m in dojo.modules if m.id == module_id), None)
+
+        if module is None:
+            return {"success": False, "error": "Invalid module id"}, 404
+        
+
+        dojo_challenge = next((c for c in module.visible_challenges() if c.id == challenge_id), None)
+
+        if dojo_challenge is None:
+            return {"success": False, "error": "Invalid challenge id"}, 404
+
+        
+        if all((dojo_challenge.progression_locked, dojo_challenge.challenge_index != 0, not dojo.is_admin())):
+            previous_dojo_challenge = dojo_challenge.module.challenges[dojo_challenge.challenge_index - 1]
+            is_challenge_unlocked = (Solves.query.filter_by(user=user, challenge=dojo_challenge.challenge).first() or
+                      Solves.query.filter_by(user=user, challenge=previous_dojo_challenge.challenge).first())
+            if not is_challenge_unlocked:
+                return {
+                    "success": False,
+                    "error": "This challenge is locked"
+                }, 403
+        
+        return {
+            "success": True,
+            "description": render_markdown(dojo_challenge.description)
+        }

--- a/dojo_plugin/api/v1/dojos.py
+++ b/dojo_plugin/api/v1/dojos.py
@@ -283,21 +283,15 @@ class DojoCourseSolveList(Resource):
 class ChallengeResource(Resource):
     @authed_only
     @dojo_route
-    def get(self, dojo, module_id, challenge_id):
+    def get(self, dojo, module, challenge_id):
         user = get_current_user()
-
-        module = next((m for m in dojo.modules if m.id == module_id), None)
-
-        if module is None:
-            return {"success": False, "error": "Invalid module id"}, 404
-        
 
         dojo_challenge = next((c for c in module.visible_challenges() if c.id == challenge_id), None)
 
         if dojo_challenge is None:
             return {"success": False, "error": "Invalid challenge id"}, 404
 
-        
+
         if all((dojo_challenge.progression_locked, dojo_challenge.challenge_index != 0, not dojo.is_admin())):
             previous_dojo_challenge = dojo_challenge.module.challenges[dojo_challenge.challenge_index - 1]
             is_challenge_unlocked = (Solves.query.filter_by(user=user, challenge=dojo_challenge.challenge).first() or
@@ -307,7 +301,7 @@ class ChallengeResource(Resource):
                     "success": False,
                     "error": "This challenge is locked"
                 }, 403
-        
+
         return {
             "success": True,
             "description": render_markdown(dojo_challenge.description)

--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -156,8 +156,17 @@ function unlockChallenge(challenge_button) {
     if (challenge_button.length && challenge_button.hasClass('disabled')) {
         challenge_button.removeClass('disabled');
         const icon = challenge_button.find('.fa-lock');
-        icon.removeClass('fa-lock')
-        icon.addClass('fa-flag')
+        icon.removeClass('fa-lock');
+        icon.addClass('fa-flag');
+
+        const item = challenge_button.closest(".accordion-item");
+        const module_id = item.find("#module").val();
+        const challenge_id = item.find("#challenge").val();
+        const description = item.find(".challenge-description");
+
+        CTFd.fetch(`/pwncollege_api/v1/dojos/${init.dojo}/${module_id}/${challenge_id}/description`)
+            .then(response => response.json())
+            .then(data => description.html(data.description));
     }
 }
 

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -113,8 +113,12 @@
             </span>
           </span>
         {% else %}
-          <div class="embed-responsive">
-            <p>{{ challenge.description | markdown }}</p>
+          <div class="embed-responsive challenge-description">
+            {% if lock_challenge %}
+              <p><em>Challenge description is not accessible</em></p>
+            {% else %}
+              {{ challenge.description | markdown }}
+            {% endif %}
           </div>
           <div class="row">
             <div class="col-sm-{% if challenge.allow_privileged %}6{% else %}12{% endif %} form-group text-center">

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -115,7 +115,7 @@
         {% else %}
           <div class="embed-responsive challenge-description">
             {% if lock_challenge %}
-              <p><em>Challenge description is not accessible</em></p>
+              <p><em>This challenge is locked</em></p>
             {% else %}
               {{ challenge.description | markdown }}
             {% endif %}


### PR DESCRIPTION
## Overview

This PR will prevent the server from sending descriptions of progression locked challenges. When the user unlocks a challenge, the client will call the pwn.college api to retrieve the challenge description and display it safely (no XSS). It will enforce proper permissions, meaning a user will not be able to forge a request to a description that they don't have access to. 

## Specifics

- Introduces the api endpoint `/pwncollege_api/v1/dojos/<dojo>/<module_id>/<challenge_id>/description` to retrieve the proper description.
- The backend sends the description as markdown html using the render_markdown function imported from utils. I looked through it and ran a quick test, so I'm fairly certain it is safe from XSS.
- Javascript renders the challenge description dynamically, so no need to refresh the page.