### PR TITLE
Site: Fix gevent python version

### DIFF
--- a/ctfd/Dockerfile
+++ b/ctfd/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim AS build
+FROM python:3.13.4-slim AS build
 WORKDIR /opt/CTFd
 
 RUN apt-get update \


### PR DESCRIPTION
See https://github.com/gevent/gevent/issues/2119.

Until we upgrade gevent (there is no release to upgrade to), python versions great than 3.13.4 (but less than 3.14, maybe?) have an issue that looks something like:
```
Exception ignored in: <function _after_fork at 0x7fcc5b97c2c0>
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/threading.py", line 1588, in _after_fork
    thread._after_fork(new_ident=ident)
  File "/usr/local/lib/python3.13/threading.py", line 1424, in _after_fork
    Thread._after_fork(self, new_ident=new_ident)
  File "/usr/local/lib/python3.13/threading.py", line 934, in _after_fork
    assert self._handle.ident == new_ident
AttributeError: '_DummyThread' object has no attribute '_handle'
Exception ignored in: <bound method _ForkHooks.after_fork_in_child of <gevent.threading._ForkHooks object at 0x7fcc5a51c830>>
Traceback (most recent call last):
  File "/opt/venv/lib/python3.13/site-packages/gevent/threading.py", line 376, in after_fork_in_child
    assert len(active) == 1
```