### PR TITLE
Fixes #685: Sage tools needed for cryptography

### DIFF
--- a/workspace/flake.nix
+++ b/workspace/flake.nix
@@ -32,11 +32,21 @@
               angr-management = (import nixpkgs-pr-angr-management { inherit system config; }).angr-management;
             };
 
+            sage-overlay = final: prev: {
+              sage = prev.sage.override {
+                extraPythonPackages = ps: with ps; [
+                  pycryptodome
+                  pwntools
+                ];
+              };
+            };
+
             pkgs = import nixpkgs {
               inherit system config;
               overlays = [
                 binaryninja-free-overlay
                 angr-management-overlay
+                sage-overlay
               ];
             };
 


### PR DESCRIPTION
Closes #685 

Adds `pycryptodome` and `pwntools` to `sage`.  All other requested packages mentioned already exist in sage environment.