### PR TITLE
Refresh flag icon when an active challenge is solved

### DIFF
--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -424,6 +424,11 @@ function windowResizeCallback(event) {
     $(".challenge-iframe").not(".challenge-iframe-fs").css("aspect-ratio", `${window.innerWidth} / ${window.innerHeight}`);
 }
 
+// TODO: Implement this function if it is needed.
+function updateNavbarDropdown(){
+
+}
+
 $(() => {
     $(".accordion-item").on("show.bs.collapse", function (event) {
         $(event.currentTarget).find("iframe").each(function (i, iframe) {

--- a/dojo_theme/static/js/dojo/workspace.js
+++ b/dojo_theme/static/js/dojo/workspace.js
@@ -136,6 +136,7 @@ function submitFlag(flag) {
         }
         else if (response.data.status == "correct") {
             animateBanner(`&#127881 Successfully completed <b>${challengeName}</b>! &#127881`, "success");
+            markChallengeAsSolved();
         }
         else if (response.data.status == "already_solved") {
             animateBanner(`&#127881 Solved <b>${challengeName}</b>! &#127881`, "success");
@@ -144,6 +145,17 @@ function submitFlag(flag) {
             animateBanner("Submission Failed.", "warn");
         }
     });
+}
+
+// change the challenge icon to solved
+function markChallengeAsSolved(){
+    const $parent = window.parent.$; // Use parent jQuery from iframe context 
+    const $activeChallenge = $parent('.challenge-active')
+    if($activeChallenge.length) {
+        $flagIcon = $activeChallenge.find('i.challenge-unsolved');
+        $flagIcon.removeClass('challenge-unsolved')
+                 .addClass('challenge-solved');
+    }
 }
 
 function hideNavbar() {


### PR DESCRIPTION
I added a empty function for `updateNavbarDropdown` because I saw an error in the console at pwn.college.
<img width="559" height="77" alt="image" src="https://github.com/user-attachments/assets/bf7a4cb1-fb7f-40e0-adf6-ac463c8ed063" />

We can remove it if it’s an old function or something planned for later.

However, the main purpose of this PR is to refresh the flag icon when a flag is successfully submitted.

Accessing the iframe’s parent content works as long as the iframe and the parent page share the same origin.
I mention this because in production they might be on different domains, subdomains, or origins, which would block direct access.


