### PR TITLE
CI: Make coverage report upload in single-node mode only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
           fi
 
       - name: Upload coverage reports to Codecov
+        if: matrix.mode == 'singlenode'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Fixed a small oversight in my original PR where coverage reports are attempted to be uploaded in multi-node mode as opposed to being skipped.

It should be skipped because the report isn't generated in multi-node.