### PR TITLE
Site: Synchronize Active Challenge Between Workspace Tabs

### DIFF
--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -49,7 +49,7 @@ function getRecentService(root) {
     return match;
 }
 
-function specialSelect(serviceName) {
+function specialSelect(serviceName, content) {
     const url = new URL("/pwncollege_api/v1/workspace", window.location.origin);
     url.searchParams.set("service", serviceName);
     fetch(url, {
@@ -97,7 +97,7 @@ function selectService(service, log=true) {
     const specialServices = ["terminal", "code", "desktop"];
     const specialPorts = ["7681", "8080", "6080"];
     if (specialServices.indexOf(service) > -1 && specialServices.indexOf(service) == specialPorts.indexOf(port)) {
-        specialSelect(service);
+        specialSelect(service, content);
     }
     else {
         content.src = "/workspace/" + port + "/";
@@ -162,10 +162,22 @@ function actionSubmitFlag(event) {
 function postStartChallenge(event, channel) {
     root = context(event);
 
-    challengeData = {
+    options = []
+    root.find("#workspace-select option").each(() => {
+        options.push($(this).val())
+    })
 
+    challenge = root.find("#current-challenge-id");
+    privilege = root.find("#workspace-change-privilege");
+
+    challengeData = {
+        "options": options,
+        "challenge-id": challenge.prop("value"),
+        "challenge-name": challenge.prop("data-challenge-name"),
+        "challenge-privilege": privilege.prop("data-privileged"),
     };
 
+    console.log(challengeData)
     channel.postMessage(challengeData);
 }
 

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -277,7 +277,7 @@ function displayPrivileged(event, invert) {
                                     : "Restart privileged");
 }
 
-function loadWorkspace() {
+function loadWorkspace(log=true) {
     if ($("#workspace-iframe").length == 0 ) {
         return;
     }
@@ -289,7 +289,7 @@ function loadWorkspace() {
     else {
         workspaceRoot.find("#workspace-select").prop("value", recent);
     }
-    selectService(recent);
+    selectService(recent, log=log);
 }
 
 $(() => {

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -78,9 +78,7 @@ function selectService(service, log=true) {
         console.log("Missing workspace iframe :(")
         return;
     }
-    if (log) {
-        logService(service);
-    }
+    if (log) {logService(service);}
     port = service.split(": ")[1];
     service = service.split(": ")[0];
     if (service == "ssh" && port == "") {

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -158,9 +158,7 @@ function actionSubmitFlag(event) {
     });
 }
 
-function postStartChallenge(event, channel) {
-    root = context(event);
-
+function sendChallengeInfo(root, channel) {
     options = []
     root.find("#workspace-select option").each((index, element) => {
         options.push({
@@ -180,6 +178,11 @@ function postStartChallenge(event, channel) {
     };
 
     channel.postMessage(challengeData);
+}
+
+function postStartChallenge(event, channel) {
+    root = context(event);
+    sendChallengeInfo(root, channel);
 }
 
 function actionStartChallenge(event) {

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -49,6 +49,30 @@ function getRecentService(root) {
     return match;
 }
 
+function specialSelect(serviceName) {
+    const url = new URL("/pwncollege_api/v1/workspace", window.location.origin);
+    url.searchParams.set("service", serviceName);
+    fetch(url, {
+        method: "GET",
+        credentials: "same-origin"
+    })
+    .then(response => response.json())
+    .then(result => {
+        if (result.success) {
+            content.src = result["iframe_src"];
+        }
+        else {
+            content.src = "";
+            console.log
+            animateBanner(
+                {target: $(content).closest(".challenge-workspace").find("#workspace-select")[0]},
+                result.error,
+                "error"
+            );
+        }
+    });
+}
+
 function selectService(service) {
     const content = document.getElementById("workspace-iframe");
     if (!content) {
@@ -71,27 +95,7 @@ function selectService(service) {
     const specialServices = ["terminal", "code", "desktop"];
     const specialPorts = ["7681", "8080", "6080"];
     if (specialServices.indexOf(service) > -1 && specialServices.indexOf(service) == specialPorts.indexOf(port)) {
-        const url = new URL("/pwncollege_api/v1/workspace", window.location.origin);
-        url.searchParams.set("service", service);
-        fetch(url, {
-            method: "GET",
-            credentials: "same-origin"
-        })
-        .then(response => response.json())
-        .then(result => {
-            if (result.success) {
-                content.src = result["iframe_src"];
-            }
-            else {
-                content.src = "";
-                console.log
-                animateBanner(
-                    {target: $(content).closest(".challenge-workspace").find("#workspace-select")[0]},
-                    result.error,
-                    "error"
-                );
-            }
-        });
+        specialSelect(service)
     }
     else {
         content.src = "/workspace/" + port + "/";

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -159,6 +159,16 @@ function actionSubmitFlag(event) {
     });
 }
 
+function postStartChallenge(event, channel) {
+    root = context(event);
+
+    challengeData = {
+
+    };
+
+    channel.postMessage(challengeData);
+}
+
 function actionStartChallenge(event) {
     const privileged = context(event).find("#workspace-change-privilege").attr("data-privileged") === "true";
 
@@ -268,6 +278,8 @@ function loadWorkspace() {
 }
 
 $(() => {
+    const channel = new BroadcastChannel("Challenge-Sync-Channel");
+
     loadWorkspace();
     $(".workspace-controls").each(function () {
         if ($(this).find("option").length < 2) {
@@ -293,7 +305,10 @@ $(() => {
             }
         });
 
-        $(this).find(".btn-challenge-start").click(actionStartCallback);
+        $(this).find(".btn-challenge-start").click((event) => {
+            actionStartCallback(event);
+            postStartChallenge(event, channel);
+        });
 
         if ($(this).find("#workspace-change-privilege").length) {
             $(this).find("#workspace-change-privilege").on("mouseenter", function(event) {

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -229,6 +229,7 @@ function actionStartChallenge(event) {
             }
 
             selectService(context(event).find("#workspace-select").prop("value"));
+            postStartChallenge(event, channel);
 
             context(event).find(".btn-challenge-start")
             .removeClass("disabled")
@@ -292,9 +293,8 @@ function loadWorkspace(log=true) {
     selectService(recent, log=log);
 }
 
+const channel = new BroadcastChannel("Challenge-Sync-Channel");
 $(() => {
-    const channel = new BroadcastChannel("Challenge-Sync-Channel");
-
     loadWorkspace();
     $(".workspace-controls").each(function () {
         if ($(this).find("option").length < 2) {
@@ -320,10 +320,7 @@ $(() => {
             }
         });
 
-        $(this).find(".btn-challenge-start").click((event) => {
-            actionStartCallback(event);
-            postStartChallenge(event, channel);
-        });
+        $(this).find(".btn-challenge-start").click(actionStartCallback);
 
         if ($(this).find("#workspace-change-privilege").length) {
             $(this).find("#workspace-change-privilege").on("mouseenter", function(event) {

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -97,7 +97,7 @@ function selectService(service, log=true) {
     const specialServices = ["terminal", "code", "desktop"];
     const specialPorts = ["7681", "8080", "6080"];
     if (specialServices.indexOf(service) > -1 && specialServices.indexOf(service) == specialPorts.indexOf(port)) {
-        specialSelect(service)
+        specialSelect(service);
     }
     else {
         content.src = "/workspace/" + port + "/";

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -173,8 +173,8 @@ function postStartChallenge(event, channel) {
     challengeData = {
         "options": options,
         "challenge-id": challenge.prop("value"),
-        "challenge-name": challenge.prop("data-challenge-name"),
-        "challenge-privilege": privilege.prop("data-privileged"),
+        "challenge-name": challenge.attr("data-challenge-name"),
+        "challenge-privilege": privilege.length > 0 ? privilege.attr("data-privileged") : "false",
     };
 
     console.log(challengeData)

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -63,7 +63,6 @@ function specialSelect(serviceName, content) {
         }
         else {
             content.src = "";
-            console.log
             animateBanner(
                 {target: $(content).closest(".challenge-workspace").find("#workspace-select")[0]},
                 result.error,
@@ -180,7 +179,6 @@ function postStartChallenge(event, channel) {
         "challenge-privilege": privilege.length > 0 ? privilege.attr("data-privileged") : "false",
     };
 
-    console.log(challengeData)
     channel.postMessage(challengeData);
 }
 

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -73,13 +73,15 @@ function specialSelect(serviceName) {
     });
 }
 
-function selectService(service) {
+function selectService(service, log=true) {
     const content = document.getElementById("workspace-iframe");
     if (!content) {
         console.log("Missing workspace iframe :(")
         return;
     }
-    logService(service);
+    if (log) {
+        logService(service);
+    }
     port = service.split(": ")[1];
     service = service.split(": ")[0];
     if (service == "ssh" && port == "") {

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -164,7 +164,10 @@ function postStartChallenge(event, channel) {
 
     options = []
     root.find("#workspace-select option").each((index, element) => {
-        options.push($(element).prop("value"));
+        options.push({
+            "value": $(element).prop("value"),
+            "text": $(element).text(),
+        });
     })
 
     challenge = root.find("#current-challenge-id");

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -163,8 +163,8 @@ function postStartChallenge(event, channel) {
     root = context(event);
 
     options = []
-    root.find("#workspace-select option").each(() => {
-        options.push($(this).val())
+    root.find("#workspace-select option").each((index, element) => {
+        options.push($(element).prop("value"));
     })
 
     challenge = root.find("#current-challenge-id");

--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -431,7 +431,10 @@ function moduleStartChallenge(event, channel) {
 
     options = []
     root.find("#workspace-select option").each((index, element) => {
-        options.push($(element).prop("value"));
+        options.push({
+            "value": $(element).prop("value"),
+            "text": $(element).text(),
+        });
     })
 
     challenge = root.find("#current-challenge-id");

--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -286,6 +286,7 @@ function startChallenge(event) {
                     .toggleClass("fa-lock", !practice)
                     .toggleClass("fa-unlock", practice);
             windowResizeCallback("");
+            moduleStartChallenge(event, channel);
         }
 
         setTimeout(function() {
@@ -452,8 +453,6 @@ function moduleStartChallenge(event, channel) {
 }
 
 $(() => {
-    const channel = new BroadcastChannel("Challenge-Sync-Channel");
-
     $(".accordion-item").on("show.bs.collapse", function (event) {
         $(event.currentTarget).find("iframe").each(function (i, iframe) {
             if ($(iframe).prop("src"))
@@ -487,14 +486,8 @@ $(() => {
     for (var i = 0; i < submits.length; i++) {
         submits[i].oninput = submitChallenge;
     }
-    $(".accordion-item").find("#challenge-start").click((event) => {
-        startChallenge(event);
-        moduleStartChallenge(event, channel);
-    });
-    $(".challenge-init").find("#challenge-priv").click((event) => {
-        startChallenge(event);
-        moduleStartChallenge(event, channel);
-    });
+    $(".accordion-item").find("#challenge-start").click(startChallenge);
+    $(".challenge-init").find("#challenge-priv").click(startChallenge);
 
     window.addEventListener("resize", windowResizeCallback, true);
     windowResizeCallback("");

--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -450,7 +450,7 @@ function moduleStartChallenge(event, channel) {
 
 $(() => {
     const channel = new BroadcastChannel("Challenge-Sync-Channel");
-    
+
     $(".accordion-item").on("show.bs.collapse", function (event) {
         $(event.currentTarget).find("iframe").each(function (i, iframe) {
             if ($(iframe).prop("src"))
@@ -488,7 +488,10 @@ $(() => {
         startChallenge(event);
         moduleStartChallenge(event, channel);
     });
-    $(".challenge-init").find("#challenge-priv").click(startChallenge);
+    $(".challenge-init").find("#challenge-priv").click((event) => {
+        startChallenge(event);
+        moduleStartChallenge(event, channel);
+    });
 
     window.addEventListener("resize", windowResizeCallback, true);
     windowResizeCallback("");

--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -448,7 +448,6 @@ function moduleStartChallenge(event, channel) {
         "challenge-privilege": (event.target.id == "challenge-priv").toString(),
     };
 
-    console.log(challengeData)
     channel.postMessage(challengeData);
 }
 

--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -452,6 +452,20 @@ function moduleStartChallenge(event, channel) {
 }
 
 $(() => {
+    channel.addEventListener("message", (event) => {
+        var challenge_id = event.data["challenge-id"];
+        $(".workspace-controls").each((index, item) => {
+            item_chal_id = $(item).find("#current-challenge-id").prop("value");
+            if (item_chal_id == challenge_id) {
+                var priv = $(item).find("#workspace-change-privilege");
+                if (priv.length > 0) {
+                    priv.attr("data-privileged", event.data["challenge-privilege"]);
+                    displayPrivileged({"target": priv[0]}, false);
+                }
+            }
+        })
+    });
+
     $(".accordion-item").on("show.bs.collapse", function (event) {
         $(event.currentTarget).find("iframe").each(function (i, iframe) {
             if ($(iframe).prop("src"))

--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -426,7 +426,31 @@ function windowResizeCallback(event) {
     $(".challenge-iframe").not(".challenge-iframe-fs").css("aspect-ratio", `${window.innerWidth} / ${window.innerHeight}`);
 }
 
+function moduleStartChallenge(event, channel) {
+    root = $(event.target).closest(".accordion-item-body").find(".workspace-controls");
+
+    options = []
+    root.find("#workspace-select option").each((index, element) => {
+        options.push($(element).prop("value"));
+    })
+
+    challenge = root.find("#current-challenge-id");
+    privilege = root.find("#workspace-change-privilege");
+
+    challengeData = {
+        "options": options,
+        "challenge-id": challenge.prop("value"),
+        "challenge-name": challenge.attr("data-challenge-name"),
+        "challenge-privilege": (event.target.id == "challenge-priv").toString(),
+    };
+
+    console.log(challengeData)
+    channel.postMessage(challengeData);
+}
+
 $(() => {
+    const channel = new BroadcastChannel("Challenge-Sync-Channel");
+    
     $(".accordion-item").on("show.bs.collapse", function (event) {
         $(event.currentTarget).find("iframe").each(function (i, iframe) {
             if ($(iframe).prop("src"))
@@ -460,7 +484,10 @@ $(() => {
     for (var i = 0; i < submits.length; i++) {
         submits[i].oninput = submitChallenge;
     }
-    $(".accordion-item").find("#challenge-start").click(startChallenge);
+    $(".accordion-item").find("#challenge-start").click((event) => {
+        startChallenge(event);
+        moduleStartChallenge(event, channel);
+    });
     $(".challenge-init").find("#challenge-priv").click(startChallenge);
 
     window.addEventListener("resize", windowResizeCallback, true);

--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -462,6 +462,8 @@ $(() => {
                     priv.attr("data-privileged", event.data["challenge-privilege"]);
                     displayPrivileged({"target": priv[0]}, false);
                 }
+
+                selectService($(item).find("#workspace-select").prop("value"), log=false);
             }
         })
     });

--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -429,26 +429,7 @@ function windowResizeCallback(event) {
 
 function moduleStartChallenge(event, channel) {
     root = $(event.target).closest(".accordion-item-body").find(".workspace-controls");
-
-    options = []
-    root.find("#workspace-select option").each((index, element) => {
-        options.push({
-            "value": $(element).prop("value"),
-            "text": $(element).text(),
-        });
-    })
-
-    challenge = root.find("#current-challenge-id");
-    privilege = root.find("#workspace-change-privilege");
-
-    challengeData = {
-        "options": options,
-        "challenge-id": challenge.prop("value"),
-        "challenge-name": challenge.attr("data-challenge-name"),
-        "challenge-privilege": (event.target.id == "challenge-priv").toString(),
-    };
-
-    channel.postMessage(challengeData);
+    sendChallengeInfo(root, channel);
 }
 
 $(() => {

--- a/dojo_theme/static/js/dojo/workspace.js
+++ b/dojo_theme/static/js/dojo/workspace.js
@@ -41,6 +41,7 @@ function updateWorkspace(data) {
         selector.append($("<option></option>").attr("value", item.value).text(item.text))
         if (item.value == current) {
             console.log("found match");
+            selector.prop("value", item.value)
             selectService(item.value, true);
             loadedService = true;
         }
@@ -65,7 +66,6 @@ $(() => {
     $("footer").hide();
 
     channel.addEventListener("message", (event) => {
-        console.log(event.data);
         updateWorkspace(event.data);
     });
 })

--- a/dojo_theme/static/js/dojo/workspace.js
+++ b/dojo_theme/static/js/dojo/workspace.js
@@ -39,9 +39,7 @@ function updateWorkspace(data) {
             loadedService = true;
         }
     })
-    if (!loadedService) {
-        loadWorkspace(log=false);
-    }
+    if (!loadedService) {loadWorkspace(log=false);}
     selector.prop("disabled", data.options.length < 2);
 }
 

--- a/dojo_theme/static/js/dojo/workspace.js
+++ b/dojo_theme/static/js/dojo/workspace.js
@@ -32,10 +32,6 @@ function updateWorkspace(data) {
         displayPrivileged({"target": priv[0]}, false);
     }
 
-    if (!changed) {
-        return;
-    }
-
     var current = $("#workspace-select").prop("value")
     console.log(current);
 }

--- a/dojo_theme/static/js/dojo/workspace.js
+++ b/dojo_theme/static/js/dojo/workspace.js
@@ -26,9 +26,9 @@ function updateWorkspace(data) {
     $("#current-challenge-id").prop("value", data["challenge-id"])
                               .attr("data-challenge-name", data["challenge-name"]);
     
-    var priv = $("#workspace-change-privilege")
+    var priv = $("#workspace-change-privilege");
     if (priv.length > 0) {
-        priv.attr("data-privileged", data["challenge-privilege"])
+        priv.attr("data-privileged", data["challenge-privilege"]);
         displayPrivileged({"target": priv[0]}, false);
     }
 
@@ -40,7 +40,7 @@ function updateWorkspace(data) {
         selector.append($("<option></option>").attr("value", item.value).text(item.text))
         if (item.value == current) {
             selector.prop("value", item.value)
-            selectService(item.value, true);
+            selectService(item.value, log=true);
             loadedService = true;
         }
     })

--- a/dojo_theme/static/js/dojo/workspace.js
+++ b/dojo_theme/static/js/dojo/workspace.js
@@ -47,12 +47,7 @@ function updateWorkspace(data) {
     if (!loadedService) {
         loadWorkspace(log=false);
     }
-    if (data.options.length > 1) {
-        selector.prop("disabled", false);
-    }
-    else {
-        selector.prop("disabled", true);
-    }
+    selector.prop("disabled", data.options.length < 2);
 }
 
 $(() => {

--- a/dojo_theme/static/js/dojo/workspace.js
+++ b/dojo_theme/static/js/dojo/workspace.js
@@ -42,11 +42,19 @@ function updateWorkspace(data) {
 
     var selector = $("#workspace-select");
     var current = selector.prop("value");
+    var loadedService = false;
     console.log(current);
     selector.empty();
     data.options.forEach((item, index) => {
         selector.append($("<option></option>").attr("value", item.value).text(item.text))
+        if (item.value == current) {
+            selectService(item.value, true);
+            loadedService = true;
+        }
     })
+    if (!loadedService) {
+        loadWorkspace(log=false);
+    }
     if (data.options.length > 1) {
         selector.prop("disabled", false);
     }

--- a/dojo_theme/static/js/dojo/workspace.js
+++ b/dojo_theme/static/js/dojo/workspace.js
@@ -35,19 +35,16 @@ function updateWorkspace(data) {
     var selector = $("#workspace-select");
     var current = selector.prop("value");
     var loadedService = false;
-    console.log(current);
     selector.empty();
     data.options.forEach((item, index) => {
         selector.append($("<option></option>").attr("value", item.value).text(item.text))
         if (item.value == current) {
-            console.log("found match");
             selector.prop("value", item.value)
             selectService(item.value, true);
             loadedService = true;
         }
     })
     if (!loadedService) {
-        console.log("no match");
         loadWorkspace(log=false);
     }
     if (data.options.length > 1) {

--- a/dojo_theme/static/js/dojo/workspace.js
+++ b/dojo_theme/static/js/dojo/workspace.js
@@ -17,6 +17,20 @@ function doFullscreen() {
     }
 }
 
+function updateWorkspace(data) {
+    $("#current-challenge-id").prop("value", data["challenge-id"])
+                              .attr("data-challenge-name", data["challenge-name"]);
+    
+    var priv = $("#workspace-change-privilege")
+    if (priv.length > 0) {
+        priv.attr("data-privileged", data["challenge-privilege"])
+        displayPrivileged({"target": priv[0]}, false);
+    }
+
+    var current = $("#workspace-select").prop("value")
+    console.log(current);
+}
+
 $(() => {
     const channel = new BroadcastChannel("Challenge-Sync-Channel");
 
@@ -27,6 +41,7 @@ $(() => {
     $("footer").hide();
 
     channel.addEventListener("message", (event) => {
-        console.log(event);
+        console.log(event.data);
+        updateWorkspace(event.data);
     });
 })

--- a/dojo_theme/static/js/dojo/workspace.js
+++ b/dojo_theme/static/js/dojo/workspace.js
@@ -32,14 +32,6 @@ function updateWorkspace(data) {
         displayPrivileged({"target": priv[0]}, false);
     }
 
-    if (!changed) {
-        iframe = $("#workspace-iframe");
-        if (iframe.length > 0) {
-            iframe[0].src = iframe[0].src;
-        }
-        return;
-    }
-
     var selector = $("#workspace-select");
     var current = selector.prop("value");
     var loadedService = false;
@@ -48,11 +40,13 @@ function updateWorkspace(data) {
     data.options.forEach((item, index) => {
         selector.append($("<option></option>").attr("value", item.value).text(item.text))
         if (item.value == current) {
+            console.log("found match");
             selectService(item.value, true);
             loadedService = true;
         }
     })
     if (!loadedService) {
+        console.log("no match");
         loadWorkspace(log=false);
     }
     if (data.options.length > 1) {
@@ -64,8 +58,6 @@ function updateWorkspace(data) {
 }
 
 $(() => {
-    const channel = new BroadcastChannel("Challenge-Sync-Channel");
-
     if (new URLSearchParams(window.location.search).has("hide-navbar")) {
         hideNavbar();
     }

--- a/dojo_theme/static/js/dojo/workspace.js
+++ b/dojo_theme/static/js/dojo/workspace.js
@@ -18,9 +18,15 @@ function doFullscreen() {
 }
 
 $(() => {
+    const channel = new BroadcastChannel("Challenge-Sync-Channel");
+
     if (new URLSearchParams(window.location.search).has("hide-navbar")) {
         hideNavbar();
     }
     $(".close-link").hide();
     $("footer").hide();
+
+    channel.addEventListener("message", (event) => {
+        console.log(event);
+    });
 })

--- a/dojo_theme/static/js/dojo/workspace.js
+++ b/dojo_theme/static/js/dojo/workspace.js
@@ -45,8 +45,14 @@ function updateWorkspace(data) {
     console.log(current);
     selector.empty();
     data.options.forEach((item, index) => {
-        selector.append($("<option></option>").attr("value", item).text(item))
+        selector.append($("<option></option>").attr("value", item.value).text(item.text))
     })
+    if (data.options.length > 1) {
+        selector.prop("disabled", false);
+    }
+    else {
+        selector.prop("disabled", true);
+    }
 }
 
 $(() => {

--- a/dojo_theme/static/js/dojo/workspace.js
+++ b/dojo_theme/static/js/dojo/workspace.js
@@ -40,8 +40,13 @@ function updateWorkspace(data) {
         return;
     }
 
-    var current = $("#workspace-select").prop("value")
+    var selector = $("#workspace-select");
+    var current = selector.prop("value");
     console.log(current);
+    selector.empty();
+    data.options.forEach((item, index) => {
+        selector.append($("<option></option>").attr("value", item).text(item))
+    })
 }
 
 $(() => {

--- a/dojo_theme/static/js/dojo/workspace.js
+++ b/dojo_theme/static/js/dojo/workspace.js
@@ -18,11 +18,6 @@ function doFullscreen() {
 }
 
 function updateWorkspace(data) {
-    var changed = false;
-    if ($("#current-challenge-id").prop("value") != data["challenge-id"]) {
-        changed = true;
-    }
-
     $("#current-challenge-id").prop("value", data["challenge-id"])
                               .attr("data-challenge-name", data["challenge-name"]);
     

--- a/dojo_theme/static/js/dojo/workspace.js
+++ b/dojo_theme/static/js/dojo/workspace.js
@@ -18,6 +18,11 @@ function doFullscreen() {
 }
 
 function updateWorkspace(data) {
+    var changed = false;
+    if ($("#current-challenge-id").prop("value") != data["challenge-id"]) {
+        changed = true;
+    }
+
     $("#current-challenge-id").prop("value", data["challenge-id"])
                               .attr("data-challenge-name", data["challenge-name"]);
     
@@ -25,6 +30,10 @@ function updateWorkspace(data) {
     if (priv.length > 0) {
         priv.attr("data-privileged", data["challenge-privilege"])
         displayPrivileged({"target": priv[0]}, false);
+    }
+
+    if (!changed) {
+        return;
     }
 
     var current = $("#workspace-select").prop("value")

--- a/dojo_theme/static/js/dojo/workspace.js
+++ b/dojo_theme/static/js/dojo/workspace.js
@@ -32,6 +32,14 @@ function updateWorkspace(data) {
         displayPrivileged({"target": priv[0]}, false);
     }
 
+    if (!changed) {
+        iframe = $("#workspace-iframe");
+        if (iframe.length > 0) {
+            iframe[0].src = iframe[0].src;
+        }
+        return;
+    }
+
     var current = $("#workspace-select").prop("value")
     console.log(current);
 }

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -300,7 +300,7 @@
 {% endblock %}
 
 {% block scripts %}
+<script defer src="{{ url_for('views.themes', path='js/dojo/actionbar.js') }}"></script>
 <script defer src="{{ url_for('views.themes', path='js/dojo/challenges.js') }}"></script>
 <script defer onload="loadScoreboard(30, 1);" src="{{ url_for('views.themes', path='js/dojo/scoreboard.js') }}"></script>
-<script defer src="{{ url_for('views.themes', path='js/dojo/actionbar.js') }}"></script>
 {% endblock %}

--- a/dojo_theme/templates/workspace.html
+++ b/dojo_theme/templates/workspace.html
@@ -53,6 +53,6 @@
 
 
 {% block scripts %}
-<script defer src="{{ url_for('views.themes', path='js/dojo/workspace.js') }}"></script>
 <script defer src="{{ url_for('views.themes', path='js/dojo/actionbar.js') }}"></script>
+<script defer src="{{ url_for('views.themes', path='js/dojo/workspace.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
This PR aims to fix an issue where workspace tabs retain information about the challenge which was active when the tab was loaded. If the user opens a workspace tab, starts a new challenge, then tries to restart or submit using the old workspace tab, these actions will use the old challenge ID, despite not matching the current challenge.

In the past, this would be resolved by reloading your workspace tabs. However, this would reset all tabs to be using the same most recent workspace service.

This PR fixes this by having tabs communicate whenever a challenge is started. Workspace tabs in particular will update their contents to reflect information about the new challenge (ID, Name, Interfaces, etc.)