### PR TITLE
SSH: Fix terminal styles from resetting (RIS)

### DIFF
--- a/sshd/enter.py
+++ b/sshd/enter.py
@@ -80,7 +80,6 @@ def main():
 
         if status != "running":
             attempts += 1
-            print("\033c", end="")
             print("\r", " " * 80, f"\rConnecting -- instance status: {status}", end="")
             time.sleep(1)
             continue


### PR DESCRIPTION
## Problem:

When connected to workspace via ssh, starting a new challenge would automatically setup the workspace container and re-enter ssh. During the process an RIS escape sequence is printed to erase the content and start a clean session. However, this escape sequence would also reset the terminal colors and styles set by the original session leading to inconsistent terminal looks.


## Solution:
- Remove the escape sequence and keep the session content from previous challenge since this could be beneficial anyways.

