### PR TITLE
sudo.py: change gr_id to gr_gid

### DIFF
--- a/workspace/core/sudo.py
+++ b/workspace/core/sudo.py
@@ -31,7 +31,7 @@ def main():
     else:
         error(f"{program}: unknown user: {args.user}")
 
-    groups = [group.gr_id for group in grp.getgrall() if user.pw_name in group.gr_mem]
+    groups = [group.gr_gid for group in grp.getgrall() if user.pw_name in group.gr_mem]
     if user.pw_gid not in groups:
         groups.append(user.pw_gid)
 


### PR DESCRIPTION
gr_id doesn't exist
```
Traceback (most recent call last):
  File "/run/dojo/bin/sudo", line 58, in <module>
    main()
  File "/run/dojo/bin/sudo", line 35, in main
    groups = [group.gr_id for group in grp.getgrall() if user.pw_name in group.gr_mem]
              ^^^^^^^^^^^
AttributeError: 'grp.struct_group' object has no attribute 'gr_id'. Did you mean: 'gr_gid'?
```