### PR TITLE
Navbar Flag Submission Async Fix

### DIFF
--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -329,6 +329,35 @@ function surveySubmit(data, item) {
 }
 
 
+function markChallengeAsSolved(item) {
+    const unsolved_flag = item.find(".challenge-unsolved");
+    if (unsolved_flag.hasClass("challenge-solved")) {
+        return;
+    }
+
+    unsolved_flag.removeClass("challenge-unsolved");
+    unsolved_flag.addClass("challenge-solved");
+
+    const total_solves = item.find(".total-solves");
+    total_solves.text(
+        (parseInt(total_solves.text().trim().split(" ")[0]) + 1) + " solves"
+    );
+
+    const answer_input = item.find("#challenge-input");
+    answer_input.val("");
+    answer_input.removeClass("wrong");
+    answer_input.addClass("correct");
+
+    const header = item.find('[id^="challenges-header-"]');
+    const current_challenge_id = parseInt(header.attr('id').match(/(\d+)$/)[1]);
+    const next_challenge_button = $(`#challenges-header-button-${current_challenge_id + 1}`);
+
+    unlockChallenge(next_challenge_button);
+    checkUserAwards()
+        .then(handleAwardPopup)
+        .catch(error => console.error("Award check failed:", error));
+}
+
 $(() => {
     $(".accordion-item").on("show.bs.collapse", function (event) {
         $(event.currentTarget).find("iframe").each(function (i, iframe) {
@@ -340,12 +369,24 @@ $(() => {
         });
     });
 
+    const broadcast = new BroadcastChannel('broadcast');
+    broadcast.onmessage = (event) => {
+        if (event.data.msg === 'challengeSolved') {
+            const challenge_id = event.data.challenge_id;
+            const item = $(`input#challenge-id[value='${challenge_id}']`).closest(".accordion-item");
+            if (item.length) {
+                markChallengeAsSolved(item);
+            }
+        }
+    };
+
     $(".challenge-input").keyup(function (event) {
         if (event.keyCode == 13) {
             const submit = $(event.currentTarget).closest(".accordion-item").find("#challenge-submit");
             submit.click();
         }
     });
+
 
     $(".accordion-item").find("#challenge-submit").click(submitChallenge);
     $(".accordion-item").find("#challenge-start").click(startChallenge);

--- a/dojo_theme/static/js/dojo/navbar.js
+++ b/dojo_theme/static/js/dojo/navbar.js
@@ -205,11 +205,15 @@ function submitFlag(event) {
     result_notification.addClass('alert alert-warning alert-dismissable text-center');
     result_message.html("Loading...");
     result_notification.slideDown();
+
+    var timer = setTimeout(() => {
+        result_notification.slideUp();
+    }, 5000);
+
     if (submission === "pwn.college{practice}") {
         result_notification.removeClass();
         result_notification.addClass('alert alert-success alert-dismissable text-center');
-        result_message.html('You have submitted the \"practice\" flag from launching the challenge in Practice mode! This flag is not valid for scoring. Run the challenge in non-practice mode by pressing Start above, then use your solution to get the \"real\" flag and submit it!');
-        setTimeout(() => result_notification.slideUp(), 5000);
+        result_message.html('You have submitted the "practice" flag from launching the challenge in Practice mode! This flag is not valid for scoring. Run the challenge in non-practice mode by pressing Start above, then use your solution to get the "real" flag and submit it!');
         event.stopPropagation();
         return
     }
@@ -221,11 +225,25 @@ function submitFlag(event) {
             result_notification.addClass('alert alert-success alert-dismissable text-center');
             result_message.html('Flag submitted successfully!');
             $("#dropdown-challenge-input").val("");
+
+            const broadcast_send = new BroadcastChannel('broadcast');
+            broadcast_send.postMessage({
+                msg: 'challengeSolved',
+                challenge_id: body.challenge_id
+            });
         } else {
             result_notification.removeClass();
             result_notification.addClass('alert alert-danger alert-dismissable text-center');
             result_message.html('Flag submission failed: '+ result.message);
         }
+        clearTimeout(timer);
+        setTimeout(() => result_notification.slideUp(), 5000);
+    }).catch(err => {
+        const result = err.data;
+        result_notification.removeClass();
+        result_notification.addClass('alert alert-danger alert-dismissable text-center');
+        result_message.html('Flag submission failed: '+ result.message);
+        clearTimeout(timer);
         setTimeout(() => result_notification.slideUp(), 5000);
     });
     event.stopPropagation();


### PR DESCRIPTION
This is the fix to #741, it adds a way for the [`challenges.js`](https://github.com/pwncollege/dojo/blob/master/dojo_theme/static/js/dojo/challenges.js) and [`navbar.js`](https://github.com/pwncollege/dojo/blob/master/dojo_theme/static/js/dojo/navbar.js) to communicate in order to indicate the user submitted the flag reflecting it on the front end.