### PR TITLE
update seccomp profile location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ COPY <<EOF /etc/docker/daemon.json
 }
 EOF
 
-ADD https://raw.githubusercontent.com/moby/moby/master/profiles/seccomp/default.json /etc/docker/seccomp.json
+ADD https://raw.githubusercontent.com/moby/profiles/master/seccomp/default.json /etc/docker/seccomp.json
 
 RUN <<EOF
 cd /tmp


### PR DESCRIPTION
The moby project moved the seccomp profile to a different repo about two hours ago (https://github.com/moby/moby/commit/a600da91f47c2b2c8e2000cb0c5eb4992a289f61), which broke our builds. This updates the path to the new repo.