### PR TITLE
Workspace: Support existing PROMPT_COMMAND

### DIFF
--- a/workspace/core/init.nix
+++ b/workspace/core/init.nix
@@ -72,7 +72,7 @@ let
       export LANG="C.UTF-8"
     fi
 
-    PROMPT_COMMAND="history -a"
+    PROMPT_COMMAND="history -a; $PROMPT_COMMAND"
   '';
 
 in pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
Some challenges rely on `/challenge/.bashrc` setting the PROMPT_COMMAND.  The source order of the initial challenge shell has this file overwrite the challenge setting.