### PR TITLE
Add skeleton for stress test tool for dojo performance evaluation

### DIFF
--- a/stress-test/README.md
+++ b/stress-test/README.md
@@ -1,0 +1,101 @@
+# pwn.college stress test — `pwn_users.json` generator
+
+A small, local stress test tool that generates synthetic user activity for pwn.college-style modules.
+It produces a JSON file (`pwn_users.json`) containing fake users, their usernames, total solves, and per-module solves. Use it to populate local dev fixtures, load-test dashboards, or exercise data pipelines without hitting any external services.
+
+> This tool only generates local data and makes no network requests. Do not use it to impersonate or spam real services.
+
+---
+
+## Features
+
+* Deterministic output via `seed` for reproducible tests.
+* Configurable target user count, with safe minimum and maximum limits.
+* Realistic-ish usernames with leetspeak and suffix variations.
+* Per-user list of modules solved with per-module solve counts.
+* Output in human-friendly JSON for easy consumption.
+
+---
+
+## Files
+
+* `stress_test.py` — Python script that generates the JSON (this is the script you provided).
+* `pwn_users.json` — generated output file (created after running the script).
+* `README.md` — this file.
+
+---
+
+## Requirements
+
+* Python 3.8 or newer. The script uses only Python standard library modules.
+
+---
+
+## Quick start
+
+Run the generator from the repository root:
+
+```bash
+python3 stress_test.py
+```
+
+By default the script writes `pwn_users.json` into the current working directory and prints:
+
+```
+wrote <N> users to pwn_users.json
+```
+
+To inspect the file:
+
+```bash
+jq '.' pwn_users.json | less
+# or, with Python
+python3 -c "import json,sys; print(len(json.load(open('pwn_users.json'))))"
+```
+
+---
+
+## Configuration
+
+The script contains a few top-level variables you can tweak:
+
+* `COUNT` — target number of users to generate. The script enforces:
+
+  * minimum: 10
+  * maximum: 15000
+* `seed` — PRNG seed for reproducible results.
+* `modules_pool` — list of module names used to sample per-user solves.
+
+If you want command-line control, add a simple `argparse` wrapper. Example snippet:
+
+```py
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--count", type=int, default=10000)
+parser.add_argument("--seed", type=int, default=12345)
+args = parser.parse_args()
+# then use args.count and args.seed in the script
+```
+
+---
+
+## Output format
+
+Each element in the JSON array is an object like:
+
+```json
+{
+  "Hacker UserName": "dark_cipher99",
+  "Number of Solves": 17,
+  "Modules Solved": [
+    { "module": "Reverse Engineering", "solves": 3 },
+    { "module": "Fuzz Dojo", "solves": 7 },
+    { "module": "Pwntools Tutorials", "solves": 7 }
+  ]
+}
+```
+
+The full file is a JSON array of these objects.
+
+---

--- a/stress-test/stress_test.py
+++ b/stress-test/stress_test.py
@@ -1,0 +1,41 @@
+import random, json, string, sys
+COUNT = 10000
+if COUNT < 10: COUNT = 10
+if COUNT > 15000: COUNT = 15000
+seed = 12345
+random.seed(seed)
+modules_pool = [
+"Your First Program","Software Introspection","Computer Memory","Hello Hackers",
+"Assembly Crash Course","Debugging Refresher","Building a Web Server",
+"Start Here","Linux Luminarium","Playing With Programs",
+"Intro to Programming Languages","Reverse Engineering","Web Security",
+"Computing 101","Pwntools Tutorials","The Art of the Shell",
+"Fuzz Dojo","Privilege Escalation","Cryptographic Exploitation",
+"Kernel Security","Windows Warzone","ARM Architecture","Content Injection",
+"Adversarial Machine Learning Dojo","CTF Archive","Pwn.college Archives",
+"Honors Dojo"
+]
+
+def rand_username():
+    adj = ["dark","silent","red","ghost","x","zero","neo","crypt","byte","ninja","sudo","root","hex","sigma","omega"]
+    noun = ["cat","snake","coder","hacker","phantom","cipher","viper","spectre","byte","reaver","spike","void","flux"]
+    num = "".join(random.choices(string.digits, k=random.choice([0,2,3])))
+    sep = random.choice(["", "_", ".", ""])
+    base = random.choice(adj)+sep+random.choice(noun)+num
+    if random.random() < 0.25:
+        base = base.replace("a","@").replace("o","0").replace("e","3")
+    if random.random() < 0.1:
+        base = base + random.choice(["X","99","1337","_pwn"])
+    return base
+def make_user():
+    mods = random.sample(modules_pool, k=random.randint(0, min(8,len(modules_pool))))
+    per_mod_solves = [random.randint(1,10) for _ in mods]
+    return {
+        "Hacker UserName": rand_username(),
+        "Number of Solves": sum(per_mod_solves),
+        "Modules Solved": [{"module":m,"solves":s} for m,s in zip(mods,per_mod_solves)]
+    }
+users = [make_user() for _ in range(COUNT)]
+with open("pwn_users.json","w") as f:
+    json.dump(users,f,indent=2)
+print("wrote",len(users),"users to pwn_users.json")


### PR DESCRIPTION
Hey! This PR adds a simple stress test script that creates fake pwn.college user data for testing and debugging. It randomly builds thousands of hacker-style usernames, assigns them a mix of module solves, and saves everything in a clean JSON file. The script keeps results consistent with a fixed random seed and checks that each user’s total solves match their module breakdown, making it easy to test logic, performance, or data pipelines without using real data.
