### PR TITLE
Workspace: Fix gcc/clang priority

### DIFF
--- a/workspace/additional/additional.nix
+++ b/workspace/additional/additional.nix
@@ -26,7 +26,7 @@ let
   pythonEnv = pkgs.python3.withPackages pythonPackages;
 
   tools = with pkgs; {
-    build = [ clang clang-tools cmake gcc gnumake qemu rustup ];
+    build = [ (lib.lowPrio clang) clang-tools cmake (lib.hiPrio gcc) gnumake qemu rustup ];
 
     compress = [ gnutar gzip unzip zip ];
 
@@ -44,7 +44,7 @@ let
 
     shells = [ fish nushell zsh ];
 
-    shell-tools = [ atuin bat fd fzf oh-my-zsh starship zoxide ];
+    shell-tools = [ atuin bat fd fzf oh-my-zsh starship zoxide ripgrep ];
 
     system = [ firejail htop landrun nftables openssh rsync ];
 


### PR DESCRIPTION
Workspace-builder is currently failing because both gcc and clang want to be `cc`. lib.hiPrio will make gcc be `cc`. 

Also added ripgrep becuase my neovim config needs it. 