### PR TITLE
Add API endpoints for use by external applications

### DIFF
--- a/dojo_plugin/api/__init__.py
+++ b/dojo_plugin/api/__init__.py
@@ -14,6 +14,7 @@ from .v1.workspace_tokens import workspace_tokens_namespace
 from .v1.workspace import workspace_namespace
 from .v1.search import search_namespace
 from .v1.test_error import test_error_namespace
+from .v1.integration import integrations_namespace
 
 api = Blueprint("pwncollege_api", __name__)
 
@@ -37,3 +38,4 @@ api_v1.add_namespace(workspace_tokens_namespace, "/workspace_tokens")
 api_v1.add_namespace(workspace_namespace, "/workspace")
 api_v1.add_namespace(search_namespace, "/search")
 api_v1.add_namespace(test_error_namespace, "/test_error")
+api_v1.add_namespace(integrations_namespace, "/integrations")

--- a/dojo_plugin/api/v1/integration.py
+++ b/dojo_plugin/api/v1/integration.py
@@ -1,10 +1,9 @@
 import logging
 import docker
-
 from flask import request, session
 from flask_restx import Namespace, Resource
-
 from CTFd.plugins import bypass_csrf_protection
+from CTFd.models import Users, Solves
 
 logger = logging.getLogger(__name__)
 
@@ -12,4 +11,61 @@ integrations_namespace = Namespace(
     "integrations", description="Endpoints for external integrations",
     decorators=[bypass_csrf_protection]
 )
+
+# Authentication of external applications.
+def authenticate_application(token):
+    return None, ({
+        "success": False,
+        "error": "Not Implemented",
+        }, 405)
+
+# Authentication of the internal dojo cli application.
+def authenticate_container(token):
+    docker_client = docker.DockerClient(base_url="unix://var/run/docker.sock")
+
+    container = None
+    try:
+        for c in docker_client.containers.list():
+            if c.labels.get("dojo.auth_token") == token:
+                continer = c
+                break
+    except Exception as e:
+        logger.error(f"Exception while listing containers: {e}")
+        return None, ({
+            "success": False,
+            "error": "Authentication processed failed"
+            }, 500)
+
+    if not container:
+        return None, ({
+            "success": False,
+            "error": "Invalid container authentication token",
+            }, 401)
+    
+    user_id = int(container.labels.get("dojo.as_user_id"))
+    session["id"] = user_id
+    user = Users.query.filter_by(id=user_id).one()
+
+    return user, None
+
+def authenticate(token, type):
+    if not token:
+        return None, ({
+            "success": False,
+            "error": "Authentication token is required",
+            }, 400)
+
+    match type:
+        case "container":
+            return authenticate_container(token)
+        
+        case "application":
+            return authenticate_application(token)
+        
+        case _:
+            return None, ({
+                "success": False,
+                "error": f"Unrecognized authentication type \"{type}\"",
+                }, 400)
+
 

--- a/dojo_plugin/api/v1/integration.py
+++ b/dojo_plugin/api/v1/integration.py
@@ -1,0 +1,15 @@
+import logging
+import docker
+
+from flask import request, session
+from flask_restx import Namespace, Resource
+
+from CTFd.plugins import bypass_csrf_protection
+
+logger = logging.getLogger(__name__)
+
+integrations_namespace = Namespace(
+    "integrations", description="Endpoints for external integrations",
+    decorators=[bypass_csrf_protection]
+)
+


### PR DESCRIPTION
Add API endpoints at `/pwncollege_api/v1/integrations` for use by external applications. The primary purpose of these endpoints is for a **cli program** inside of a challenge container to be able to authenticate. This could be expanded for use outside of the challenge container later, allowing for the ssh-ers to never have to visit the website again.

Something to consider is what capabilities these endpoints should have. A concern is that a malicious dojo/challenge could mess with an unsuspecting dojo user. Someone *other than me* should make decisions on what capabilities a program within the container should have with respect to interacting with pwn.college / CTFd.

Implementation is derived from Yan's work in #767

The `check_authentication` endpoint was added for testing purposes, and can be removed in the future.