### PR TITLE
Fix a benign bug in dojo_initialize_files

### DIFF
--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -266,7 +266,7 @@ def load_dojo_subyamls(data, dojo_dir):
 def dojo_initialize_files(data, dojo_dir):
     for dojo_file in data.get("files", []):
         assert is_admin(), "yml-specified files support requires admin privileges"
-        rel_path = dojo_dir / dojo_file["path"]
+        rel_path = dojo_file["path"]
 
         abs_path = dojo_dir / rel_path
         assert not abs_path.is_symlink(), f"{rel_path} is a symbolic link!"


### PR DESCRIPTION
There's a small bug in dojo_initialize_files which incorrectly defines the rel_path as an absolute path, and then defines abs_path as dojo_dir / rel_path (which can be thought of as doing dojo_dir / dojo_dir / dojo_file["path"]). This doesn't cause problems because dojo_dir is an abolute path, and python's pathlib ignores attempts to prepend an absolute path. I figured it's still worth fixing.