### PR TITLE
Allow specifying challenges as a resource type, ordered in with the other resources.

### DIFF
--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -442,8 +442,8 @@ class DojoModules(db.Model):
             items.append((resource.resource_index, resource))
         
         for challenge in self.challenges:
-            if challenge.original_index is not None:
-                index = challenge.original_index
+            if challenge.unified_index is not None:
+                index = challenge.unified_index
             else:
                 index = 1000 + challenge.challenge_index
             items.append((index, challenge))
@@ -497,7 +497,7 @@ class DojoChallenges(db.Model):
     description = db.Column(db.Text)
 
     data = db.Column(JSONB)
-    data_fields = ["image", "path_override", "importable", "allow_privileged", "progression_locked", "survey", "original_index"]
+    data_fields = ["image", "path_override", "importable", "allow_privileged", "progression_locked", "survey", "unified_index"]
     data_defaults = {
         "importable": True,
         "allow_privileged": True,

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -439,25 +439,17 @@ class DojoModules(db.Model):
         items = []
         
         for resource in self.resources:
-            items.append({
-                'type': 'resource',
-                'item': resource,
-                'index': resource.resource_index
-            })
+            items.append((resource.resource_index, resource))
         
         for challenge in self.challenges:
             if challenge.original_index is not None:
                 index = challenge.original_index
             else:
                 index = 1000 + challenge.challenge_index
-            items.append({
-                'type': 'challenge',
-                'item': challenge,
-                'index': index
-            })
+            items.append((index, challenge))
         
-        items.sort(key=lambda x: x['index'])
-        return items
+        items.sort(key=lambda x: x[0])
+        return [item for _, item in items]
 
     def visible_challenges(self, user=None):
         return [challenge for challenge in self.challenges if challenge.visible() or self.dojo.is_admin(user=user)]
@@ -486,6 +478,7 @@ class DojoModules(db.Model):
 
 class DojoChallenges(db.Model):
     __tablename__ = "dojo_challenges"
+    item_type = "challenge"
     __table_args__ = (
         db.ForeignKeyConstraint(["dojo_id"], ["dojos.dojo_id"], ondelete="CASCADE"),
         db.ForeignKeyConstraint(["dojo_id", "module_index"],
@@ -663,6 +656,7 @@ class SurveyResponses(db.Model):
 
 class DojoResources(db.Model):
     __tablename__ = "dojo_resources"
+    item_type = "resource"
 
     __table_args__ = (
         db.ForeignKeyConstraint(["dojo_id", "module_index"],

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -435,7 +435,7 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
     for module_data in dojo_data.get("modules", []):
         for resource_index, resource_data in enumerate(module_data.get("resources", [])):
             if resource_data.get("type") == "challenge":
-                resource_data["original_index"] = resource_index
+                resource_data["unified_index"] = resource_index
                 challenge_resources.append((module_data, resource_data))
             else:
                 regular_resources.append((module_data, resource_data))
@@ -458,7 +458,7 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
                     default=(assert_import_one(DojoChallenges.from_id(*import_ids(["dojo", "module", "challenge"], dojo_data, module_data, challenge_data)),
                                         f"Import challenge `{'/'.join(import_ids(['dojo', 'module', 'challenge'], dojo_data, module_data, challenge_data))}` does not exist")
                              if "import" in challenge_data else None),
-                    original_index=challenge_data.get("original_index"),
+                    unified_index=challenge_data.get("unified_index"),
                 )
                 for challenge_data in (
                     [r for m, r in challenge_resources if m == module_data] + 

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -182,6 +182,46 @@ DOJO_SPEC = Schema({
                 Optional("slides"): str,
                 **VISIBILITY,
             },
+            {
+                "type": "challenge",
+                "id": ID_REGEX,
+                "name": NAME_REGEX,
+                Optional("description"): str,
+                **VISIBILITY,
+                Optional("image"): IMAGE_REGEX,
+                Optional("allow_privileged"): bool,
+                Optional("importable"): bool,
+                Optional("progression_locked"): bool,
+                Optional("auxiliary"): dict,
+                Optional("import"): {
+                    Optional("dojo"): UNIQUE_ID_REGEX,
+                    Optional("module"): ID_REGEX,
+                    "challenge": ID_REGEX,
+                },
+                Optional("transfer"): {
+                    Optional("dojo"): UNIQUE_ID_REGEX,
+                    Optional("module"): ID_REGEX,
+                    "challenge": ID_REGEX,
+                },
+                Optional("survey"): Or(
+                    {
+                        "type": "multiplechoice",
+                        "prompt": str,
+                        Optional("probability"): float,
+                        "options": [str],
+                    },
+                    {
+                        "type": "thumb",
+                        "prompt": str,
+                        Optional("probability"): float,
+                    },
+                    {
+                        "type": "freeform",  
+                        "prompt": str,
+                        Optional("probability"): float,
+                    },
+                ),
+            },
         )],
 
         Optional("auxiliary", default={}, ignore_extra_keys=True): dict,
@@ -385,6 +425,16 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
         datas_import = [data.get("import", {}) for data in datas]
         return tuple(shadow(id, *datas_import) for id in attrs)
 
+    challenge_resources = []
+    regular_resources = []
+    for module_data in dojo_data.get("modules", []):
+        for resource_index, resource_data in enumerate(module_data.get("resources", [])):
+            if resource_data.get("type") == "challenge":
+                resource_data["original_index"] = resource_index
+                challenge_resources.append((module_data, resource_data))
+            else:
+                regular_resources.append((module_data, resource_data))
+
     dojo.modules = [
         DojoModules(
             **{kwarg: module_data.get(kwarg) for kwarg in ["id", "name", "description"]},
@@ -403,16 +453,22 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
                     default=(assert_import_one(DojoChallenges.from_id(*import_ids(["dojo", "module", "challenge"], dojo_data, module_data, challenge_data)),
                                         f"Import challenge `{'/'.join(import_ids(['dojo', 'module', 'challenge'], dojo_data, module_data, challenge_data))}` does not exist")
                              if "import" in challenge_data else None),
+                    original_index=challenge_data.get("original_index"),
                 )
-                for challenge_data in module_data["challenges"]
-            ] if "challenges" in module_data else None,
+                for challenge_data in (
+                    [r for m, r in challenge_resources if m == module_data] + 
+                    module_data.get("challenges", [])
+                )
+            ],
             resources = [
                 DojoResources(
                     **{kwarg: resource_data.get(kwarg) for kwarg in ["name", "type", "content", "video", "playlist", "slides"]},
                     visibility=visibility(DojoResourceVisibilities, dojo_data, module_data, resource_data),
+                    resource_index=resource_index,
                 )
-                for resource_data in module_data["resources"]
-            ] if "resources" in module_data else None,
+                for resource_index, resource_data in enumerate(module_data.get("resources", []))
+                if resource_data.get("type") != "challenge"
+            ],
             default=(assert_import_one(DojoModules.from_id(*import_ids(["dojo", "module"], dojo_data, module_data)),
                                 f"Import module `{'/'.join(import_ids(['dojo', 'module'], dojo_data, module_data))}` does not exist")
                      if "import" in module_data else None),

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -183,6 +183,11 @@ DOJO_SPEC = Schema({
                 **VISIBILITY,
             },
             {
+                "type": "header",
+                "content": str,
+                **VISIBILITY,
+            },
+            {
                 "type": "challenge",
                 "id": ID_REGEX,
                 "name": NAME_REGEX,

--- a/dojo_theme/static/css/custom.css
+++ b/dojo_theme/static/css/custom.css
@@ -227,6 +227,11 @@ p[data-hide="true"] {
     width: 2.5rem;
 }
 
+.resource-icon {
+    width: 2.5rem;
+    color: #6c757d;
+}
+
 /* Styles for greying out the challenges button if it is disabled */
 .accordion-item-header:has(.disabled)  {
     opacity: 0.6 !important;

--- a/dojo_theme/templates/macros/widgets.html
+++ b/dojo_theme/templates/macros/widgets.html
@@ -45,17 +45,17 @@
   </a>
 {%- endmacro %}
 
-{% macro accordion_item(accordion_id, item_id, is_disabled) %}
+{% macro accordion_item(accordion_id, item_id, is_disabled, challenge_index=None) %}
   <div class="accordion-item">
     <div class="accordion-item-header" id="{{ accordion_id }}-header-{{ item_id }}">
       <h2 class="mb-0 button-wrapper">
-        <button id="{{ accordion_id }}-header-button-{{ item_id }}" class="btn btn-link text-decoration-none w-100 challenge-button-2 collapsed {% if is_disabled %}disabled{% endif %}" type="button" data-toggle="collapse" data-target="#{{ accordion_id }}-body-{{ item_id }}" aria-expanded="false" aria-controls="{{ accordion_id }}-body-{{ item_id }}">
+        <button id="{% if challenge_index %}challenges-header-button-{{ challenge_index }}{% else %}{{ accordion_id }}-header-button-{{ item_id }}{% endif %}" class="btn btn-link text-decoration-none w-100 challenge-button-2 collapsed {% if is_disabled %}disabled{% endif %}" type="button" data-toggle="collapse" data-target="#{% if challenge_index %}challenges-body-{{ challenge_index }}{% else %}{{ accordion_id }}-body-{{ item_id }}{% endif %}" aria-expanded="false" aria-controls="{% if challenge_index %}challenges-body-{{ challenge_index }}{% else %}{{ accordion_id }}-body-{{ item_id }}{% endif %}">
           {{ caller(True) }}
         </button>
       </h2>
     </div>
 
-    <div id="{{ accordion_id }}-body-{{ item_id }}" class="collapse" aria-labelledby="{{ accordion_id }}-header-{{ item_id }}" data-parent="#{{ accordion_id }}">
+    <div id="{% if challenge_index %}challenges-body-{{ challenge_index }}{% else %}{{ accordion_id }}-body-{{ item_id }}{% endif %}" class="collapse" aria-labelledby="{{ accordion_id }}-header-{{ item_id }}" data-parent="#{{ accordion_id }}">
       <div class="accordion-item-body">
         {{ caller(False) }}
       </div>

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -32,9 +32,9 @@
 
   <div class="accordion" id="module-content">
     {% set ns = namespace(challenge_count=0) %}
-    {% for entry in module.unified_items %}
-      {% if entry.type == 'resource' %}
-        {% set resource = entry.item %}
+    {% for item in module.unified_items %}
+      {% if item.item_type == 'resource' %}
+        {% set resource = item %}
         {% if resource.type == 'header' %}
           <br>
           <h2>{{ resource.content }}</h2>
@@ -70,17 +70,17 @@
           {% endif %}
         {% endcall %}
         {% endif %}
-      {% elif entry.type == 'challenge' and (module.show_challenges or dojo.is_admin()) %}
-        {% set challenge = entry.item %}
+      {% elif item.item_type == 'challenge' and (module.show_challenges or dojo.is_admin()) %}
+        {% set challenge = item %}
         {% set ns.challenge_count = ns.challenge_count + 1 %}
         {% set solved = "challenge-solved" if challenge.challenge_id in user_solves else "challenge-unsolved" %}
         {% set active = "challenge-active" if challenge.challenge_id == current_dojo_challenge.challenge_id else "" %}
         
         {% set previous_challenge = None %}
         {% set visible_challenges = [] %}
-        {% for prev_entry in module.unified_items[:loop.index0] %}
-          {% if prev_entry.type == 'challenge' and (module.show_challenges or dojo.is_admin()) %}
-            {% set _ = visible_challenges.append(prev_entry.item) %}
+        {% for prev_item in module.unified_items[:loop.index0] %}
+          {% if prev_item.item_type == 'challenge' and (module.show_challenges or dojo.is_admin()) %}
+            {% set _ = visible_challenges.append(prev_item) %}
           {% endif %}
         {% endfor %}
         {% if visible_challenges %}
@@ -217,9 +217,9 @@
   {% endif %}
 
   {% set visible_challenges = [] %}
-  {% for entry in module.unified_items %}
-    {% if entry.type == 'challenge' %}
-      {% set _ = visible_challenges.append(entry.item) %}
+  {% for item in module.unified_items %}
+    {% if item.item_type == 'challenge' %}
+      {% set _ = visible_challenges.append(item) %}
     {% endif %}
   {% endfor %}
   

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -35,6 +35,10 @@
     {% for entry in module.unified_items %}
       {% if entry.type == 'resource' %}
         {% set resource = entry.item %}
+        {% if resource.type == 'header' %}
+          <br>
+          <h2>{{ resource.content }}</h2>
+        {% else %}
         {% call(header) accordion_item("module-content", loop.index) %}
           {% if header %}
             {% set resource_icon = "fa-video" if resource.type == "lecture" else "fa-file-alt" %}
@@ -65,6 +69,7 @@
             {% endif %}
           {% endif %}
         {% endcall %}
+        {% endif %}
       {% elif entry.type == 'challenge' and (module.show_challenges or dojo.is_admin()) %}
         {% set challenge = entry.item %}
         {% set ns.challenge_count = ns.challenge_count + 1 %}

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -67,6 +67,7 @@
         {% endcall %}
       {% elif entry.type == 'challenge' and (module.show_challenges or dojo.is_admin()) %}
         {% set challenge = entry.item %}
+        {% set ns.challenge_count = ns.challenge_count + 1 %}
         {% set solved = "challenge-solved" if challenge.challenge_id in user_solves else "challenge-unsolved" %}
         {% set active = "challenge-active" if challenge.challenge_id == current_dojo_challenge.challenge_id else "" %}
         
@@ -89,9 +90,9 @@
         {% set hidden = not challenge.visible() %}
         {% set icon = "fa-lock" if lock_challenge else "fa-flag" %}
 
-        {% call(header) accordion_item("module-content", loop.index, lock_challenge) %}
+        {% call(header) accordion_item("module-content", loop.index, lock_challenge, challenge_index=ns.challenge_count) %}
           {% if header %}
-            <h4 class="accordion-item-name challenge-name {{ active }}">
+            <h4 class="accordion-item-name challenge-name {{ active }}" data-challenge-index="{{ ns.challenge_count }}" data-challenge-name="{{ challenge.name or challenge.id }}" id="challenges-header-{{ ns.challenge_count }}">
                 <i class="challenge-icon pr-3 fas {{ icon }} {{ solved }} "></i>
                 {% if lock_challenge %}
                 <div class="challenge-text-wrapper">
@@ -203,7 +204,6 @@
             </div>
           {% endif %}
         {% endcall %}
-        {% set ns.challenge_count = ns.challenge_count + 1 %}
       {% endif %}
     {% endfor %}
   </div>

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -23,186 +23,198 @@
   <br>
   {% endif %}
 
-  {% if module.resources %}
-  <h2>Lectures and Reading</h2>
+  {% if module.resources or module.challenges %}
+  <h2>Module Content</h2>
 
-  <div class="accordion" id="resources">
-    {% for resource in module.resources %}
-      {% call(header) accordion_item("resources", loop.index) %}
-        {% if header %}
-          <h4 class="accordion-item-name">{{ resource.name }}</h4>
-        {% else %}
-          {% if resource.type == "lecture" %}
-          {% if resource.video %}
-          {% set src = "https://www.youtube.com/embed/" + resource.video + "?" + ("list=" + resource.playlist + "&" if resource.playlist else "") + "rel=0" %}
-          <div class="embed-responsive embed-responsive-16by9">
-            <iframe class="embed-responsive-item" data-src="{{ src }}" title="YouTube video player" allowfullscreen></iframe>
-          </div>
-          {% endif %}
-          {% if resource.slides %}
-          {% set src = "https://docs.google.com/presentation/d/" + resource.slides + "/embed" %}
-          <div class="embed-responsive embed-responsive-16by9">
-            <iframe class="embed-responsive-item" data-src="{{ src }}"></iframe>
-          </div>
-          <button onclick="window.open('{{ src.replace('/embed', '') }}', '_blank')" class="btn btn-primary">Open Slides in New Window</button>
-          {% endif %}
-
-          {% elif resource.type == "markdown" %}
-          <div class="embed-responsive">
-            {{ resource.content | markdown }}
-          </div>
-          {% endif %}
-        {% endif %}
-      {% endcall %}
-    {% endfor %}
-  </div>
-
-  <br>
-  {% endif %}
-
-  {% if challenges and (module.show_challenges or dojo.is_admin()) %}
-  <h2>{% if dojo.is_admin() %}(Hidden) {% endif %}Challenges</h2>
-
-  {% if dojo.is_admin() %}
+  {% if dojo.is_admin() and not module.show_challenges %}
   <p><i>This module's challenges are hidden from view. You can see them as the dojo's administrator.</i></p>
   {% endif %}
 
-  <div class="accordion" id="challenges">
-    {% for challenge in challenges %}
+  <div class="accordion" id="module-content">
+    {% set ns = namespace(challenge_count=0) %}
+    {% for entry in module.unified_items %}
+      {% if entry.type == 'resource' %}
+        {% set resource = entry.item %}
+        {% call(header) accordion_item("module-content", loop.index) %}
+          {% if header %}
+            <h4 class="accordion-item-name">{{ resource.name }}</h4>
+          {% else %}
+            {% if resource.type == "lecture" %}
+            {% if resource.video %}
+            {% set src = "https://www.youtube.com/embed/" + resource.video + "?" + ("list=" + resource.playlist + "&" if resource.playlist else "") + "rel=0" %}
+            <div class="embed-responsive embed-responsive-16by9">
+              <iframe class="embed-responsive-item" data-src="{{ src }}" title="YouTube video player" allowfullscreen></iframe>
+            </div>
+            {% endif %}
+            {% if resource.slides %}
+            {% set src = "https://docs.google.com/presentation/d/" + resource.slides + "/embed" %}
+            <div class="embed-responsive embed-responsive-16by9">
+              <iframe class="embed-responsive-item" data-src="{{ src }}"></iframe>
+            </div>
+            <button onclick="window.open('{{ src.replace('/embed', '') }}', '_blank')" class="btn btn-primary">Open Slides in New Window</button>
+            {% endif %}
 
-      {% set solved = "challenge-solved" if challenge.challenge_id in user_solves else "challenge-unsolved" %}
-      {% set active = "challenge-active" if challenge.challenge_id == current_dojo_challenge.challenge_id else "" %}
-      {% set previous_challenge = challenges[loop.index0 - 1] %}
-      {% set progression_locked = challenge.progression_locked and not loop.first %}
-      {% set lock_challenge = progression_locked
-        and previous_challenge.challenge_id not in user_solves
-        and solved == "challenge-unsolved"
-        and not dojo.is_admin() %}
-      {% set hidden = not challenge.visible() %}
-      {% set icon = "fa-lock" if lock_challenge else "fa-flag" %}
+            {% elif resource.type == "markdown" %}
+            <div class="embed-responsive">
+              {{ resource.content | markdown }}
+            </div>
+            {% endif %}
+          {% endif %}
+        {% endcall %}
+      {% elif entry.type == 'challenge' and (module.show_challenges or dojo.is_admin()) %}
+        {% set challenge = entry.item %}
+        {% set solved = "challenge-solved" if challenge.challenge_id in user_solves else "challenge-unsolved" %}
+        {% set active = "challenge-active" if challenge.challenge_id == current_dojo_challenge.challenge_id else "" %}
+        
+        {% set previous_challenge = None %}
+        {% set visible_challenges = [] %}
+        {% for prev_entry in module.unified_items[:loop.index0] %}
+          {% if prev_entry.type == 'challenge' and (module.show_challenges or dojo.is_admin()) %}
+            {% set _ = visible_challenges.append(prev_entry.item) %}
+          {% endif %}
+        {% endfor %}
+        {% if visible_challenges %}
+          {% set previous_challenge = visible_challenges[-1] %}
+        {% endif %}
+        
+        {% set progression_locked = challenge.progression_locked and previous_challenge %}
+        {% set lock_challenge = progression_locked
+          and previous_challenge.challenge_id not in user_solves
+          and solved == "challenge-unsolved"
+          and not dojo.is_admin() %}
+        {% set hidden = not challenge.visible() %}
+        {% set icon = "fa-lock" if lock_challenge else "fa-flag" %}
 
-      {% call(header) accordion_item("challenges", loop.index, lock_challenge) %}
-        {% if header %}
-          <h4 class="accordion-item-name challenge-name {{ active }}">
-              <i class="challenge-icon pr-3 fas {{ icon }} {{ solved }} "></i>
-              {% if lock_challenge %}
-              <div class="challenge-text-wrapper">
-                <span class="challenge-name-text">{{ challenge.name or challenge.id }}</span>
-                <span class="challenge-locked-text">Solve <strong></string><span style="color: white">{{ previous_challenge.name or previous_challenge.id }}</span></strong> to unlock this challenge</span>
-                <!-- Invisible placeholder has the same text as challenge-name-text and is used so that the button is sized to fit the text properly -->
-                <span class="invisible-placeholder pr-2">{{ challenge.name or challenge.id }}</span>
-              </div>
-              {% else %}
-              <span class="pr-2">{{ challenge.name or challenge.id }}</span>
-              {% endif %}
-              {% if dojo.is_admin() and (progression_locked or hidden) %}
-              <small><small><small>
-                    <i>
-                      {% if progression_locked %}progression locked{% endif %}
-                      {% if progression_locked and hidden %} & {% endif %}
-                      {% if hidden %}hidden{% endif %}
-                    </i>
-                    &mdash; this challenge is accessible because you are this dojo's administrator
-              </small></small></small>
-              {% endif %}
-          </h4>
-          <span class="challenge-header-right">
-            {% if challenge_container_counts.get(challenge.id, 0) > 0 %}
-            <span class="total-hackers">
-              {{ challenge_container_counts.get(challenge.id, 0) }} hacking,
-            </span>
-            {% endif %}
-            <span class="total-solves">
-              {{ total_solves.get(challenge.challenge_id, 0) }} solves
-            </span>
-          </span>
-        {% else %}
-          <div class="embed-responsive challenge-description">
-            {% if lock_challenge %}
-              <p><em>This challenge is locked</em></p>
-            {% else %}
-              {{ challenge.description | markdown }}
-            {% endif %}
-          </div>
-          <div class="row">
-            <div class="col-sm-{% if challenge.allow_privileged %}6{% else %}12{% endif %} form-group text-center">
-              <button id="challenge-start" type="submit" class="btn btn-md btn-outline-secondary w-100">
-                <span class="d-sm-block d-md-block d-lg-block">
-                  <i class="fas fa-play fa-2x pr-3"></i>Start
-                </span>
-              </button>
-            </div>
-            {% if challenge.allow_privileged %}
-            <div class="col-sm-6 form-group text-center">
-              <button id="challenge-practice" type="submit" class="btn btn-md btn-outline-secondary w-100">
-                <span class="d-sm-block d-md-block d-lg-block">
-                  <i class="fas fa-flask fa-2x pr-3"></i>Practice
-                </span>
-              </button>
-            </div>
-            {% endif %}
-          </div>
-          <div class="row submit-row">
-            <div class="col-md-9 form-group">
-              <input id="module" type="hidden" value="{{ challenge.module.id }}">
-              <input id="challenge" type="hidden" value="{{ challenge.id }}">
-              <input id="challenge-id" type="hidden" value="{{ challenge.challenge_id }}">
-              <input id="challenge-input" class="challenge-input form-control" type="text" name="answer" placeholder="Flag">
-            </div>
-            <div class="col-md-3 form-group key-submit">
-              <button id="challenge-submit" type="submit" class="challenge-submit btn btn-md btn-outline-secondary float-right w-100 h-100">
-                Submit
-              </button>
-            </div>
-          </div>
-          <div class="row notification-row">
-	          <div class="col-md-12">
-	            <div id="result-notification" class="alert alert-dismissable text-center w-100" role="alert" style="display: none;">
-		            <strong id="result-message"></strong>
-	            </div>
-	          </div>
-	        </div>
-          <div class="row survey-row">
-            <div class="col-md-12">
-              <div id="survey-notification" class="survey alert-dismissable w-100" role="alert" style="display: none;">
-                <span id="survey-prompt" class="survey-prompt">{{ challenge.survey.prompt }}</span>
-                {% if challenge.survey.type == "thumb" %}
-                <div id="survey-thumb" class="survey-thumb">
-                  <i id="survey-thumbs-up" class="fa fa-thumbs-up"></i>
-                  <i id="survey-thumbs-down" class="fa fa-thumbs-down"></i>
+        {% call(header) accordion_item("module-content", loop.index, lock_challenge) %}
+          {% if header %}
+            <h4 class="accordion-item-name challenge-name {{ active }}">
+                <i class="challenge-icon pr-3 fas {{ icon }} {{ solved }} "></i>
+                {% if lock_challenge %}
+                <div class="challenge-text-wrapper">
+                  <span class="challenge-name-text">{{ challenge.name or challenge.id }}</span>
+                  <span class="challenge-locked-text">Solve <strong></string><span style="color: white">{{ previous_challenge.name or previous_challenge.id }}</span></strong> to unlock this challenge</span>
+                  <span class="invisible-placeholder pr-2">{{ challenge.name or challenge.id }}</span>
                 </div>
-                {% elif challenge.survey.type == "freeform" %}
-                <div id="survey-freeresponse">
-                  <div class="row survey-freeresponse-row">
-                    <div class="col-md-9 form-group">
-                      <input id="survey-freeresponse-input" class="form-control survey-text-input" type="text" name="answer">
-                    </div>
-                    <div class="col-md-3 form-group key-submit">
-                      <button id="survey-submit" type="submit" class="btn btn-md btn-outline-secondary float-right w-100 h-100 survey-submit">
-                        Submit
-                      </button>
+                {% else %}
+                <span class="pr-2">{{ challenge.name or challenge.id }}</span>
+                {% endif %}
+                {% if dojo.is_admin() and (progression_locked or hidden) %}
+                <small><small><small>
+                      <i>
+                        {% if progression_locked %}progression locked{% endif %}
+                        {% if progression_locked and hidden %} & {% endif %}
+                        {% if hidden %}hidden{% endif %}
+                      </i>
+                      &mdash; this challenge is accessible because you are this dojo's administrator
+                </small></small></small>
+                {% endif %}
+            </h4>
+            <span class="challenge-header-right">
+              {% if challenge_container_counts.get(challenge.id, 0) > 0 %}
+              <span class="total-hackers">
+                {{ challenge_container_counts.get(challenge.id, 0) }} hacking,
+              </span>
+              {% endif %}
+              <span class="total-solves">
+                {{ total_solves.get(challenge.challenge_id, 0) }} solves
+              </span>
+            </span>
+          {% else %}
+            <div class="embed-responsive challenge-description">
+              {% if lock_challenge %}
+                <p><em>This challenge is locked</em></p>
+              {% else %}
+                {{ challenge.description | markdown }}
+              {% endif %}
+            </div>
+            <div class="row">
+              <div class="col-sm-{% if challenge.allow_privileged %}6{% else %}12{% endif %} form-group text-center">
+                <button id="challenge-start" type="submit" class="btn btn-md btn-outline-secondary w-100">
+                  <span class="d-sm-block d-md-block d-lg-block">
+                    <i class="fas fa-play fa-2x pr-3"></i>Start
+                  </span>
+                </button>
+              </div>
+              {% if challenge.allow_privileged %}
+              <div class="col-sm-6 form-group text-center">
+                <button id="challenge-practice" type="submit" class="btn btn-md btn-outline-secondary w-100">
+                  <span class="d-sm-block d-md-block d-lg-block">
+                    <i class="fas fa-flask fa-2x pr-3"></i>Practice
+                  </span>
+                </button>
+              </div>
+              {% endif %}
+            </div>
+            <div class="row submit-row">
+              <div class="col-md-9 form-group">
+                <input id="module" type="hidden" value="{{ challenge.module.id }}">
+                <input id="challenge" type="hidden" value="{{ challenge.id }}">
+                <input id="challenge-id" type="hidden" value="{{ challenge.challenge_id }}">
+                <input id="challenge-input" class="challenge-input form-control" type="text" name="answer" placeholder="Flag">
+              </div>
+              <div class="col-md-3 form-group key-submit">
+                <button id="challenge-submit" type="submit" class="challenge-submit btn btn-md btn-outline-secondary float-right w-100 h-100">
+                  Submit
+                </button>
+              </div>
+            </div>
+            <div class="row notification-row">
+              <div class="col-md-12">
+                <div id="result-notification" class="alert alert-dismissable text-center w-100" role="alert" style="display: none;">
+                  <strong id="result-message"></strong>
+                </div>
+              </div>
+            </div>
+            <div class="row survey-row">
+              <div class="col-md-12">
+                <div id="survey-notification" class="survey alert-dismissable w-100" role="alert" style="display: none;">
+                  <span id="survey-prompt" class="survey-prompt">{{ challenge.survey.prompt }}</span>
+                  {% if challenge.survey.type == "thumb" %}
+                  <div id="survey-thumb" class="survey-thumb">
+                    <i id="survey-thumbs-up" class="fa fa-thumbs-up"></i>
+                    <i id="survey-thumbs-down" class="fa fa-thumbs-down"></i>
+                  </div>
+                  {% elif challenge.survey.type == "freeform" %}
+                  <div id="survey-freeresponse">
+                    <div class="row survey-freeresponse-row">
+                      <div class="col-md-9 form-group">
+                        <input id="survey-freeresponse-input" class="form-control survey-text-input" type="text" name="answer">
+                      </div>
+                      <div class="col-md-3 form-group key-submit">
+                        <button id="survey-submit" type="submit" class="btn btn-md btn-outline-secondary float-right w-100 h-100 survey-submit">
+                          Submit
+                        </button>
+                      </div>
                     </div>
                   </div>
+                  {% elif challenge.survey.type == "multiplechoice" %}
+                  <div id="survey-multiplechoice" class="survey-multiplechoice">
+                    {% for option in challenge.survey.options %}
+                    <div class="survey-option" data-id={{ loop.index - 1 }}>{{ option }}</div>
+                    {% endfor %}
+                  </div>
+                  {% endif %}
                 </div>
-                {% elif challenge.survey.type == "multiplechoice" %}
-                <div id="survey-multiplechoice" class="survey-multiplechoice">
-                  {% for option in challenge.survey.options %}
-                  <div class="survey-option" data-id={{ loop.index - 1 }}>{{ option }}</div>
-                  {% endfor %}
-                </div>
-                {% endif %}
               </div>
             </div>
-          </div>
-        {% endif %}
-      {% endcall %}
+          {% endif %}
+        {% endcall %}
+        {% set ns.challenge_count = ns.challenge_count + 1 %}
+      {% endif %}
     {% endfor %}
   </div>
 
   <br>
   {% endif %}
 
-  {% if challenges and module.show_scoreboard %}
+  {% set visible_challenges = [] %}
+  {% for entry in module.unified_items %}
+    {% if entry.type == 'challenge' %}
+      {% set _ = visible_challenges.append(entry.item) %}
+    {% endif %}
+  {% endfor %}
+  
+  {% if visible_challenges and module.show_scoreboard %}
 
   <h2 class="row" id="scoreboard-heading">30-Day Scoreboard:</h2>
   <p>This scoreboard reflects solves for challenges in this module after the module launched in this dojo.</p>

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -37,7 +37,11 @@
         {% set resource = entry.item %}
         {% call(header) accordion_item("module-content", loop.index) %}
           {% if header %}
-            <h4 class="accordion-item-name">{{ resource.name }}</h4>
+            {% set resource_icon = "fa-video" if resource.type == "lecture" else "fa-file-alt" %}
+            <h4 class="accordion-item-name">
+              <i class="resource-icon pr-3 fas {{ resource_icon }}"></i>
+              <span class="pr-2">{{ resource.name }}</span>
+            </h4>
           {% else %}
             {% if resource.type == "lecture" %}
             {% if resource.video %}

--- a/test/dojos/module_resources_dojo.yml
+++ b/test/dojos/module_resources_dojo.yml
@@ -15,6 +15,8 @@ modules:
         type: markdown
         content: |
           Test content B with unique string: TESTB123
+      - type: header
+        content: Advanced Section
       - name: "Resource C"
         type: lecture
         video: hIK1Dfjxq4E

--- a/test/dojos/module_resources_dojo.yml
+++ b/test/dojos/module_resources_dojo.yml
@@ -20,6 +20,13 @@ modules:
         video: hIK1Dfjxq4E
         slides: 1NjoOj03eQsjnZWhm-A3IsxTVqeWUqFvR4wgfXnhsnu4
         playlist: PLHhKcdBlprMfIBVorNvOfY5UiHJmOk9nh
+      - name: "Challenge A"
+        id: test
+        type: challenge
+        import:
+          dojo: example
+          module: hello
+          challenge: apple
       - name: "Resource D"
         type: markdown
         content: |
@@ -28,4 +35,10 @@ modules:
         type: lecture
         video: 1H1V1HkVt3k
         slides: 1_xdrCm136NzcDl9bqSgAEQuigUHkNjkKmamhaej296Q
-    challenges: []
+    challenges:
+      - name: "Challenge B"
+        id: testb
+        import:
+          dojo: example
+          module: hello
+          challenge: banana

--- a/test/dojos/module_resources_dojo.yml
+++ b/test/dojos/module_resources_dojo.yml
@@ -1,0 +1,31 @@
+id: module-resources-test
+name: Module Resources Test
+description: Test dojo for module resources
+
+modules:
+  - id: test
+    name: Test Module
+    description: Test module with mixed resources
+    resources:
+      - name: "Resource A"
+        type: lecture
+        video: hh4XAU6XYP0
+        slides: 14ZJRIyf0HnoYO1N8GI5ygE-ZVgdhjJrvzkETFLz7NIo
+      - name: "Resource B" 
+        type: markdown
+        content: |
+          Test content B with unique string: TESTB123
+      - name: "Resource C"
+        type: lecture
+        video: hIK1Dfjxq4E
+        slides: 1NjoOj03eQsjnZWhm-A3IsxTVqeWUqFvR4wgfXnhsnu4
+        playlist: PLHhKcdBlprMfIBVorNvOfY5UiHJmOk9nh
+      - name: "Resource D"
+        type: markdown
+        content: |
+          Test content D with unique string: TESTD456
+      - name: "Resource E"
+        type: lecture
+        video: 1H1V1HkVt3k
+        slides: 1_xdrCm136NzcDl9bqSgAEQuigUHkNjkKmamhaej296Q
+    challenges: []

--- a/test/test_module_resources.py
+++ b/test/test_module_resources.py
@@ -1,0 +1,50 @@
+import pytest
+import requests
+
+from utils import DOJO_URL, create_dojo_yml, TEST_DOJOS_LOCATION
+
+
+@pytest.fixture(scope="session")
+def module_resources_dojo(admin_session):
+    return create_dojo_yml(open(TEST_DOJOS_LOCATION / "module_resources_dojo.yml").read(), session=admin_session)
+
+
+def test_module_resources(module_resources_dojo, admin_session):
+    dojo_id = module_resources_dojo
+    
+    response = admin_session.get(f"{DOJO_URL}/{dojo_id}/test/")
+    assert response.status_code == 200
+    page_content = response.text
+    
+    assert "Resource A" in page_content
+    assert "Resource B" in page_content
+    assert "Resource C" in page_content
+    assert "Resource D" in page_content
+    assert "Resource E" in page_content
+    
+    assert "hh4XAU6XYP0" in page_content
+    assert "14ZJRIyf0HnoYO1N8GI5ygE-ZVgdhjJrvzkETFLz7NIo" in page_content
+    assert "TESTB123" in page_content
+    assert "hIK1Dfjxq4E" in page_content
+    assert "1NjoOj03eQsjnZWhm-A3IsxTVqeWUqFvR4wgfXnhsnu4" in page_content
+    assert "PLHhKcdBlprMfIBVorNvOfY5UiHJmOk9nh" in page_content
+    assert "TESTD456" in page_content
+    assert "1H1V1HkVt3k" in page_content
+    assert "1_xdrCm136NzcDl9bqSgAEQuigUHkNjkKmamhaej296Q" in page_content
+
+
+def test_module_resources_order(module_resources_dojo, admin_session):
+    dojo_id = module_resources_dojo
+    
+    response = admin_session.get(f"{DOJO_URL}/{dojo_id}/test/")
+    assert response.status_code == 200
+    page_content = response.text
+    
+    pos_a = page_content.find("Resource A")
+    pos_b = page_content.find("Resource B")
+    pos_c = page_content.find("Resource C")
+    pos_d = page_content.find("Resource D")
+    pos_e = page_content.find("Resource E")
+    
+    assert pos_a != -1 and pos_b != -1 and pos_c != -1 and pos_d != -1 and pos_e != -1
+    assert pos_a < pos_b < pos_c < pos_d < pos_e

--- a/test/test_module_resources.py
+++ b/test/test_module_resources.py
@@ -109,7 +109,7 @@ def test_header_resources(module_resources_dojo, admin_session, example_dojo):
     assert response.status_code == 200
     page_content = response.text
     
-    assert "<hr>" in page_content
+    assert "<br>" in page_content
     assert "<h2>Advanced Section</h2>" in page_content
     
     pos_b = page_content.find("Resource B")

--- a/test/test_module_resources.py
+++ b/test/test_module_resources.py
@@ -83,7 +83,8 @@ def test_unified_ordering(module_resources_dojo, admin_session, example_dojo):
     
     items = [
         "Resource A",
-        "Resource B", 
+        "Resource B",
+        "Advanced Section",
         "Resource C",
         "Challenge A",
         "Resource D",
@@ -98,3 +99,21 @@ def test_unified_ordering(module_resources_dojo, admin_session, example_dojo):
     
     for i in range(len(positions) - 1):
         assert positions[i] < positions[i+1], f"{items[i]} (at {positions[i]}) should appear before {items[i+1]} (at {positions[i+1]})"
+
+
+def test_header_resources(module_resources_dojo, admin_session, example_dojo):
+    """Test that header resources render correctly"""
+    dojo_id = module_resources_dojo
+    
+    response = admin_session.get(f"{DOJO_URL}/{dojo_id}/test/")
+    assert response.status_code == 200
+    page_content = response.text
+    
+    assert "<hr>" in page_content
+    assert "<h2>Advanced Section</h2>" in page_content
+    
+    pos_b = page_content.find("Resource B")
+    pos_header = page_content.find("<h2>Advanced Section</h2>")
+    pos_c = page_content.find("Resource C")
+    
+    assert pos_b < pos_header < pos_c, f"Header should be between Resource B and C"

--- a/test/test_module_resources.py
+++ b/test/test_module_resources.py
@@ -9,7 +9,7 @@ def module_resources_dojo(admin_session):
     return create_dojo_yml(open(TEST_DOJOS_LOCATION / "module_resources_dojo.yml").read(), session=admin_session)
 
 
-def test_module_resources(module_resources_dojo, admin_session):
+def test_module_resources(module_resources_dojo, admin_session, example_dojo):
     dojo_id = module_resources_dojo
     
     response = admin_session.get(f"{DOJO_URL}/{dojo_id}/test/")
@@ -33,7 +33,7 @@ def test_module_resources(module_resources_dojo, admin_session):
     assert "1_xdrCm136NzcDl9bqSgAEQuigUHkNjkKmamhaej296Q" in page_content
 
 
-def test_module_resources_order(module_resources_dojo, admin_session):
+def test_module_resources_order(module_resources_dojo, admin_session, example_dojo):
     dojo_id = module_resources_dojo
     
     response = admin_session.get(f"{DOJO_URL}/{dojo_id}/test/")
@@ -48,3 +48,53 @@ def test_module_resources_order(module_resources_dojo, admin_session):
     
     assert pos_a != -1 and pos_b != -1 and pos_c != -1 and pos_d != -1 and pos_e != -1
     assert pos_a < pos_b < pos_c < pos_d < pos_e
+
+
+def test_module_resources_with_challenges(module_resources_dojo, admin_session, example_dojo):
+    dojo_id = module_resources_dojo
+    
+    response = admin_session.get(f"{DOJO_URL}/{dojo_id}/test/")
+    assert response.status_code == 200
+    page_content = response.text
+    
+    assert "Challenge A" in page_content
+    assert "Challenge B" in page_content
+    
+    pos_resource_c = page_content.find("Resource C")
+    pos_challenge_a = page_content.find("Challenge A")
+    pos_resource_d = page_content.find("Resource D")
+    pos_challenge_b = page_content.find("Challenge B")
+    
+    assert pos_resource_c != -1 and pos_challenge_a != -1 and pos_resource_d != -1 and pos_challenge_b != -1
+    
+    assert pos_resource_c < pos_challenge_a < pos_resource_d, f"Challenge A should be between Resource C ({pos_resource_c}) and Resource D ({pos_resource_d}), but found at {pos_challenge_a}"
+    
+    pos_resource_e = page_content.find("Resource E")
+    assert pos_resource_e < pos_challenge_b, f"Challenge B ({pos_challenge_b}) should come after Resource E ({pos_resource_e})"
+
+
+def test_unified_ordering(module_resources_dojo, admin_session, example_dojo):
+    """Test that resources and challenges appear in YAML order"""
+    dojo_id = module_resources_dojo
+    
+    response = admin_session.get(f"{DOJO_URL}/{dojo_id}/test/")
+    assert response.status_code == 200
+    page_content = response.text
+    
+    items = [
+        "Resource A",
+        "Resource B", 
+        "Resource C",
+        "Challenge A",
+        "Resource D",
+        "Resource E",
+        "Challenge B"
+    ]
+    
+    positions = [page_content.find(item) for item in items]
+    
+    for i, pos in enumerate(positions):
+        assert pos != -1, f"{items[i]} not found in page"
+    
+    for i in range(len(positions) - 1):
+        assert positions[i] < positions[i+1], f"{items[i]} (at {positions[i]}) should appear before {items[i+1]} (at {positions[i+1]})"


### PR DESCRIPTION
We've discussed this for a while, and it's here. This one was pricy:

```
Total cost:            $92.39
Total duration (API):  1h 49m 18.4s
Total duration (wall): 6h 57m 46.3s
Total code changes:    902 lines added, 416 lines removed
Usage by model:
    claude-3-5-haiku:  175.8k input, 7.2k output, 0 cache read, 0 cache write
         claude-opus:  1.2k input, 96.1k output, 32.3m cache read, 1.9m cache write
```

We should heavily review the code, because claude did this almost autonomously. Theoretically, it claims that:

- you can now add challenges as any other resource (`type: challenge`).
- you can still add challenges the old fashioned way (they'll just be added at the end)

We might want to add a `type: header` resource that recreates an `<h2>` separator.