### PR TITLE
Handle 404 or other errors for custom interfaces

### DIFF
--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -109,7 +109,7 @@ function selectService(service, log=true) {
           if (!response.ok) {
               return sourceFailed(content, "Failed to connect to service, try restarting or contact dojo admin");
           }
-          target.src = url;
+          content.src = url;
       });
     }
 }


### PR DESCRIPTION
This PR extends some of the logic for handling failed connections to services to custom interfaces. The user will not see a 404, and instead is told to try reloading the challenge or contact the dojo administrator.