### PR TITLE
Workspace: Restore personality seccomp modifications

### DIFF
--- a/dojo_plugin/api/v1/docker.py
+++ b/dojo_plugin/api/v1/docker.py
@@ -162,6 +162,7 @@ def start_container(docker_client, user, as_user, user_mounts, dojo_challenge, p
         },
         init=True,
         cap_add=["SYS_PTRACE", "SYS_ADMIN"] if dojo_challenge.privileged else ["SYS_PTRACE"],
+        security_opt=[f"seccomp={SECCOMP}"],
         sysctls={"net.ipv4.ip_unprivileged_port_start": 1024},
         cpu_period=100000,
         cpu_quota=400000,

--- a/dojo_plugin/config.py
+++ b/dojo_plugin/config.py
@@ -24,16 +24,6 @@ WORKSPACE_NODES = {
 def create_seccomp():
     seccomp = json.load(pathlib.Path("/etc/docker/seccomp.json").open())
 
-    seccomp["syscalls"].append({
-        "names": [
-            "clone",
-            "sethostname",
-            "setns",
-            "unshare",
-        ],
-        "action": "SCMP_ACT_ALLOW",
-    })
-
     READ_IMPLIES_EXEC = 0x0400000
     ADDR_NO_RANDOMIZE = 0x0040000
 


### PR DESCRIPTION
## Summary
- enforce seccomp profile when starting challenge containers
- drop namespace-related allowances from seccomp profile creation
- group seccomp security option with other security settings

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_6894e210c3608333b1f65187700205cd