### PR TITLE
Update nix to 25.05

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 
 RUN apk add --no-cache nix
-
+RUN apk add --no-cache git
 RUN cat >> /etc/nix/nix.conf <<EOF
 experimental-features = nix-command flakes
 substituters = https://cache.nixos.org/

--- a/workspace/additional/additional.nix
+++ b/workspace/additional/additional.nix
@@ -37,7 +37,7 @@ let
 
     network = [ netcat-openbsd tcpdump wireshark termshark nmap burpsuite ];
 
-    debugging = [ strace ltrace gdb pwndbg gef bata24-gef ];
+    debugging = [ strace ltrace gdb gef bata24-gef ];
 
     reversing = [ file ghidra ida-free radare2 cutter angr-management binaryninja-free ];
 

--- a/workspace/flake.nix
+++ b/workspace/flake.nix
@@ -2,17 +2,19 @@
   description = "DOJO Workspace Flake";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
-    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs-24-11.url = "github:NixOS/nixpkgs/nixos-24.11";
     nixpkgs-pr-angr-management.url = "github:NixOS/nixpkgs/pull/360310/head";
+    pwndbg.url = "github:pwndbg/pwndbg";
   };
 
   outputs =
     {
       self,
       nixpkgs,
-      nixpkgs-unstable,
+      nixpkgs-24-11,
       nixpkgs-pr-angr-management,
+      pwndbg,
     }:
     {
       packages = {
@@ -24,13 +26,13 @@
               allowBroken = true; # angr is currently marked "broken" in nixpkgs, but works fine (without unicorn)
             };
 
-            binaryninja-free-overlay = self: super: {
-              binaryninja-free = (import nixpkgs-unstable { inherit system config; }).binaryninja-free;
-            };
-
             angr-management-overlay = self: super: {
               angr-management = (import nixpkgs-pr-angr-management { inherit system config; }).angr-management;
             };
+
+	    ida-free-overlay = self: super: {
+		ida-free = (import nixpkgs-24-11 { inherit system config; }).ida-free;
+	    };
 
             sage-overlay = final: prev: {
               sage = prev.sage.override {
@@ -45,8 +47,8 @@
             pkgs = import nixpkgs {
               inherit system config;
               overlays = [
-                binaryninja-free-overlay
                 angr-management-overlay
+		ida-free-overlay
                 sage-overlay
               ];
             };
@@ -83,6 +85,7 @@
               curl
               findutils
               gawk
+	      git
               glibc
               glibc.static
               glibcLocales
@@ -111,7 +114,9 @@
               desktop-service
             ];
 
-            fullPackages = corePackages ++ additional.packages;
+            fullPackages = corePackages ++ additional.packages ++ [
+              pwndbg.packages.${system}.default 
+            ];
 
             buildDojoEnv =
               name: paths:


### PR DESCRIPTION
Pwndbg was removed from nixpkgs in 25.05 so instead referencing their flake.

Using ida-free version 8 from nix 24.11
ida-free moves to version 9 in 25.05 which no longer serves the binary due to a change in license. 