### PR TITLE
Update ssh hint to dojo.pwn.college in the dojo_theme templates

### DIFF
--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -262,7 +262,7 @@
               </div>
               <div class="workspace-ssh">
                 <h3>Connect with SSH</h3>
-                Link your <a href="/settings#ssh-key" target="_blank">SSH key</a>, then connect with: <code>ssh hacker@pwn.college</code>
+                Link your <a href="/settings#ssh-key" target="_blank">SSH key</a>, then connect with: <code>ssh hacker@dojo.pwn.college</code>
               </div>
               {% include "components/actionbar.html" %}
             </div>

--- a/dojo_theme/templates/settings.html
+++ b/dojo_theme/templates/settings.html
@@ -132,7 +132,7 @@
           </form><b><label for="ssh-key-create">How To Create a SSH Key</label></b>
           <p id="ssh-key-create">You can quickly generate an ssh key by running <code>ssh-keygen -f key -N ''</code> in a terminal on your (unix-friendly) host machine.
           This will generate files <code>key</code> and <code>key.pub</code>, which are your private and public keys respectively.
-          Once you have linked your <em>public</em> ssh key to your account, you can connect to the dojo over ssh with <code>ssh -i key hacker@pwn.college</code>.</p>
+          Once you have linked your <em>public</em> ssh key to your account, you can connect to the dojo over ssh with <code>ssh -i key hacker@dojo.pwn.college</code>.</p>
         </div>
 
         {% if discord_enabled %}


### PR DESCRIPTION
Changed the ssh hint from `hacker@pwn.college` to `hacker@dojo.pwn.college`.

@robwaz 

# Before
<img width="686" height="95" alt="Screenshot from 2025-09-18 18-29-56" src="https://github.com/user-attachments/assets/c6b01b7f-d4ac-4aa9-892b-ca5865a74a21" />
<img width="765" height="165" alt="Screenshot from 2025-09-18 18-28-28" src="https://github.com/user-attachments/assets/42372d4e-2ed6-496a-9a65-932b6d110bcd" />

# After
<img width="845" height="87" alt="Screenshot from 2025-09-18 18-29-39" src="https://github.com/user-attachments/assets/10d34624-51f7-425d-bb81-bf4deed83d39" />
<img width="531" height="50" alt="Screenshot from 2025-09-18 18-29-00" src="https://github.com/user-attachments/assets/bf6a696c-6ad0-4268-8e05-7761e16b8fc5" />
