### PR TITLE
stats.py: Remove an irrelevant and buggy line introduced in 52a51cb.

### DIFF
--- a/dojo_plugin/utils/stats.py
+++ b/dojo_plugin/utils/stats.py
@@ -34,8 +34,6 @@ def get_dojo_stats(dojo):
     chart_solves = []
     chart_users = []
 
-    challenge_solves = dict(module.solves())
-
     return {
         'users': total_users,
         'challenges': total_challenges,


### PR DESCRIPTION
This line uses `module`, which is not defined anywhere in this method, and writes to `challenge_solves`, which is not used anywhere in this method. It is likely an irrelevant line that @zardus accidentally committed from his local working copy.