### PR TITLE
Clarify `workspace-change-privilege` Button

### DIFF
--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -232,8 +232,8 @@ function displayPrivileged(event, invert) {
     const lockStatus = privileged === invert;
 
     button.find(".fas")
-        .toggleClass("fa-lock", lockStatus)
-        .toggleClass("fa-unlock", !lockStatus);
+        .toggleClass("fa-times", lockStatus)
+        .toggleClass("fa-check", !lockStatus);
 
     button.attr("title", privileged ? "Restart unprivileged"
                                     : "Restart privileged");

--- a/dojo_theme/templates/components/actionbar.html
+++ b/dojo_theme/templates/components/actionbar.html
@@ -172,7 +172,7 @@
       title="Restart {{'unprivileged' if practice else 'privileged'}}"
       class="workspace-control btn btn-md btn-outline-secondary btn-challenge-start"
       data-privileged="{{'true' if practice else 'false'}}">
-    <i class="fas fa-{{'unlock' if practice else 'lock'}}"></i>
+    Debug[<i class="fas fa-{{'check' if practice else 'times'}}"></i>]
   </button>
   {% endif %}
   <button id="fullscreen" title="Toggle fullscreen" class="workspace-control btn btn-md btn-outline-secondary">

--- a/dojo_theme/templates/components/actionbar.html
+++ b/dojo_theme/templates/components/actionbar.html
@@ -31,7 +31,6 @@
   }
 
   button.workspace-control {
-    width: 2.5em;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/dojo_theme/templates/components/actionbar.html
+++ b/dojo_theme/templates/components/actionbar.html
@@ -7,6 +7,14 @@
     --warn: #d0c000;
   }
 
+  .fa-check {
+    color: var(--brand-green)
+  }
+
+  .fa-times {
+    color: var(--error)
+  }
+
   .SSH {
     height: 0 !important;
     min-height: 0 !important;


### PR DESCRIPTION
This PR clarifies the purpose of the `workspace-change-privilege` button by adding the text `Debug[<icon>]` to the button.

The icon is either a check or times (X) based on if the challenge is in practice/privileged/sudo/debug/whateverwe'recallingitatthispoint mode or not. This is hopefully more clear to end users than the previous lock/unlock icons.