### PR TITLE
Synchronize Challenge Workspaces

### DIFF
--- a/dojo_plugin/api/v1/workspace.py
+++ b/dojo_plugin/api/v1/workspace.py
@@ -6,6 +6,7 @@ from CTFd.models import Users
 from CTFd.utils.user import get_current_user, is_admin
 from CTFd.utils.decorators import authed_only
 
+from ...utils.dojo import get_current_dojo_challenge
 from ...utils import get_current_container, container_password
 from ...utils.workspace import start_on_demand_service, reset_home
 
@@ -77,6 +78,26 @@ class view_desktop(Resource):
             return {"success": False, "active": True, "error": f"Failed to start service {service}"}
 
         return {"success": True, "active": True, "iframe_src": iframe_src, "service": service}
+
+
+@workspace_namespace.route("/update")
+class UpdateWorkspace(Resource):
+    @authed_only
+    def get(self):
+        user = get_current_user
+        container = get_current_container(user)
+        challenge = get_current_dojo_challenge(user)
+        if challenge is None:
+            return {"success": False}
+        
+        return {
+            "success": True,
+            "id": challenge.challenge_id,
+            "name": challenge.name,
+            "privileged": container.labels.get("dojo.mode") == "privileged",
+            "allow-privileged": challenge.allow_privileged,
+            "interfaces": challenge.interfaces,
+        }
 
 
 @workspace_namespace.route("/reset_home")


### PR DESCRIPTION
The PR aims to synchronize which challenge is being worked on between all open workspaces.

Currently, the workspace loads information about a challenge when the page is loaded. This means that even if a user starts another challenge, that workspace will retain the id, name, etc of the previous challenge. In order to use that workspace for the new challenge, the user needs to reload the page. Reloading the page also resets which interface is in use. If a user is using multiple workspace tabs (such as desktop + vscode), both will use the same interface when reloaded, instead of the interface last used in each respective workspace tab.

This can be solved by dispatching an event whenever a challenge is started, and having workspaces update themselves with the most up-to-date challenge information.