### PR TITLE
Site: Fix sensai proxy headers

### DIFF
--- a/nginx/conf.d/location-sensai.conf
+++ b/nginx/conf.d/location-sensai.conf
@@ -2,6 +2,7 @@ location @sensai {
     set $redirect_uri $upstream_http_redirect_uri;
     set $redirect_auth $upstream_http_redirect_auth;
     proxy_pass $redirect_uri;
+    include /etc/nginx/conf.d/proxy-headers.conf;
     proxy_set_header Authorization $redirect_auth;
     proxy_set_header X-Forwarded-Prefix /sensai;
     proxy_ignore_headers X-Accel-Redirect;


### PR DESCRIPTION
From nginx docs (https://nginx.org/en/docs/http/ngx_http_proxy_module.html):

```
Syntax:	proxy_set_header field value;
Default:	
proxy_set_header Host $proxy_host;
proxy_set_header Connection close;
Context:	http, server, location
```
Allows redefining or appending fields to the request header [passed](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass_request_headers) to the proxied server. The value can contain text, variables, and their combinations. These directives are inherited from the previous configuration level if and only if there are no proxy_set_header directives defined on the current level.

---

In other words, if we `proxy_set_headers` we lose the higher-hierarchy values (and so must set them again).