### PR TITLE
active-module route - respect challenge visibility

### DIFF
--- a/dojo_plugin/pages/dojo.py
+++ b/dojo_plugin/pages/dojo.py
@@ -76,8 +76,8 @@ def active_module():
     g.dojo = active_challenge.dojo
 
     current_challenge = active_challenge
-    current_index = current_challenge.challenge_index
-    challenges = current_challenge.module.challenges
+    challenges = list(filter(lambda x: x.visible(), current_challenge.module.challenges))
+    current_index = challenges.index(current_challenge)
 
     previous_challenge = challenges[current_index - 1] if current_index > 0 else None
     next_challenge = challenges[current_index + 1] if current_index < (len(challenges) - 1) else None


### PR DESCRIPTION
Changes active-module route to respect challenge visibility.

active-module route is used by workspace quicknav UI to advance challenges.  Previously, hidden challenges can appear in the interface's next/prev UI elements, but fail to launch via the dojo api.