### PR TITLE
Workspace: Add `dojo` Command-Line Application

### DIFF
--- a/dojo_plugin/api/v1/docker.py
+++ b/dojo_plugin/api/v1/docker.py
@@ -11,6 +11,7 @@ import docker.errors
 import docker.types
 import redis
 from flask import abort, request, current_app
+from itsdangerous.url_safe import URLSafeTimedSerializer
 from flask_restx import Namespace, Resource
 from CTFd.cache import cache
 from CTFd.models import Users, Solves
@@ -24,7 +25,6 @@ from ...utils import (
     container_name,
     lookup_workspace_token,
     resolved_tar,
-    serialize_user_container,
     serialize_user_flag,
     user_docker_client,
     user_node,
@@ -99,7 +99,7 @@ def start_container(docker_client, user, as_user, user_mounts, dojo_challenge, p
         ]
     )[:64]
 
-    auth_token = serialize_user_container(user.id, dojo_challenge.id)
+    auth_token = URLSafeTimedSerializer(current_app.config["SECRET_KEY"]).dumps([user.id, dojo_challenge.id, "cli-auth-token"])
 
     challenge_bin_path = "/run/challenge/bin"
     dojo_bin_path = "/run/dojo/bin"

--- a/dojo_plugin/api/v1/user.py
+++ b/dojo_plugin/api/v1/user.py
@@ -1,12 +1,47 @@
-from ...utils.workspace import authed_only_cli
-from flask import session
 from flask_restx import Namespace, Resource
+from flask import current_app, request, session
+from itsdangerous.url_safe import URLSafeTimedSerializer
 from CTFd.utils.decorators import authed_only
 from CTFd.utils.user import get_current_user
+from CTFd.models import Users
+from ...utils import get_current_container
 
-user_namespace = Namespace(
-    "user", description="User management endpoints"
-)
+user_namespace = Namespace("user", description="User management endpoints")
+
+
+def authed_only_cli(func):
+    def wrapper(*args, **kwargs):
+        auth_header = request.headers.get("Authorization")
+        if not auth_header:
+            return func(*args, **kwargs)
+        try:
+            assert auth_header.startswith("Bearer ")
+            token = auth_header[len("Bearer "):].strip()
+            user_id, challenge_id, token_tag = URLSafeTimedSerializer(
+                current_app.config["SECRET_KEY"]
+            ).loads(token, max_age=21600)
+            assert token_tag == "cli-auth-token"
+        except Exception:
+            return {"success": False, "error": "Failed to authenticate container token."}, 401
+        user = Users.query.filter_by(id=user_id).one()
+        container = get_current_container(user)
+        if container is None:
+            return {"success": False, "error": "No active challenge container."}, 403
+        if container.labels["dojo.challenge_id"] != challenge_id:
+            return {"success": False, "error": "Token failed to authenticate active challenge container."}, 403
+        try:
+            session.update({
+                "id": user.id,
+                "name": user.name,
+                "type": user.type,
+                "verified": user.verified,
+            })
+            return func(*args, **kwargs)
+        finally:
+            for key in ("id", "name", "type", "verified"):
+                session.pop(key, None)
+    return wrapper
+
 
 @user_namespace.route("/me")
 class CurrentUser(Resource):
@@ -15,14 +50,6 @@ class CurrentUser(Resource):
     def get(self):
         """Get current user information"""
         user = get_current_user()
-
-        # Don't expose as much info to containers.
-        if session.get("cli", False):
-            return {
-                "id":   -1            if user.hidden else user.id,
-                "name": "Hidden User" if user.hidden else user.name,
-            }
-
         return {
             "id": user.id,
             "name": user.name,

--- a/dojo_plugin/utils/__init__.py
+++ b/dojo_plugin/utils/__init__.py
@@ -13,7 +13,7 @@ import bleach
 import docker
 import docker.errors
 from flask import current_app, Response, Markup, abort, g
-from itsdangerous.url_safe import URLSafeSerializer, URLSafeTimedSerializer
+from itsdangerous.url_safe import URLSafeSerializer
 from CTFd.exceptions import UserNotFoundException, UserTokenExpiredException
 from CTFd.models import db, Solves, Challenges, Users
 from CTFd.utils.encoding import hexencode
@@ -67,30 +67,6 @@ def get_all_containers(dojo=None):
         for docker_client in all_docker_clients()
         for container in docker_client.containers.list(filters=filters, ignore_removed=True)
     ]
-
-
-def validate_user_container(token: str, secret=None) -> tuple[int, str]:
-    """
-    Returns the userID and challenge id of the signed container token.
-    Raises an exception if validation of signature fails.
-    """
-    if secret is None:
-        secret = current_app.config["SECRET_KEY"]
-    serializer = URLSafeTimedSerializer(secret)
-    data = serializer.loads(token, max_age=(21600))
-    return (data[0], data[1])
-
-
-def serialize_user_container(account_id: int, challenge_id: str, secret=None) -> str:
-    """
-    Gives a unique token for a container based on the user and current challenge.
-    """
-    if secret is None:
-        secret = current_app.config["SECRET_KEY"]
-    serializer = URLSafeTimedSerializer(secret)
-    data = [account_id, challenge_id, "cli-container-token"]
-    token = serializer.dumps(data)
-    return token
 
 
 def serialize_user_flag(account_id, challenge_id, *, secret=None):

--- a/test/test_integrations.py
+++ b/test/test_integrations.py
@@ -1,22 +1,8 @@
-import subprocess
+from utils import start_challenge, workspace_run
 
-from utils import workspace_run, start_challenge
 
 def test_whoami(random_user, welcome_dojo):
-    """
-    Tests the dojo application with the "whoami" command.
-
-    Likely reasons for failure are:
-    - Issue with the dojo application.
-    - Issue with the integrations api.
-    - Issue with container (challenge -> nginx) networking.
-    """
-    # Make sure we have a running challenge container.
     name, session = random_user
     start_challenge(welcome_dojo, "welcome", "challenge", session=session)
-
-    try:
-        result = workspace_run("dojo whoami", user=name)
-        assert name in result.stdout, f"Expected hacker to be {name}, got: {(result.stdout, result.stderr)}"
-    except subprocess.CalledProcessError as error:
-        assert False, f"Exception in when running command \"dojo whoami\": {(error.stdout, error.stderr)}"
+    result = workspace_run("dojo whoami", user=name)
+    assert name in result.stdout, f"Expected hacker to be {name}, got: {(result.stdout, result.stderr)}"

--- a/test/utils.py
+++ b/test/utils.py
@@ -53,7 +53,6 @@ def _get_container_ip(container_name):
 
 DOJO_IP = _get_container_ip(DOJO_CONTAINER) or os.getenv("DOJO_IP", "localhost")
 DOJO_URL = os.getenv("DOJO_URL", f"http://{DOJO_IP}:80/")
-DOJO_API = f"{DOJO_URL}pwncollege_api/v1"
 DOJO_SSH_HOST = os.getenv("DOJO_SSH_HOST", DOJO_IP)
 TEST_DOJOS_LOCATION = pathlib.Path(__file__).parent / "dojos"
 

--- a/workspace/core/dojo-cli.nix
+++ b/workspace/core/dojo-cli.nix
@@ -1,28 +1,8 @@
 { pkgs }:
 
-let in pkgs.stdenv.mkDerivation {
-  name = "dojo";
-  src = ./dojo-cli.py;
-
-  buildInputs = [ pkgs.python3 ];
-
-  unpackPhase = ''
-    runHook preUnpack
-    cp $src $PWD
-    runHook postUnpack
-  '';
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/bin
-    echo "#!${pkgs.python3}/bin/python3" > $out/bin/dojo
-    cat ${./dojo-cli.py} >> $out/bin/dojo
-    chmod +x $out/bin/dojo
-    runHook postInstall
-  '';
-
-  meta = with pkgs.lib; {
-    description = "CLI application to interact with the pwncollege dojo.";
-    platforms = platforms.linux;
-  };
-}
+let
+  python = pkgs.python3.withPackages (ps: [ ps.requests ]);
+in
+pkgs.writeShellScriptBin "dojo" ''
+  exec ${python}/bin/python3 ${./dojo-cli.py} "$@"
+''

--- a/workspace/core/dojo-cli.py
+++ b/workspace/core/dojo-cli.py
@@ -1,131 +1,39 @@
-import urllib.request
-import urllib.parse
-import urllib.error
 import argparse
-import json
-import sys
 import os
+import sys
+import requests
 
-DOJO_URL = "http://pwn.college:80"
-DOJO_API = f"{DOJO_URL}/pwncollege_api/v1"
+DOJO_API = "http://pwn.college:80/pwncollege_api/v1"
+DOJO_AUTH_TOKEN = os.environ.get("DOJO_AUTH_TOKEN")
 
-INCORRECT_USAGE = 1
-TOKEN_NOT_FOUND = 2
-API_ERROR = 3
 
-def get_token() -> str | None:
-    return os.environ.get("DOJO_AUTH_TOKEN")
+def whoami():
+    response = requests.get(
+        f"{DOJO_API}/users/me",
+        headers={"Authorization": f"Bearer {DOJO_AUTH_TOKEN}"},
+        timeout=5.0,
+    )
+    data = response.json()
+    if not response.ok:
+        sys.exit(data.get("error", "Unknown error"))
+    print(f"You are the epic hacker {data['name']} ({data['id']}).")
 
-def apiRequest(endpoint: str, method: str = "GET", args: dict[str, str] = {}) -> tuple[int, str | None, dict[str, str]]:
-    """
-    Make a request to the given integration endpoint.
-    Will call `sys.exit` if the auth token is not specified in the environment.
-
-    Returns the http response code, an error message (or `None`), and a dictionary with the json response data.
-
-    Supports `GET` and `POST` methods.
-    """
-    # Container authentication token required.
-    token = get_token()
-    if not token:
-        print("Failed to find authentication token (DOJO_AUTH_TOKEN). Did you change environment variables?")
-        sys.exit(TOKEN_NOT_FOUND)
-
-    # Append args to URL.
-    url = f"{DOJO_API}{endpoint}"
-    if (len(args) > 0 and method == "GET"):
-        url += f"?{urllib.parse.urlencode(args)}"
-
-    # Construct HTTP request.
-    match method:
-        case "GET":
-            request = urllib.request.Request(
-                url,
-                method="GET",
-                headers={
-                    "AuthToken":token
-                }
-            )
-        case "POST":
-            data = json.dumps(args).encode()
-            request = urllib.request.Request(
-                url,
-                method="POST",
-                data=data,
-                headers={
-                    "AuthToken":token,
-                    "Content-Type": "application/json; charset=utf-8",
-                }
-            )
-        case _:
-            return 0, f"Unsupported method \"{method}\".", {}
-
-    # Make request, handle errors.
-    try:
-        response = urllib.request.urlopen(request, timeout=5.0)
-    except urllib.error.HTTPError as exception:
-        try:
-            return exception.code, json.loads(exception.read().decode())["error"], {}
-        except:
-            return exception.code, exception.reason, {}
-    except urllib.error.URLError as exception:
-        return 0, exception.reason, {}
-
-    # Parse response.
-    try:
-        response_json = json.loads(response.read().decode())
-    except json.JSONDecodeError as exception:
-        return response.status, exception.msg, {}
-    except UnicodeDecodeError as exception:
-        return response.status, exception.reason, {}
-    except Exception as exception:
-        return response.status, "Exception while parsing reponse.", {}
-
-    return response.status, None, response_json
-
-def whoami() -> int:
-    """
-    Calls the WHOAMI integration api, printing information
-    about the current user such as userID and username.
-    """
-
-    # Make request.
-    status, error, jsonData = apiRequest("/users/me")
-    if error is not None:
-        print(f"WHOAMI request failed ({status}): {error}")
-        sys.exit(API_ERROR)
-
-    # Print who's hacking.
-    print(f"You are the epic hacker {jsonData["name"]} ({jsonData["id"]}).")
-    return 0
 
 def main():
     parser = argparse.ArgumentParser(
         prog="dojo",
-        description="Command-line application for interacting with the dojo from inside of the challenge environment."
+        description="Command-line application for interacting with the dojo from inside of the challenge environment.",
     )
-
-    subparsers = parser.add_subparsers(
-        dest="command",
-        help="Dojo command to execute, not case sensitive."
-    )
-
-    whoami_parser = subparsers.add_parser(
-        name="whoami",
-        help="Prints information about the current user (you!)."
-    )
-
+    subparsers = parser.add_subparsers(dest="command", help="Dojo command to execute, not case sensitive.")
+    subparsers.add_parser(name="whoami", help="Prints information about the current user (you!).")
     args = parser.parse_args()
-
-    if args.command is None:
-        parser.print_help()
-        return INCORRECT_USAGE
-
-    if args.command.lower() == "whoami":
+    if not DOJO_AUTH_TOKEN:
+        sys.exit("Missing DOJO_AUTH_TOKEN.")
+    if args.command and args.command.lower() == "whoami":
         return whoami()
-
     parser.print_help()
-    return INCORRECT_USAGE
+    sys.exit(1)
+
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/workspace/core/init.nix
+++ b/workspace/core/init.nix
@@ -30,10 +30,6 @@ let
       mkdir -p /bin && ln -sfT /run/dojo/bin/sh /bin/sh
     fi
 
-    if [ -x /nix/store/*/bin/dojo ]; then
-      mkdir -p /run/dojo/bin && ln -sf /nix/store/*/bin/dojo /run/dojo/bin/dojo
-    fi
-
     home_directory="/home/hacker"
     home_mount_options="$(findmnt -nro OPTIONS -- "$home_directory")"
     if [ -n "$home_mount_options" ] && ! printf '%s' "$home_mount_options" | grep -Fqw 'nosuid'; then


### PR DESCRIPTION
# Overview
Adds a command line application, `dojo`, which allows for limited interaction with a custom set of integration APIs. The application authenticates using the `DOJO_AUTH_TOKEN` environment variable, which has been changed to be a set of *signed values* tying the token to the user and their current challenge.

In order to allow for communication between the application and the dojo, **challenge containers** have been given network access to the **nginx container**. In theory the iptables configuration in `dojo/dojo-init` should ensure that this is the *only* other container that the challenge containers can access, but someone more familiar with iptables should sanity check this.

# Integrations
Added a new namespace to the pwn.college api, `integrations`. Endpoints within the integrations namespace expect requests to use the ~~`auth_token`~~ `AuthToken` header to provide the current container's authentication token.

# Command
## whoami
A simple command which prints out information about the current user. Prints the user's name and id.

Invoked by calling `dojo whoami` in a terminal.