### PR TITLE
Workspace: Restore personality seccomp modifications

### DIFF
--- a/dojo_plugin/api/v1/docker.py
+++ b/dojo_plugin/api/v1/docker.py
@@ -171,6 +171,7 @@ def start_container(docker_client, user, as_user, user_mounts, dojo_challenge, p
         stdin_open=True,
         auto_remove=True,
         runtime="io.containerd.run.kata.v2" if dojo_challenge.privileged else "runc",
+        security_opt=[f"seccomp={SECCOMP}"],
     )
 
     container = docker_client.containers.create(**container_create_attributes)

--- a/dojo_plugin/config.py
+++ b/dojo_plugin/config.py
@@ -24,16 +24,6 @@ WORKSPACE_NODES = {
 def create_seccomp():
     seccomp = json.load(pathlib.Path("/etc/docker/seccomp.json").open())
 
-    seccomp["syscalls"].append({
-        "names": [
-            "clone",
-            "sethostname",
-            "setns",
-            "unshare",
-        ],
-        "action": "SCMP_ACT_ALLOW",
-    })
-
     READ_IMPLIES_EXEC = 0x0400000
     ADDR_NO_RANDOMIZE = 0x0040000
 


### PR DESCRIPTION
## Summary
- enforce seccomp profile when starting challenge containers
- drop namespace-related allowances from seccomp profile creation

## Testing
- `pytest` *(fails: Failed to find CSRF token)*

------
https://chatgpt.com/codex/tasks/task_e_6894e210c3608333b1f65187700205cd