### PR TITLE
Workspace: Use resolved challenge's image and privileged runtime

### DIFF
--- a/dojo_plugin/api/v1/docker.py
+++ b/dojo_plugin/api/v1/docker.py
@@ -306,7 +306,8 @@ def start_challenge(user, dojo_challenge, practice, *, as_user=None):
         practice=practice,
     )
 
-    insert_challenge(container, as_user, dojo_challenge)
+    if dojo_challenge.path.exists():
+        insert_challenge(container, as_user, dojo_challenge)
 
     if practice:
         flag = "practice"

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -506,7 +506,7 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
                 challenge
                 for module in dojo.modules
                 for challenge in module.challenges
-                if not challenge.path.exists()
+                if not (challenge.data.get("image") or challenge.path.exists())
             ]
             assert not missing_challenge_paths, "".join(
                 f"Missing challenge path: {challenge.module.id}/{challenge.id}\n"

--- a/test/dojos/privileged_dojo.yml
+++ b/test/dojos/privileged_dojo.yml
@@ -3,8 +3,5 @@ modules:
   - id: test
     challenges:
       - id: test
+        image: pwncollege/challenge-simple
         privileged: true
-        import:
-          dojo: example
-          module: world
-          challenge: earth

--- a/test/test_challenges.py
+++ b/test/test_challenges.py
@@ -193,11 +193,10 @@ def test_reset_home_directory(random_user_name, random_user_session, example_doj
 def test_unprivileged_challenge(random_user_name, random_user_session, example_dojo):
     start_challenge(example_dojo, "hello", "apple", session=random_user_session)
     try:
-        workspace_run("unshare true", user=random_user_name)
+        result = workspace_run("unshare true", user=random_user_name)
+        assert False, f"Expected unshare to fail, but it succeeded: {(result.stdout, result.stderr)}"
     except subprocess.CalledProcessError as e:
         assert "unshare: unshare failed: Operation not permitted" in e.stderr, f"Expected unshare to fail, but got: {(e.stdout, e.stderr)}"
-    else:
-        assert False, f"Expected unshare to fail, but it succeeded: {(e.stdout, e.stderr)}"
 
 
 def test_privileged_challenge(random_user_name, random_user_session, privileged_dojo):


### PR DESCRIPTION
We shouldn't allow an importer to override whether or not the challenge runtime is privileged.

This change also makes it so that if a challenge specifies an image, it does not need to have challenge files.