### PR TITLE
Multiple dojos in one repository

### DIFF
--- a/dojo_plugin/api/v1/dojos.py
+++ b/dojo_plugin/api/v1/dojos.py
@@ -91,12 +91,15 @@ class CreateDojo(Resource):
             return {"success": False, "error": "You can only create 1 dojo per day."}, 429
 
         try:
-            dojo = dojo_create(user, repository, public_key, private_key, spec)
+            dojos = dojo_create(user, repository, public_key, private_key, spec)
         except RuntimeError as e:
             return {"success": False, "error": str(e)}, 400
 
         cache.set(key, 1, timeout=timeout)
-        return {"success": True, "dojo": dojo.reference_id}
+        if len(dojos) == 1:
+            return {"success": True, "dojo": dojos[0].reference_id}
+        else:
+            return {"success": True, "dojos": [dojo.reference_id for dojo in dojos]}
 
 
 @dojos_namespace.route("/<dojo>/modules")

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -59,9 +59,9 @@ class Dojos(db.Model):
 
     dojo_id = db.Column(db.Integer, primary_key=True)
 
-    repository = db.Column(db.String(256), unique=True, index=True)
-    public_key = db.Column(db.String(128), unique=True)
-    private_key = db.Column(db.String(512), unique=True)
+    repository = db.Column(db.String(256), index=True)
+    public_key = db.Column(db.String(128))
+    private_key = db.Column(db.String(512))
     update_code = db.Column(db.String(32), unique=True, index=True)
 
     id = db.Column(db.String(32), index=True, nullable=False)
@@ -72,12 +72,13 @@ class Dojos(db.Model):
     password = db.Column(db.String(128))
 
     data = db.Column(JSONB)
-    data_fields = ["type", "award", "course", "pages", "privileged", "importable", "comparator", "show_scoreboard"]
+    data_fields = ["type", "award", "course", "pages", "privileged", "importable", "comparator", "show_scoreboard", "shared_repository"]
     data_defaults = {
         "pages": [],
         "privileged": False,
         "importable": True,
         "show_scoreboard": True,
+        "shared_repository": False,
     }
 
     users = db.relationship("DojoUsers", back_populates="dojo")
@@ -200,7 +201,10 @@ class Dojos(db.Model):
     def path(self):
         if hasattr(self, "_path"):
             return self._path
-        return DOJOS_DIR / self.hex_dojo_id
+        if self.shared_repository:
+            return DOJOS_DIR / f"shared-{hashlib.md5(self.repository.encode()).hexdigest()}"
+        else:
+            return DOJOS_DIR / self.hex_dojo_id
 
     @contextlib.contextmanager
     def located_at(self, path):


### PR DESCRIPTION
Adds base functionality for including multiple dojos in a single repository (CURRENTLY UNFINISHED).

As of now, the dojo.yml can optionally have a `dojos` key, which is a list of standard dojo yml objects. All modules live in the base directory, and are loaded conditionally per dojo yml object. (https://github.com/2stinkysocks/example-monorepo-dojo)

Current issues:
All dojos in a shared repository must not exist during dojo creation, or they will all fail.
There is no mechanism for migrating existing dojos into a single repository.
I have not tested a lot of existing features, and there may be some side effects I haven't found.
I have not tested github ci at all.

Currently working:
Shared repositories can be loaded as usual, multiple dojos will be created. 

Updating dojos will update only the one for which update was clicked. The files for shared repositories are updated any time any dojo is updated, but the database will only be changed for the dojo which update was called on (I don't think this has side effects, needs further testing). The git hash for all dojos in a single repo will be the same in the admin page.
Files for shared repos are stored under the same directory, with the format `shared-{repository_url_md5}`

Promoting dojos works (single boolean column change).