### PR TITLE
Improve error message for duplicate challenge IDs to include module id for easier debugging

### DIFF
--- a/dojo_plugin/pages/dojo.py
+++ b/dojo_plugin/pages/dojo.py
@@ -200,26 +200,32 @@ def update_dojo(dojo, update_code=None):
         db.session.rollback()
         error = str(e)
         match = re.search(r"Key \(dojo_id, module_index, id\)=\(.*?,\s*(\d+),\s*([^\)]+)\)", error)
-        if match:
-            module_index, challenge_id = match.groups()
-            module_index = int(module_index)
-            challenge_id = challenge_id.strip()
-            try:
-                module = dojo.modules[module_index]
-                challenge = next((c for c in module.challenges if c.id == challenge_id), None)
-                module_name = module.name
-                challenge_name = challenge.name if challenge else challenge_id
-                error_message = f"Duplicate ID used in Module: {module_name}, for Challenge: {challenge_name}."
-                return {"success": False, "error": error_message}, 400
-            except (IndexError, StopIteration):
-                 return {"success": False, "error": "Database integrity error: Could not parse module/challenge."}, 400
-        else:
-            print(f"ERROR: Dojo failed for {dojo}", file=sys.stderr, flush=True)
+
+        if not match:
+            print(f"ERROR: Dojo update failed with unparsed IntegrityError for {dojo}", file=sys.stderr, flush=True)
             traceback.print_exc(file=sys.stderr)
-            return {"success": False, "error": "Database integrity error"}, 400
+            return {"success": False, "error": "Database integrity error: A challenge ID is likely duplicated."}, 400
+
+        module_index_str, challenge_id = match.groups()
+        module_index = int(module_index_str)
+        challenge_id = challenge_id.strip()
+
+        if module_index >= len(dojo.modules):
+            print(f"ERROR: IntegrityError for {dojo} references out-of-bounds module_index {module_index}", file=sys.stderr, flush=True)
+            return {"success": False, "error": "Database integrity error: Inconsistent module data."}, 400
+
+        module = dojo.modules[module_index]
+        challenge = next((c for c in module.challenges if c.id == challenge_id), None)
+
+        module_name = module.name
+        challenge_name = challenge.name if challenge else challenge_id
+        error_message = f"Duplicate ID '{challenge_id}' used in module '{module_name}'."
+
+        return {"success": False, "error": error_message}, 400
+
     except Exception as e:
         db.session.rollback()
-        print(f"ERROR: Dojo failed for {dojo}", file=sys.stderr, flush=True)
+        print(f"ERROR: Dojo update failed for {dojo}", file=sys.stderr, flush=True)
         traceback.print_exc(file=sys.stderr)
         return {"success": False, "error": str(e)}, 400
     return {"success": True}

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -427,8 +427,14 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
     challenge_resources = []
     regular_resources = []
     for module_data in dojo_data.get("modules", []):
+        seen_challenge_ids = set()
         for resource_index, resource_data in enumerate(module_data.get("resources", [])):
             if resource_data.get("type") == "challenge":
+                challenge_id = resource_data.get("id")
+                if challenge_id in seen_challenge_ids:
+                    raise AssertionError(f"Duplicate challenge id: {challenge_id} in module {module_data.get('id')}")
+                seen_challenge_ids.add(challenge_id)
+
                 resource_data["unified_index"] = resource_index
                 challenge_resources.append((module_data, resource_data))
             else:

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -658,16 +658,7 @@ def dojo_create(user, repository, public_key, private_key, spec):
         deploy_url = f"https://github.com/{repository}/settings/keys"
         raise RuntimeError(f"Failed to clone: <a href='{deploy_url}' target='_blank'>add deploy key</a>")
 
-    except IntegrityError as e:
-        db.session.rollback()
-        if "dojo_challenges_dojo_id_module_index_id_key" in str(e):
-            match = re.search(r"Key \(dojo_id, module_index, id\)=\((?P<dojo_id>\d+), (?P<module_index>\d+), '(?P<challenge_id>[^']*)'\) already exists", str(e))
-            if match:
-                challenge_id = match.group("challenge_id")
-                module_index = int(match.group("module_index"))
-                module = next((m for m in dojo.modules if m.module_index == module_index), None)
-                module_id = module.id if module else "unknown"
-                raise RuntimeError(f"Duplicate challenge id: '{challenge_id}' in module '{module_id}'")
+    except IntegrityError:
         raise RuntimeError("This repository already exists as a dojo")
 
     except AssertionError as e:


### PR DESCRIPTION
**Purpose of the PR:**

When parsing the yml files if a module contains duplicate challenge `ids` we now raise an assertion caused it to hit an `Internal Server Error`, with this PR that includes the module id:

```py
raise AssertionError(f"Duplicate challenge id: {challenge_id} in module {module_data.get('id')}")
```

This makes the error message explicit about *which module* contains the duplicate id, improving diagnosability compared to a generic "Internal Server Error".

**Why this change**

* Previously a duplicate challenge id could result in a vague server error that made it hard to identify the source of the problem.
* Returning a clear assertion message that includes the module id helps maintainers and dojo authors find and fix the problematic module quickly.

**Before**

* Duplicate challenge IDs → generic Internal Server Error (hard to trace).
<img width="829" height="451" alt="error_before" src="https://github.com/user-attachments/assets/b958b112-7d49-470d-be5b-49c079677a60" />

**After**

* Duplicate challenge IDs → `AssertionError("Duplicate challenge id: <id> in module <module_id>")`, making it clear which module needs attention.
<img width="880" height="497" alt="error_after" src="https://github.com/user-attachments/assets/5a7598d0-7c34-41f2-aad5-d7db558777ac" />

**Files changed**

* `dojo_plugin/utils/dojo.py`: inside `dojo_from_spec(...)` function, while iterating module resources.

**How to test**

1. Create a dojo with a `module.yml` where one module contains two resources of type `challenge` with the same `id`.
2. Click on the `update` button on admin panel the dojo.
3. Confirm the raised error message contains the duplicate challenge id and the module id:

```
AssertionError: Duplicate challenge id: <duplicate_id> in module <module_id>
```

**TLDR: clearer error when a module contains duplicate challenge IDs from generic `Internal Server Error` to message now includes the module id to help locate the issue.**
