### PR TITLE
Site: Force workspace notification banner to wrap message text

### DIFF
--- a/dojo_theme/templates/components/actionbar.html
+++ b/dojo_theme/templates/components/actionbar.html
@@ -148,7 +148,7 @@
     padding: 1em;
     height: 4em;
     bottom: 4em;
-    white-space: nowrap;
+    white-space: normal;
     text-align: center;
     overflow: hidden;
     display: none;


### PR DESCRIPTION
Currently, if the banner message is too long and/or the window width is too small, this happens:
<img width="942" height="351" alt="Screenshot 2025-10-21 at 17 43 23" src="https://github.com/user-attachments/assets/7c38898f-4056-4e54-b839-0f3c61569867" />
This PR changes it so the text wraps correctly.
<img width="969" height="388" alt="Screenshot 2025-10-21 at 17 46 58" src="https://github.com/user-attachments/assets/7c8b0bb7-8cf4-4615-9235-009f95d9ef61" />
The height/margin could be better.