### PR TITLE
Fix Accordion Item Overexpansion

### DIFF
--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -62,6 +62,10 @@
   background-color: var(--foreground);
   border-radius: 0.5em;
 }
+
+.challenge-hidden .workspace-ssh {
+  display: none !important;
+}
 </style>
 
 


### PR DESCRIPTION
When expanding an accordion item, the height of the SSH hint is being taken into consideration. However, the SSH hint is not displayed when the item finishes expanding, so the item overshoots before snapping to the correct height. By setting the hint to not display when inside a hidden challenge workspace, the item does not incorrectly add the height of the hint.

So, whoops, this one was my fault (introduced in 0bf38c5).

closes #823 