### PR TITLE
Engagement: Improve statistics dashboard

### DIFF
--- a/dojo_plugin/utils/stats.py
+++ b/dojo_plugin/utils/stats.py
@@ -14,7 +14,7 @@ def get_container_stats():
 
 @cache.memoize(timeout=1200, forced_update=force_cache_updates)
 def get_dojo_stats(dojo):
-    now = datetime.now() - timedelta(days=75)  # FIX TEST DATE FILTER WHEN DONE!!! 
+    now = datetime.now()
     base_q = dojo.solves()
     
     total_challenges = len(dojo.challenges)

--- a/dojo_plugin/utils/stats.py
+++ b/dojo_plugin/utils/stats.py
@@ -1,7 +1,9 @@
 from CTFd.cache import cache
 from CTFd.models import Solves
+from datetime import datetime, timedelta
+from sqlalchemy import func, desc
 
-from . import force_cache_updates, get_all_containers
+from . import force_cache_updates, get_all_containers, DojoChallenges
 
 @cache.memoize(timeout=1200, forced_update=force_cache_updates)
 def get_container_stats():
@@ -10,12 +12,95 @@ def get_container_stats():
             for attr in ["dojo", "module", "challenge"]}
             for container in containers]
 
-
 @cache.memoize(timeout=1200, forced_update=force_cache_updates)
 def get_dojo_stats(dojo):
-    return dict(
-        users=dojo.solves().group_by(Solves.user_id).count(),
-        challenges=len(dojo.challenges),
-        visible_challenges=len([challenge for challenge in dojo.challenges if challenge.visible()]),
-        solves=dojo.solves().count(),
-    )
+    now = datetime.now() - timedelta(days=75)  # FIX TEST DATE FILTER WHEN DONE!!! 
+    base_q = dojo.solves()
+    
+    total_challenges = len(dojo.challenges)
+    visible_challenges = len([c for c in dojo.challenges if c.visible()])
+    
+    total_stats = base_q.with_entities(
+        func.count(Solves.id).label('total_solves'),
+        func.count(func.distinct(Solves.user_id)).label('total_users')
+    ).first()
+    
+    total_solves = total_stats.total_solves or 0
+    total_users = total_stats.total_users or 0
+    
+    # chart data 
+    snapshot_days = [1, 7, 30, 60]
+    chart_labels = ['Today', '1w ago', '1mo ago', '2mo ago']
+    chart_solves = []
+    chart_users = []
+    
+    for days_ago in snapshot_days:
+        # get day given how many days ago
+        snapshot_date = now - timedelta(days=days_ago)
+        day_start = snapshot_date.replace(hour=0, minute=0, second=0, microsecond=0)
+        day_end = day_start + timedelta(days=1)
+        
+        # get day info
+        day_stats = base_q.filter(
+            Solves.date >= day_start,
+            Solves.date < day_end
+        ).with_entities(
+            func.count(Solves.id).label('day_solves'),
+            func.count(func.distinct(Solves.user_id)).label('day_users')
+        ).first()
+        
+        chart_solves.append(day_stats.day_solves or 0)
+        chart_users.append(day_stats.day_users or 0)
+    
+    # recent solves data
+    try:
+        basic_query = (
+            base_q
+            .with_entities(
+                Solves.date.label('date'),
+                DojoChallenges.name.label('challenge_name')
+            )
+            .order_by(desc(Solves.date))
+            .limit(5)
+            .all()
+        )
+        
+        recent_solves = [
+            {
+                'challenge_name': f'{solve.challenge_name}',
+                'date': solve.date,
+                'date_display': solve.date.strftime('%m/%d/%y %I:%M %p') if solve.date else 'Unknown time'
+            }
+            for solve in basic_query
+        ]
+        
+    except Exception as e:
+        print(f"Basic query failed: {e}")
+        recent_solves = []
+
+    def trend_calc(current, previous):
+        if previous == 0:
+            return 100 if current > 0 else 0
+        change = ((current - previous) / previous) * 100
+        return max(-99, min(999, round(change)))
+    
+    trends = {
+        'solves': trend_calc(chart_solves[0], chart_solves[1]),
+        'users': trend_calc(chart_users[0], chart_users[1]),
+        'active': 0,  # No historical need to store, keeping in case we want to implement this
+        'challenges': 0  # Need to store same as above
+    }
+    
+    return {
+        'users': total_users,
+        'challenges': total_challenges,
+        'visible_challenges': visible_challenges,
+        'solves': total_solves,
+        'recent_solves': recent_solves,
+        'trends': trends,
+        'chart_data': {
+            'labels': chart_labels,
+            'solves': chart_solves,
+            'users': chart_users
+        }
+    }

--- a/dojo_plugin/utils/stats.py
+++ b/dojo_plugin/utils/stats.py
@@ -15,82 +15,77 @@ def get_container_stats():
 @cache.memoize(timeout=1200, forced_update=force_cache_updates)
 def get_dojo_stats(dojo):
     now = datetime.now()
-    base_q = dojo.solves()
-    
+    solves_query = dojo.solves()
+
     total_challenges = len(dojo.challenges)
     visible_challenges = len([c for c in dojo.challenges if c.visible()])
-    
-    total_stats = base_q.with_entities(
+
+    total_stats = solves_query.with_entities(
         func.count(Solves.id).label('total_solves'),
         func.count(func.distinct(Solves.user_id)).label('total_users')
     ).first()
-    
+
     total_solves = total_stats.total_solves or 0
     total_users = total_stats.total_users or 0
-    
-    # chart data 
+
+    # chart data
     snapshot_days = [1, 7, 30, 60]
     chart_labels = ['Today', '1w ago', '1mo ago', '2mo ago']
     chart_solves = []
     chart_users = []
-    
+
     for days_ago in snapshot_days:
         # get day given how many days ago
         snapshot_date = now - timedelta(days=days_ago)
         day_start = snapshot_date.replace(hour=0, minute=0, second=0, microsecond=0)
         day_end = day_start + timedelta(days=1)
-        
+
         # get day info
-        day_stats = base_q.filter(
+        day_stats = solves_query.filter(
             Solves.date >= day_start,
             Solves.date < day_end
         ).with_entities(
             func.count(Solves.id).label('day_solves'),
             func.count(func.distinct(Solves.user_id)).label('day_users')
         ).first()
-        
+
         chart_solves.append(day_stats.day_solves or 0)
         chart_users.append(day_stats.day_users or 0)
-    
+
     # recent solves data
-    try:
-        basic_query = (
-            base_q
-            .with_entities(
-                Solves.date.label('date'),
-                DojoChallenges.name.label('challenge_name')
-            )
-            .order_by(desc(Solves.date))
-            .limit(5)
-            .all()
+    basic_query = (
+        solves_query
+        .with_entities(
+            Solves.date.label('date'),
+            DojoChallenges.name.label('challenge_name')
         )
-        
-        recent_solves = [
-            {
-                'challenge_name': f'{solve.challenge_name}',
-                'date': solve.date,
-                'date_display': solve.date.strftime('%m/%d/%y %I:%M %p') if solve.date else 'Unknown time'
-            }
-            for solve in basic_query
-        ]
-        
-    except Exception as e:
-        print(f"Basic query failed: {e}")
-        recent_solves = []
+        .order_by(desc(Solves.date))
+        .limit(5)
+        .all()
+    )
+
+    recent_solves = [
+        {
+            'challenge_name': f'{solve.challenge_name}',
+            'date': solve.date,
+            'date_display': solve.date.strftime('%m/%d/%y %I:%M %p') if solve.date else 'Unknown time'
+        }
+        for solve in basic_query
+    ]
 
     def trend_calc(current, previous):
         if previous == 0:
             return 100 if current > 0 else 0
         change = ((current - previous) / previous) * 100
         return max(-99, min(999, round(change)))
-    
+
     trends = {
         'solves': trend_calc(chart_solves[0], chart_solves[1]),
         'users': trend_calc(chart_users[0], chart_users[1]),
-        'active': 0,  # No historical need to store, keeping in case we want to implement this
-        'challenges': 0  # Need to store same as above
+        'active': 0,
+        'challenges': 0,
     }
-    
+
     return {
         'users': total_users,
         'challenges': total_challenges,

--- a/dojo_theme/static/css/custom.css
+++ b/dojo_theme/static/css/custom.css
@@ -878,6 +878,197 @@ code {
     border-radius: 2px;
 }
 
+.stats-dashboard {
+    display: grid;
+    grid-template-columns: repeat(4, 265px);
+    gap: 12px;
+    margin: 6px auto;
+    font-family: 'Space Grotesk', sans-serif;
+    text-transform: none;
+    font-size: 16px;
+    line-height: 1.2;
+    padding: 6px;
+    width: fit-content;
+    max-width: 100%;
+    box-sizing: border-box;
+    overflow-x: auto;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0, 0, 0, 0.3) transparent;
+}
+
+.stat-card {
+    background: linear-gradient(110deg, rgba(0, 0, 0, 1) 0%, rgb(8, 8, 8) 60%, rgb(17, 17, 17) 100%);
+    border: 1px solid var(--brand-black);
+    padding: 16px;
+    border-radius: 8px;
+    height: 185px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4), 0 2px 4px rgba(0, 0, 0, 0.2);
+    transition: all 0.2s ease;
+    position: relative;
+    flex-shrink: 0;
+    box-sizing: border-box;
+}
+
+.stat-card-header {
+    font-size: 16px;
+    color: var(--brand-green);
+    text-transform: none;
+    text-align: left;
+    padding: 0;
+    margin-bottom: 12px;
+    font-weight: 500;
+}
+
+.stat-container {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    grid-template-rows: 1fr 1fr;
+    gap: 12px;
+    height: calc(100% - 32px);
+}
+
+.stat-box:nth-child(1) { /* Total Solves */
+    grid-column: 1;
+    grid-row: 1;
+}
+
+.stat-box:nth-child(2) { /* Hacking Now */
+    grid-column: 2;
+    grid-row: 1;
+}
+
+.stat-box:nth-child(3) { /* Unique Hackers */
+    grid-column: 1;
+    grid-row: 2;
+}
+
+.stat-box:nth-child(4) { /* Challenges */
+    grid-column: 2;
+    grid-row: 2;
+}
+
+.stat-box {
+    padding: 8px;
+    border-left: 2px solid var(--brand-green);
+    background: rgba(255, 255, 255, 0.02);
+    border-radius: 4px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    transition: all 0.2s ease;
+}
+
+.stat-label {
+    font-size: 10px;
+    color: var(--brand-light-gray);
+    margin-bottom: 8px;
+    font-weight: 400;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.stat-value {
+    font-size: 14px;
+    font-weight: 550;
+    color: var(--brand-white);
+    display: flex;
+    align-items: baseline;
+    flex-wrap: nowrap;
+    line-height: 1.1;
+}
+
+.stat-trend {
+    margin-left: 6px;
+    font-size: 10px;
+    font-weight: 500;
+    white-space: nowrap;
+    padding: 2px 2px;
+}
+
+.trend-up { 
+    color: var(--brand-green);
+}
+
+.trend-down { 
+    color: #ff4444;
+}
+
+.trend-neutral { 
+    color: var(--brand-light-gray);
+}
+
+.chart-container {
+    height: calc(100% - 32px);
+    margin: 4px 0;
+    padding: 2px;
+    max-height: 170px;
+    overflow: hidden;
+}
+
+.recent-activity, .recent-awards {
+    height: calc(100% - 32px);
+    max-height: 160px;
+    overflow-y: auto;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0, 0, 0, 0.3) transparent;
+    padding: 4px;
+}
+
+.recent-activity::-webkit-scrollbar,
+.recent-awards::-webkit-scrollbar {
+    width: 4px;
+}
+
+.recent-activity::-webkit-scrollbar-track,
+.recent-awards::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.recent-activity::-webkit-scrollbar-thumb,
+.recent-awards::-webkit-scrollbar-thumb {
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 2px;
+}
+
+.recent-activity::-webkit-scrollbar-thumb:hover,
+.recent-awards::-webkit-scrollbar-thumb:hover {
+    background: rgba(0, 0, 0, 0.5);
+}
+
+.recent-item {
+    padding: 8px 6px;
+    border-bottom: 1px solid #1a1a1a;
+    font-size: 11px;
+    color: var(--brand-white);
+    transition: background 0.2s ease;
+    margin-bottom: 2px;
+}
+
+.recent-item:hover {
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.recent-item:last-child {
+    border-bottom: none;
+}
+
+.recent-time {
+    color: var(--brand-light-gray);
+    font-size: 10px;
+    margin-top: 2px;
+}
+
+.award-link {
+    color: var(--brand-green);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.2s ease;
+}
+
+.award-link:hover {
+    color: rgba(120, 190, 32, 0.8);
+    text-decoration: none;
+}
+
 @keyframes navbar-slide-out {
     0% {
         transform: translateY(0);

--- a/dojo_theme/static/css/custom.css
+++ b/dojo_theme/static/css/custom.css
@@ -982,15 +982,15 @@ code {
     padding: 2px 2px;
 }
 
-.trend-up { 
+.trend-up {
     color: var(--brand-green);
 }
 
-.trend-down { 
+.trend-down {
     color: #ff4444;
 }
 
-.trend-neutral { 
+.trend-neutral {
     color: var(--brand-light-gray);
 }
 

--- a/dojo_theme/static/css/custom.css
+++ b/dojo_theme/static/css/custom.css
@@ -883,7 +883,7 @@ code {
     grid-template-columns: repeat(4, 265px);
     gap: 12px;
     margin: 6px auto;
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Space Grotesk';
     text-transform: none;
     font-size: 16px;
     line-height: 1.2;
@@ -915,7 +915,7 @@ code {
     text-transform: none;
     text-align: left;
     padding: 0;
-    margin-bottom: 12px;
+    margin-bottom: 8px;
     font-weight: 500;
 }
 
@@ -960,15 +960,14 @@ code {
     font-size: 10px;
     color: var(--brand-light-gray);
     margin-bottom: 8px;
-    font-weight: 400;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 }
 
 .stat-value {
-    font-size: 14px;
-    font-weight: 550;
+    font-size: 16px;
+    font-weight: 700;
     color: var(--brand-white);
     display: flex;
     align-items: baseline;
@@ -979,7 +978,6 @@ code {
 .stat-trend {
     margin-left: 6px;
     font-size: 10px;
-    font-weight: 500;
     white-space: nowrap;
     padding: 2px 2px;
 }
@@ -1012,7 +1010,7 @@ code {
     scrollbar-color: rgba(0, 0, 0, 0.3) transparent;
     padding: 4px;
 }
-
+/* scrollbar styles for stats */
 .recent-activity::-webkit-scrollbar,
 .recent-awards::-webkit-scrollbar {
     width: 4px;
@@ -1037,7 +1035,7 @@ code {
 .recent-item {
     padding: 8px 6px;
     border-bottom: 1px solid #1a1a1a;
-    font-size: 11px;
+    font-size: 12px;
     color: var(--brand-white);
     transition: background 0.2s ease;
     margin-bottom: 2px;

--- a/dojo_theme/templates/base.html
+++ b/dojo_theme/templates/base.html
@@ -16,9 +16,9 @@
     <link rel="stylesheet" href="{{ url_for('views.themes', path='css/fonts.css') }}">
     <link rel="stylesheet" href="{{ url_for('views.themes', path='css/main.css') }}">
     <link rel="stylesheet" href="{{ url_for('views.themes', path='css/core.css') }}">
-    <link rel="preload" href="{{ url_for('views.themes', path='font/SpaceMono-Regular.ttf') }}" as="font" type="font/ttf">
-    <link rel="preload" href="{{ url_for('views.themes', path='font/SpaceMono-Bold.ttf') }}" as="font" type="font/ttf">
-    <link rel="preload" href="{{ url_for('views.themes', path='font/SpaceGrotesk-VariableFont_wght.ttf') }}" as="font" type="font/ttf">
+    <link rel="preload" href="{{ url_for('views.themes', path='font/SpaceMono-Regular.ttf') }}" as="font" type="font/ttf" crossorigin="anonymous">
+    <link rel="preload" href="{{ url_for('views.themes', path='font/SpaceMono-Bold.ttf') }}" as="font" type="font/ttf" crossorigin="anonymous">
+    <link rel="preload" href="{{ url_for('views.themes', path='font/SpaceGrotesk-VariableFont_wght.ttf') }}" as="font" type="font/ttf" crossorigin="anonymous">
     <style>
       @font-face {
         font-family: 'Space Mono';

--- a/dojo_theme/templates/components/stat_dashboard.html
+++ b/dojo_theme/templates/components/stat_dashboard.html
@@ -12,7 +12,7 @@
             {% if trend > 0 %}▲{% elif trend < 0 %}▼{% else %}-{% endif %}{{ trend|abs }}%
           </span>
           {% else %}
-          <span class="stat-trend trend-neutral"></span>
+          <span class="stat-trend trend-neutral">- 0%</span>
           {% endif %}
         </div>
       </div>
@@ -35,7 +35,7 @@
             {% if trend > 0 %}▲{% elif trend < 0 %}▼{% else %}-{% endif %}{{ trend|abs }}%
           </span>
           {% else %}
-          <span class="stat-trend trend-neutral"></span>
+          <span class="stat-trend trend-neutral">- 0%</span>
           {% endif %}
         </div>
       </div>
@@ -71,7 +71,7 @@
             {{ award.user.name }}
           </a>
           <div class="recent-time">
-            {{ award.date }}
+              {{ award.date.strftime('%m/%d/%y %I:%M %p') if award.date else 'Unknown time' }}
           </div>
         </div>
         {% endfor %}
@@ -92,7 +92,7 @@
         </div>
         {% endfor %}
       {% else %}
-        <div class="recent-item">No recent activity</div>
+        <div class="recent-item">No recent solves</div>
       {% endif %}
     </div>
   </div>

--- a/dojo_theme/templates/components/stat_dashboard.html
+++ b/dojo_theme/templates/components/stat_dashboard.html
@@ -1,0 +1,206 @@
+<div id="stats-dashboard" class="stats-dashboard">
+  <div class="stat-card">
+    <div class="stat-card-header">Dojo Stats</div>
+    <div class="stat-container">
+      <div class="stat-box">
+        <div class="stat-label">Total Solves</div>
+        <div class="stat-value">
+          {{ "{:,}".format(stats.solves if stats and stats.solves else 0) }}
+          {% set trend = stats.trends.solves if stats and stats.trends and stats.trends.solves is defined else 0 %}
+          {% if trend != 0 %}
+          <span class="stat-trend {% if trend > 0 %}trend-up{% elif trend < 0 %}trend-down{% else %}trend-neutral{% endif %}">
+            {% if trend > 0 %}▲{% elif trend < 0 %}▼{% else %}-{% endif %}{{ trend|abs }}%
+          </span>
+          {% else %}
+          <span class="stat-trend trend-neutral"></span>
+          {% endif %}
+        </div>
+      </div>
+      
+      <div class="stat-box">
+        <div class="stat-label">Hacking Now</div>
+        <div class="stat-value">
+          {{ stats.active if stats and stats.active else 0 }}
+          <span class="stat-trend trend-neutral"></span>
+        </div>
+      </div>
+
+      <div class="stat-box">
+        <div class="stat-label">Unique Hackers</div>
+        <div class="stat-value">
+          {{ "{:,}".format(stats.users if stats and stats.users else 0) }}
+          {% set trend = stats.trends.users if stats and stats.trends and stats.trends.users is defined else 0 %}
+          {% if trend != 0 %}
+          <span class="stat-trend {% if trend > 0 %}trend-up{% elif trend < 0 %}trend-down{% else %}trend-neutral{% endif %}">
+            {% if trend > 0 %}▲{% elif trend < 0 %}▼{% else %}-{% endif %}{{ trend|abs }}%
+          </span>
+          {% else %}
+          <span class="stat-trend trend-neutral"></span>
+          {% endif %}
+        </div>
+      </div>
+      
+      <div class="stat-box">
+        <div class="stat-label">Challenges</div>
+        <div class="stat-value">
+          {{ stats.visible_challenges if stats and stats.visible_challenges else 0 }}
+          <span class="stat-trend trend-neutral"></span>
+        </div>
+      </div>
+    </div>
+  </div>
+  
+  <div class="stat-card">
+    <div class="stat-card-header">Activity History</div>
+    <div class="chart-container">
+      <canvas id="activity-chart" 
+              data-labels='{{ stats.chart_data.labels|tojson if stats and stats.chart_data and stats.chart_data.labels else "[]" }}'
+              data-solves='{{ stats.chart_data.solves|tojson if stats and stats.chart_data and stats.chart_data.solves else "[]" }}'
+              data-users='{{ stats.chart_data.users|tojson if stats and stats.chart_data and stats.chart_data.users else "[]" }}'>
+      </canvas>
+    </div>
+  </div>
+  
+  <div class="stat-card">
+    <div class="stat-card-header">Recent Awardees</div>
+    <div class="recent-awards">
+      {% if awards %}
+        {% for award in awards[:3] %}
+        <div class="recent-item">
+          <a href="{{ url_for('pwncollege_users.view_other', user_id=award.user_id) }}" class="award-link">
+            {{ award.user.name }}
+          </a>
+          <div class="recent-time">
+            {{ award.date }}
+          </div>
+        </div>
+        {% endfor %}
+      {% else %}
+        <div class="recent-item">No awards yet</div>
+      {% endif %}
+    </div>
+  </div>
+  
+  <div class="stat-card">
+    <div class="stat-card-header">Recent Solves</div>
+    <div class="recent-activity">
+      {% if stats and stats.recent_solves and stats.recent_solves|length > 0 %}
+        {% for solve in stats.recent_solves %}
+        <div class="recent-item">
+          {{ solve.challenge_name if solve.challenge_name else 'Unknown Challenge' }}
+          <div class="recent-time">{{ solve.date_display if solve.date_display else 'Unknown time' }}</div>
+        </div>
+        {% endfor %}
+      {% else %}
+        <div class="recent-item">No recent activity</div>
+      {% endif %}
+    </div>
+  </div>
+</div>
+
+<script>
+function initializeChart() {
+  const chartCanvas = document.getElementById('activity-chart');
+  if (!chartCanvas || typeof Chart === 'undefined') {
+    setTimeout(initializeChart, 100);
+    return;
+  }
+  
+  const parseData = (attr, fallback) => {
+    try {
+      const value = chartCanvas.dataset[attr];
+      return value ? JSON.parse(value) : fallback;
+    } catch (e) {
+      console.error(`Error parsing ${attr}:`, e);
+      return fallback;
+    }
+  };
+  
+  const labels = parseData('labels', ['Today', '1w ago', '1mo ago', '2mo ago']);
+  const solvesData = parseData('solves', [0, 0, 0, 0]);
+  const usersData = parseData('users', [0, 0, 0, 0]);
+  
+  // Chart.js config
+  Chart.defaults.color = '#ffffff';
+  Chart.defaults.font.family = "'Space Mono', 'JetBrains Mono', 'Consolas', monospace";
+  Chart.defaults.font.size = 9;
+  
+  new Chart(chartCanvas.getContext('2d'), {
+    type: 'bar',
+    data: {
+      labels: labels,
+      datasets: [
+        {
+          label: 'Daily Solves',
+          data: solvesData,
+          backgroundColor: 'rgba(120, 190, 32, 0.7)',
+          borderColor: '#78be20',
+          borderWidth: 1
+        },
+        {
+          label: 'Daily Users',
+          data: usersData,
+          backgroundColor: 'rgba(0, 163, 224, 0.7)',
+          borderColor: '#00a3e0',
+          borderWidth: 1
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: {
+        intersect: false,
+        mode: 'index'
+      },
+      scales: {
+        x: {
+          grid: { 
+            display: false 
+          },
+          ticks: {
+            color: '#747474',
+            maxRotation: 25,
+            minRotation: 15
+          }
+        },
+        y: {
+          beginAtZero: true,
+          grid: { 
+            color: 'rgba(72, 72, 72, 0.3)'
+          },
+          ticks: {
+            color: '#747474'
+          }
+        }
+      },
+      plugins: {
+        legend: { 
+          display: false
+        },
+        tooltip: {
+          backgroundColor: 'rgba(0, 0, 0, 0.9)',
+          titleColor: '#ffffff',
+          bodyColor: '#ffffff',
+          borderColor: '#484848',
+          borderWidth: 1,
+          cornerRadius: 4,
+          padding: 8,
+          displayColors: true,
+          callbacks: {
+            title: function(context) {
+              return `${context[0].label}`;
+            }
+          }
+        }
+      }
+    }
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initializeChart);
+} else {
+  initializeChart();
+}
+</script>

--- a/dojo_theme/templates/components/stat_dashboard.html
+++ b/dojo_theme/templates/components/stat_dashboard.html
@@ -6,7 +6,7 @@
         <div class="stat-label">Total Solves</div>
         <div class="stat-value">
           {{ "{:,}".format(stats.solves if stats and stats.solves else 0) }}
-          {% set trend = stats.trends.solves if stats and stats.trends and stats.trends.solves is defined else 0 %}
+          {% set trend = stats.trends.solves if stats and stats.trends and stats.trends.get('solves') is not none else 0 %}
           {% if trend != 0 %}
           <span class="stat-trend {% if trend > 0 %}trend-up{% elif trend < 0 %}trend-down{% else %}trend-neutral{% endif %}">
             {% if trend > 0 %}▲{% elif trend < 0 %}▼{% else %}-{% endif %}{{ trend|abs }}%
@@ -54,7 +54,7 @@
     <div class="stat-card-header">Activity History</div>
     <div class="chart-container">
       <canvas id="activity-chart" 
-              data-labels='{{ stats.chart_data.labels|tojson if stats and stats.chart_data and stats.chart_data.labels else "[]" }}'
+              data-labels='{{ stats.chart_data.labels|tojson|safe if stats and stats.chart_data and stats.chart_data.labels else "[]" }}'
               data-solves='{{ stats.chart_data.solves|tojson if stats and stats.chart_data and stats.chart_data.solves else "[]" }}'
               data-users='{{ stats.chart_data.users|tojson if stats and stats.chart_data and stats.chart_data.users else "[]" }}'>
       </canvas>
@@ -199,7 +199,10 @@ function initializeChart() {
 }
 
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initializeChart);
+  if (!window.chartInitialized) {
+    window.chartInitialized = true;
+    document.addEventListener('DOMContentLoaded', initializeChart);
+  }
 } else {
   initializeChart();
 }

--- a/dojo_theme/templates/components/stat_dashboard.html
+++ b/dojo_theme/templates/components/stat_dashboard.html
@@ -1,66 +1,54 @@
+{%- macro render_stat_value(stats, field, show_neutral=True) -%}
+  {% set trend = stats.trends.get(field, 0) %}
+  <div class="stat-value">
+    {{ "{:,}".format(stats.get(field, 0)) }}
+    {% if trend != 0 or show_neutral %}
+      <span class="stat-trend {% if trend > 0 %}trend-up{% elif trend < 0 %}trend-down{% else %}trend-neutral{% endif %}">
+        {% if trend > 0 %}▲{% elif trend < 0 %}▼{% else %}-{% endif %}{{ trend|abs }}%
+      </span>
+    {% else %}
+      <span class="stat-trend trend-neutral">- 0%</span>
+    {% endif %}
+  </div>
+{%- endmacro -%}
+
 <div id="stats-dashboard" class="stats-dashboard">
   <div class="stat-card">
     <div class="stat-card-header">Dojo Stats</div>
     <div class="stat-container">
       <div class="stat-box">
         <div class="stat-label">Total Solves</div>
-        <div class="stat-value">
-          {{ "{:,}".format(stats.solves if stats and stats.solves else 0) }}
-          {% set trend = stats.trends.solves if stats and stats.trends and stats.trends.get('solves') is not none else 0 %}
-          {% if trend != 0 %}
-          <span class="stat-trend {% if trend > 0 %}trend-up{% elif trend < 0 %}trend-down{% else %}trend-neutral{% endif %}">
-            {% if trend > 0 %}▲{% elif trend < 0 %}▼{% else %}-{% endif %}{{ trend|abs }}%
-          </span>
-          {% else %}
-          <span class="stat-trend trend-neutral">- 0%</span>
-          {% endif %}
-        </div>
+        <div class="stat-value">{{ render_stat_value(stats, "solves") }}</div>
       </div>
-      
+
       <div class="stat-box">
         <div class="stat-label">Hacking Now</div>
-        <div class="stat-value">
-          {{ stats.active if stats and stats.active else 0 }}
-          <span class="stat-trend trend-neutral"></span>
-        </div>
+        <div class="stat-value">{{ render_stat_value(stats, "active", show_neutral=False) }}</div>
       </div>
 
       <div class="stat-box">
         <div class="stat-label">Unique Hackers</div>
-        <div class="stat-value">
-          {{ "{:,}".format(stats.users if stats and stats.users else 0) }}
-          {% set trend = stats.trends.users if stats and stats.trends and stats.trends.users is defined else 0 %}
-          {% if trend != 0 %}
-          <span class="stat-trend {% if trend > 0 %}trend-up{% elif trend < 0 %}trend-down{% else %}trend-neutral{% endif %}">
-            {% if trend > 0 %}▲{% elif trend < 0 %}▼{% else %}-{% endif %}{{ trend|abs }}%
-          </span>
-          {% else %}
-          <span class="stat-trend trend-neutral">- 0%</span>
-          {% endif %}
-        </div>
+        <div class="stat-value">{{ render_stat_value(stats, "users") }}</div>
       </div>
-      
+
       <div class="stat-box">
         <div class="stat-label">Challenges</div>
-        <div class="stat-value">
-          {{ stats.visible_challenges if stats and stats.visible_challenges else 0 }}
-          <span class="stat-trend trend-neutral"></span>
-        </div>
+        <div class="stat-value">{{ render_stat_value(stats, "challenges", show_neutral=False) }}</div>
       </div>
     </div>
   </div>
-  
+
   <div class="stat-card">
     <div class="stat-card-header">Activity History</div>
     <div class="chart-container">
-      <canvas id="activity-chart" 
+      <canvas id="activity-chart"
               data-labels='{{ stats.chart_data.labels|tojson|safe if stats and stats.chart_data and stats.chart_data.labels else "[]" }}'
               data-solves='{{ stats.chart_data.solves|tojson if stats and stats.chart_data and stats.chart_data.solves else "[]" }}'
               data-users='{{ stats.chart_data.users|tojson if stats and stats.chart_data and stats.chart_data.users else "[]" }}'>
       </canvas>
     </div>
   </div>
-  
+
   <div class="stat-card">
     <div class="stat-card-header">Recent Awardees</div>
     <div class="recent-awards">
@@ -80,7 +68,7 @@
       {% endif %}
     </div>
   </div>
-  
+
   <div class="stat-card">
     <div class="stat-card-header">Recent Solves</div>
     <div class="recent-activity">
@@ -105,7 +93,7 @@ function initializeChart() {
     setTimeout(initializeChart, 100);
     return;
   }
-  
+
   const parseData = (attr, fallback) => {
     try {
       const value = chartCanvas.dataset[attr];
@@ -115,16 +103,16 @@ function initializeChart() {
       return fallback;
     }
   };
-  
+
   const labels = parseData('labels', ['Today', '1w ago', '1mo ago', '2mo ago']);
   const solvesData = parseData('solves', [0, 0, 0, 0]);
   const usersData = parseData('users', [0, 0, 0, 0]);
-  
+
   // Chart.js config
   Chart.defaults.color = '#ffffff';
   Chart.defaults.font.family = "'Space Mono', 'JetBrains Mono', 'Consolas', monospace";
   Chart.defaults.font.size = 9;
-  
+
   new Chart(chartCanvas.getContext('2d'), {
     type: 'bar',
     data: {
@@ -155,8 +143,8 @@ function initializeChart() {
       },
       scales: {
         x: {
-          grid: { 
-            display: false 
+          grid: {
+            display: false
           },
           ticks: {
             color: '#747474',
@@ -166,7 +154,7 @@ function initializeChart() {
         },
         y: {
           beginAtZero: true,
-          grid: { 
+          grid: {
             color: 'rgba(72, 72, 72, 0.3)'
           },
           ticks: {
@@ -175,7 +163,7 @@ function initializeChart() {
         }
       },
       plugins: {
-        legend: { 
+        legend: {
           display: false
         },
         tooltip: {

--- a/dojo_theme/templates/dojo.html
+++ b/dojo_theme/templates/dojo.html
@@ -47,46 +47,8 @@
 
   {% if dojo.modules %}
   <h2 class="row">Stats</h2>
-  <br>
-  <div class="row">
-    <p>
-      <b>Hacking Now:</b> <code>{{ stats["active"] }}</code>
-      <br>
-      <b>Hackers:</b> <code>{{ "{:,}".format(stats["users"]) }}</code>
-      <br>
-      <b>Challenges:</b> <code>{{ stats["visible_challenges"] }}</code>
-      <br>
-      <b>Solves:</b> <code>{{ "{:,}".format(stats["solves"]) }}</code>
-      {% if awards %}
-      <br>
-      <b>Awardees:</b> <code>{{ "{:,}".format(awards|length) }}</code>
-      <br>
-      <b>Earliest Awardees:</b>
-      {% for award in awards[-5:][::-1] %}
-      <span title="Awarded on {{award.date}}.">
-        <code>
-          <a href="{{ url_for('pwncollege_users.view_other', user_id=award.user_id) }}">
-            {{award.user.name}}
-          </a>
-          {% if not loop.last %} &middot; {% endif %}
-        </code>
-      </span>
-      {% endfor %}
-      <br>
-      <b>Latest Awardees:</b>
-      {% for award in awards[:5] %}
-      <span title="Awarded on {{award.date}}.">
-        <code>
-          <a href="{{ url_for('pwncollege_users.view_other', user_id=award.user_id) }}">
-            {{award.user.name}}
-          </a>
-          {% if not loop.last %} &middot; {% endif %}
-        </code>
-      </span>
-      {% endfor %}
-      {% endif %}
-    </p>
-  </div>
+  {% include "components/stat_dashboard.html" %}
+  <div class="row"></div>
 
   <br>
 
@@ -129,4 +91,5 @@
 {% block scripts %}
 <script defer onload="loadScoreboard(30, 1);" src="{{ url_for('views.themes', path='js/dojo/scoreboard.js') }}"></script>
 <script defer src="{{ url_for('views.themes', path='js/dojo/copy.js') }}"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 {% endblock %}


### PR DESCRIPTION
Add Interactive Statistics Dashboard to Dojo Pages
This PR adds a statistics dashboard to the dojo pages.

Interactive Statistics Dashboard

Dashboard displays the following:
Total Solves (with trend indicators)
Currently Hacking (active users)
Unique Hackers (with trend indicators)
Total Challenges

Activity History Chart showing daily solves and users over time using Chart.js
Recent Awardees section highlighting latest belt/badge recipients
Recent Solves feed showing the most recent challenge completions -- this somewhat implements this #https://github.com/pwncollege/dojo/issues/664

Added additional statistics calculations in stats.py:
Historical trend analysis
Chart data for 4 time periods (Today, 1w ago, 1mo ago, 2mo ago)
Recent activity tracking

Visual Design:
![statsdashboard](https://github.com/user-attachments/assets/626cc1f7-dcd2-43f8-a01b-d34d01e1453f)
