### PR TITLE
Site: Scroll to challenge on direct links

### DIFF
--- a/dojo_plugin/pages/dojo.py
+++ b/dojo_plugin/pages/dojo.py
@@ -109,6 +109,7 @@ def view_dojo_path(dojo, path, subpath=None):
     if module:
         if subpath:
             DojoChallenges.query.filter_by(dojo=dojo, module=module, id=subpath).first_or_404()
+            return view_module(dojo, module, scroll_to_challenge=subpath)
         return view_module(dojo, module)
     elif path in dojo.pages and not subpath:
         return view_page(dojo, path)
@@ -326,7 +327,7 @@ def dojo_solves(dojo, solves_code=None, format="csv"):
         return {"success": False, "error": "Invalid format"}, 400
 
 
-def view_module(dojo, module):
+def view_module(dojo, module, scroll_to_challenge=None):
     user = get_current_user()
     user_solves = set(solve.challenge_id for solve in (
         module.solves(user=user, ignore_visibility=True, ignore_admins=False) if user else []
@@ -422,6 +423,7 @@ def view_module(dojo, module):
         module_description_edit_url=module_description_edit_url,
         challenge_description_edit_urls=challenge_description_edit_urls,
         resource_description_edit_urls=resource_description_edit_urls,
+        scroll_to_challenge=scroll_to_challenge,
     )
 
 

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -185,7 +185,7 @@
 
         {% call(header) accordion_item("module-content", loop.index, lock_challenge, challenge_index=ns.challenge_count) %}
           {% if header %}
-            <h4 class="accordion-item-name challenge-name {{ active }}" data-challenge-index="{{ ns.challenge_count }}" data-challenge-name="{{ challenge.name or challenge.id }}" id="challenges-header-{{ ns.challenge_count }}">
+            <h4 class="accordion-item-name challenge-name {{ active }}" data-challenge-index="{{ ns.challenge_count }}" data-challenge-id="{{ challenge.id }}" data-challenge-name="{{ challenge.name or challenge.id }}" id="challenges-header-{{ ns.challenge_count }}">
                 <i class="challenge-icon pr-3 {{ icon }} {{ solved }} "></i>
                 {% if lock_challenge %}
                 <div class="challenge-text-wrapper">
@@ -307,4 +307,31 @@
 <script defer src="{{ url_for('views.themes', path='js/dojo/actionbar.js') }}"></script>
 <script defer src="{{ url_for('views.themes', path='js/dojo/challenges.js') }}"></script>
 <script defer onload="loadScoreboard(30, 1);" src="{{ url_for('views.themes', path='js/dojo/scoreboard.js') }}"></script>
+{% if scroll_to_challenge %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  setTimeout(() => {
+    const el = document.querySelector('[data-challenge-id="{{ scroll_to_challenge }}"]');
+    if (!el) return;
+    const idx = el.getAttribute('data-challenge-index');
+    const btn = idx && document.getElementById(`challenges-header-button-${idx}`);
+    
+    const scrollToChallenge = () => {
+      const rect = el.getBoundingClientRect();
+      const offsetTop = window.pageYOffset + rect.top - 60;
+      window.scrollTo({
+        top: offsetTop,
+        behavior: 'smooth'
+      });
+    };
+    if (btn && btn.getAttribute('aria-expanded') !== 'true') {
+      btn.click();
+      setTimeout(scrollToChallenge, 400);
+    } else {
+      scrollToChallenge();
+    }
+  }, 500);
+});
+</script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
This pull request adds support for automatically scrolling to a specific challenge within a dojo module page when a subpath is provided, improving the user experience for deep linking and navigation. The changes include backend updates to pass the challenge ID to the template, template adjustments to support scrolling, and JavaScript to perform the scroll action.