### PR TITLE
keep resource_index when using imports

### DIFF
--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -744,7 +744,7 @@ class DojoResources(db.Model):
             if kwargs.get("data"):
                 raise AttributeError("Import requires data to be empty")
 
-            for field in ["type", "name"]:
+            for field in ["type", "name", "resource_index"]:
                 kwargs[field] = kwargs[field] if kwargs.get(field) is not None else getattr(default, field, None)
 
             for field in self.data_fields:


### PR DESCRIPTION
Fixes https://github.com/pwncollege/dojo/issues/859, the dojo import process passes in the resource_index to DojoResources but it's never used, so it ends up with the wrong value and resources are displayed out of order. 