### PR TITLE
Site: Access workspace interface by port

### DIFF
--- a/dojo_theme/templates/components/actionbar.html
+++ b/dojo_theme/templates/components/actionbar.html
@@ -14,16 +14,17 @@
 
   .workspace-controls {
     width: 100%;
+    height: 2.5em;
     margin: 5px 0;
     padding: 0 5px;
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     position: relative;
   }
 
   .workspace-control {
     height: 100%;
-    margin: 2px 2px;
+    margin: 0 2px;
     border-width: 0px;
     border-radius: 1em;
     background-color: var(--foreground);

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -24,8 +24,7 @@
 
 .challenge-iframe-fs {
   aspect-ratio: unset !important;
-  display: flex;
-  flex: 1;
+  height: calc(100vh - 2.5em - 10px);
 }
 
 .challenge-init {
@@ -41,8 +40,6 @@
 }
 
 .workspace-fullscreen {
-  display:flex;
-  flex-direction: column;
   position: fixed;
   z-index: 1031;/* Navbar z-index + 1 */
   bottom: -16px;
@@ -50,11 +47,6 @@
   background-color: #111;
   width: 100% !important;
   height: 100% !important;
-}
-
-.workspace-fullscreen .iframe-wrapper {
-  display: flex;
-  flex: 1;
 }
 
 .workspace-ssh {


### PR DESCRIPTION
Change the js to connect to interfaces using the port.

Has special cases where the interface: port pairs are as follows:
```
terminal: 7681
code: 8080
desktop: 6080
```
The js will then hit the workspace API to start these services.