### PR TITLE
Site: Allow challenges to be started in practice mode

### DIFF
--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -178,7 +178,7 @@ function startChallenge(event) {
     const item = $(event.currentTarget).closest(".accordion-item");
     const module = item.find("#module").val()
     const challenge = item.find("#challenge").val()
-    const practice = event.currentTarget.id == "challenge-practice";
+    const practice = event.currentTarget.id == "challenge-priv";
 
     item.find("#challenge-start").addClass("disabled-button");
     item.find("#challenge-start").prop("disabled", true);
@@ -459,6 +459,7 @@ $(() => {
         submits[i].oninput = submitChallenge;
     }
     $(".accordion-item").find("#challenge-start").click(startChallenge);
+    $(".challenge-init").find("#challenge-priv").click(startChallenge);
 
     window.addEventListener("resize", windowResizeCallback, true);
     windowResizeCallback("");

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -193,7 +193,14 @@
                   <i class="fas fa-play fa-2x pr-3"></i>Start
                 </button>
               </div>
-              <div class="col-md-9">
+              {% if challenge.allow_privileged %}
+              <div class="col-md-3 form=group text-center">
+                <button id="challenge-priv" type="submit" class="btn btn-md btn-outline-secondary challenge-init">
+                  <i class="fas fa-unlock fa-2x pr-3"></i>Privileged
+                </button>
+              </div>
+              {% endif %}
+              <div class="col-md-{% if challenge.allow_privileged %}6{% else %}9{% endif %}">
                 <input id="module" type="hidden" value="{{ challenge.module.id }}">
                 <input id="challenge" type="hidden" value="{{ challenge.id }}">
                 <input id="challenge-id" type="hidden" value="{{ challenge.challenge_id }}">


### PR DESCRIPTION
Adds a privileged button to the modules page.

If the challenge allows privileged mode, this button is displayed. Pressing it starts the challenge in privileged mode, saving the extra input to start the challenge normally, then switch it into privileged mode from the workspace control bar.