### PR TITLE
emoji duplication/pruning/updating updates

### DIFF
--- a/dojo_plugin/api/v1/dojos.py
+++ b/dojo_plugin/api/v1/dojos.py
@@ -39,10 +39,10 @@ class PruneAwards(Resource):
     def post(self, dojo):
         all_completions = set(user for user,_ in dojo.completions())
         num_pruned = 0
-        for award in Emojis.query.where(Emojis.category==dojo.hex_dojo_id):
+        for award in Emojis.query.where(Emojis.category==dojo.hex_dojo_id, Emojis.name != "STALE"):
             if award.user not in all_completions:
                 num_pruned += 1
-                db.session.delete(award)
+                award.name = "STALE"
         db.session.commit()
         return {"success": True, "pruned_awards": num_pruned}
 

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -272,11 +272,9 @@ class Dojos(db.Model):
         if "belt" in self.award:
             result = result.where(Awards.type == "belt", Awards.name == self.award["belt"])
         elif "emoji" in self.award:
-            result = result.where(Awards.type == "emoji", Awards.name == self.award["emoji"], Awards.category == self.hex_dojo_id)
+            result = result.where(Awards.type == "emoji", Awards.name != "STALE", Awards.category == self.hex_dojo_id)
 
         awards = result.order_by(Awards.date.desc()).all()
-        if "emoji" in self.award:
-            awards = [ a for a in awards if a.name == self.award["emoji"] ]
 
         return awards
 

--- a/dojo_plugin/utils/awards.py
+++ b/dojo_plugin/utils/awards.py
@@ -91,7 +91,7 @@ def get_viewable_emojis(user):
             url = "#"
         else:
             dojo = viewable_dojos.get(emoji.category)
-            if not dojo or not dojo.award:
+            if not dojo or not dojo.award or not dojo.award.get('emoji'):
                 continue
             emoji_symbol = dojo.award.get('emoji')
             url = url_for("pwncollege_dojo.listing", dojo=dojo.reference_id)

--- a/dojo_plugin/utils/awards.py
+++ b/dojo_plugin/utils/awards.py
@@ -62,15 +62,16 @@ def get_belts():
 
 def get_viewable_emojis(user):
     result = { }
-    viewable_dojo_urls = {
-        dojo.hex_dojo_id: url_for("pwncollege_dojo.listing", dojo=dojo.reference_id)
+    viewable_dojos = {
+        dojo.hex_dojo_id: dojo
         for dojo in Dojos.viewable(user=user).where(Dojos.data["type"].astext != "example")
     }
+    
     emojis = (
         Emojis.query
         .join(Users)
-        .filter(~Users.hidden, db.or_(Emojis.category.in_(viewable_dojo_urls.keys()), Emojis.category == None))
-        .order_by(Emojis.date)
+        .filter(~Users.hidden, db.or_(Emojis.category.in_(viewable_dojos.keys()), Emojis.category == None))
+        .order_by(Emojis.date, Emojis.name.desc())  # Order by date, then name DESC (STALE < CURRENT < legacy emojis)
         .with_entities(
             Emojis.name,
             Emojis.description,
@@ -78,13 +79,34 @@ def get_viewable_emojis(user):
             Users.id.label("user_id"),
         )
     )
+    
+    seen = set()
     for emoji in emojis:
+        key = (emoji.user_id, emoji.category)
+        if key in seen:
+            continue
+            
+        if emoji.category is None:
+            emoji_symbol = emoji.name
+            url = "#"
+        else:
+            dojo = viewable_dojos.get(emoji.category)
+            if not dojo or not dojo.award:
+                continue
+            emoji_symbol = dojo.award.get('emoji')
+            url = url_for("pwncollege_dojo.listing", dojo=dojo.reference_id)
+        
+        is_stale = emoji.name == "STALE"
+        
         result.setdefault(emoji.user_id, []).append({
             "text": emoji.description,
-            "emoji": emoji.name,
+            "emoji": emoji_symbol,
             "count": 1,
-            "url": viewable_dojo_urls.get(emoji.category, "#"),
+            "url": url,
+            "stale": is_stale,
         })
+        seen.add(key)
+    
     return result
 
 def update_awards(user):
@@ -118,7 +140,7 @@ def update_awards(user):
 
     current_emojis = get_user_emojis(user)
     for emoji,dojo_display_name,hex_dojo_id in current_emojis:
-        emoji_award = Emojis.query.filter_by(user=user, name=emoji, category=hex_dojo_id).first()
+        emoji_award = Emojis.query.filter(Emojis.user==user, Emojis.category==hex_dojo_id, Emojis.name != "STALE").first()
         if emoji_award:
             continue
         
@@ -128,7 +150,7 @@ def update_awards(user):
             
         display_name = dojo.name or dojo.reference_id
         description = f"Awarded for completing the {display_name} dojo."
-        db.session.add(Emojis(user=user, name=emoji, description=description, category=hex_dojo_id))
+        db.session.add(Emojis(user=user, name="CURRENT", description=description, category=hex_dojo_id))
         db.session.commit()
         
         if dojo.official or dojo.data.get("type") == "public":

--- a/dojo_theme/static/js/dojo/scoreboard.js
+++ b/dojo_theme/static/js/dojo/scoreboard.js
@@ -73,8 +73,9 @@ function loadScoreboard(duration, page) {
             user.badges.forEach(badge => {
                 if (!badge.url) badge.url = "#";
                 var count = badge.count <= 1 ? "" : `<sub>x${badge.count}</sub>`
+                var staleStyle = badge.stale ? 'style="opacity: 0.4; filter: grayscale(100%);"' : '';
                 row.find(".scoreboard-completions").append($(`
-                    <span title="${badge.text}">
+                    <span title="${badge.text}" ${staleStyle}>
                     <a href="${badge.url}">${badge.emoji}</a>${count}
                     </span><span> </span>
                 `));

--- a/dojo_theme/templates/hacker.html
+++ b/dojo_theme/templates/hacker.html
@@ -18,7 +18,7 @@
       </h1>
       <h2>
         {% for badge in badges[user.id] %}
-        <span title="{{badge.text}}">
+        <span title="{{badge.text}}" {% if badge.stale %}style="opacity: 0.4; filter: grayscale(100%);"{% endif %}>
           <a href="{{badge.url}}">{{badge.emoji}}</a>
           </span><span>
         </span>

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 #pylint:disable=redefined-outer-name,use-dict-literal,missing-timeout,unspecified-encoding,consider-using-with
 
-from utils import TEST_DOJOS_LOCATION, DOJO_URL, login, make_dojo_official, create_dojo, create_dojo_yml
+from utils import TEST_DOJOS_LOCATION, DOJO_URL, login, make_dojo_official, create_dojo, create_dojo_yml, start_challenge, solve_challenge
 from selenium.webdriver import Firefox, FirefoxOptions
 
 @pytest.fixture(scope="session")
@@ -34,10 +34,17 @@ def random_user_session(random_user):
     yield session
 
 
-@pytest.fixture(scope="session")
-def completionist_user():
+@pytest.fixture
+def completionist_user(simple_award_dojo):
     random_id = "".join(random.choices(string.ascii_lowercase, k=16))
     session = login(random_id, random_id, register=True)
+
+    response = session.get(f"{DOJO_URL}/dojo/{simple_award_dojo}/join/")
+    assert response.status_code == 200
+    for module, challenge in [ ("hello", "apple"), ("hello", "banana") ]:
+        start_challenge(simple_award_dojo, module, challenge, session=session)
+        solve_challenge(simple_award_dojo, module, challenge, session=session, user=random_id)
+
     yield random_id, session
 
 

--- a/test/test_dojos.py
+++ b/test/test_dojos.py
@@ -119,7 +119,8 @@ def test_prune_dojo_awards(simple_award_dojo, admin_session, completionist_user)
     scoreboard = admin_session.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{simple_award_dojo}/_/0/1").json()
     us = next(u for u in scoreboard["standings"] if u["name"] == user_name)
     assert us["solves"] == 1
-    assert len(us["badges"]) == 0
+    assert len(us["badges"]) == 1
+    assert us["badges"][0]["stale"] == True
 
 
 def test_lfs(lfs_dojo, random_user_name, random_user_session):

--- a/test/test_dojos.py
+++ b/test/test_dojos.py
@@ -63,21 +63,10 @@ def test_promote_dojo_member(admin_session, guest_dojo_admin, example_dojo):
     assert random_user_name in response.text and response.text.index("Members") > response.text.index(random_user_name)
 
 
-def test_dojo_completion(simple_award_dojo, completionist_user):
+def test_dojo_completion_emoji(simple_award_dojo, completionist_user):
     user_name, session = completionist_user
-    dojo = simple_award_dojo
 
-    response = session.get(f"{DOJO_URL}/dojo/{dojo}/join/")
-    assert response.status_code == 200
-    for module, challenge in [
-        ("hello", "apple"), ("hello", "banana"),
-        #("world", "earth"), ("world", "mars"), ("world", "venus")
-    ]:
-        start_challenge(dojo, module, challenge, session=session)
-        solve_challenge(dojo, module, challenge, session=session, user=user_name)
-
-    # check for emoji
-    scoreboard = session.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{dojo}/_/0/1").json()
+    scoreboard = session.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{simple_award_dojo}/_/0/1").json()
     us = next(u for u in scoreboard["standings"] if u["name"] == user_name)
     assert us["solves"] == 2
     assert len(us["badges"]) == 1


### PR DESCRIPTION
Fixes https://github.com/pwncollege/dojo/issues/878

This changes how we store and look up emojis: currently, the actual emoji is stored as the name of the award. This is a nightmare for several reasons. One is #878, but aside from this, querying on unicode emojis is actually hella broken, in different ways, in sqlalchemy and on the commandline.

With this PR, the name of the award itself is `CURRENT` or `STALE`, and the actual emoji is retrieved from the dojo. `STALE` is what happens now (instead of deletion) for award pruning, and stale emojis show up grey. Pruning has never happened on pwn.college before, but now it can be less destructive!