### PR TITLE
Infrastructure: Improve docker compose profiles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
   splunk:
     container_name: splunk
-    image: splunk/splunk:9.1.2
     profiles:
       - splunk
+    image: splunk/splunk:9.1.2
     hostname: splunk
     restart: always
     environment:
@@ -27,6 +27,8 @@ services:
 
   workspace-builder:
     container_name: workspace-builder
+    profiles:
+      - workspace
     build: ./workspace
     environment:
       - DOJO_WORKSPACE=${DOJO_WORKSPACE}
@@ -36,6 +38,8 @@ services:
 
   dojofs:
     container_name: dojofs
+    profiles:
+      - workspace
     privileged: true
     pid: host
     build: ./dojofs
@@ -45,6 +49,9 @@ services:
 
   homefs:
     container_name: homefs
+    profiles:
+      - main
+      - workspace
     privileged: true
     build: ./homefs
     environment:
@@ -136,12 +143,6 @@ services:
       timeout: 10s
       retries: 3
     depends_on:
-      workspace-builder:
-        condition: service_completed_successfully
-      dojofs:
-        condition: service_started
-      homefs:
-        condition: service_started
       pgbouncer:
         condition: service_started
       cache:
@@ -256,6 +257,9 @@ services:
 
   node-exporter:
     container_name: node-exporter
+    profiles:
+      - main
+      - workspace
     image: prom/node-exporter
     command:
       - "--path.rootfs=/host"
@@ -266,6 +270,9 @@ services:
 
   cadvisor:
     container_name: cadvisor
+    profiles:
+      - main
+      - workspace
     image: gcr.io/cadvisor/cadvisor
     privileged: true
     ports:
@@ -351,6 +358,9 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
   create-workspace-net:
+    profiles:
+      - main
+      - workspace
     image: busybox:uclibc
     command: /bin/true
     networks:

--- a/dojo/dojo
+++ b/dojo/dojo
@@ -66,14 +66,24 @@ case "$ACTION" in
 
     # HELP: compose ARGS: run a docker compose command with the config.env file loaded
     "compose")
-        profile="main"
-        [ "$WORKSPACE_NODE" -gt 0 ] && profile="workspace"
+        profiles=()
 
-        if [ "${ENABLE_SPLUNK}" = "true" ]; then
-            docker compose --env-file=/data/config.env --profile "$profile" --profile splunk "$@"
+        multi_node=$(jq -e 'length > 0' /data/workspace_nodes.json 2>/dev/null)
+        if [ "$WORKSPACE_NODE" -gt 0 ]; then
+            profiles+=("workspace")
+        elif [ "$multi_node" == "true" ]; then
+            profiles+=("main")
         else
-            docker compose --env-file=/data/config.env --profile "$profile" "$@"
+            profiles+=("main" "workspace")
         fi
+
+        [ "${ENABLE_SPLUNK}" = "true" ] && profiles+=("splunk")
+
+        args=(--env-file=/data/config.env)
+        for p in "${profiles[@]}"; do
+            args+=(--profile "$p")
+        done
+        docker compose "${args[@]}" "$@"
         ;;
 
     # HELP: node: run a dojo node command

--- a/dojo/dojo
+++ b/dojo/dojo
@@ -68,7 +68,7 @@ case "$ACTION" in
     "compose")
         profiles=()
 
-        multi_node=$(jq -e 'length > 0' /data/workspace_nodes.json 2>/dev/null)
+        multi_node=$(jq 'length > 0' /data/workspace_nodes.json 2>/dev/null || echo "unknown")
         if [ "$WORKSPACE_NODE" -gt 0 ]; then
             profiles+=("workspace")
         elif [ "$multi_node" == "true" ]; then
@@ -83,6 +83,7 @@ case "$ACTION" in
         for p in "${profiles[@]}"; do
             args+=(--profile "$p")
         done
+        echo docker compose "${args[@]}" "$@"
         docker compose "${args[@]}" "$@"
         ;;
 


### PR DESCRIPTION
This PR makes it so that we don't need to wait on `workspace-builder` to finish in order to start the site. Of course, for testing purposes, we must still wait (just as we must wait for our docker image(s) to be pulled).

By removing the dependency, it also means that the main node in a multi-node setup no longer needs to run `workspace-builder` at all. This means `dojo update` should be much faster.