### PR TITLE
Feature: Ability to link files opening in new page

### DIFF
--- a/dojo_theme/templates/text_file.html
+++ b/dojo_theme/templates/text_file.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="jumbotron">
+  <div class="container">
+    <h1>{{ dojo.name or dojo.id }}</h1>
+    <p class="lead">
+      {% if challenge %}
+        {{ module.name or module.id }} &raquo; {{ challenge.name or challenge.id }}
+      {% elif module %}
+        {{ module.name or module.id }}
+      {% endif %}
+    </p>
+    <p class="text-muted">{{ file_name }}</p>
+  </div>
+</div>
+<div class="container">
+  <pre class="bg-light p-3 border rounded" style="white-space: pre-wrap;">{{ content }}</pre>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Dojo Asset Links Support

Dojo owners can now embed links inside dojo, module, and challenge descriptions that point to files stored in their dojo repository. Visiting a URL of the form `/dojo_id/<asset-path>` renders the referenced artifact directly in the platform:

- `/{dojo_id}/{filename}` resolves dojo-level files.
- `/{dojo_id}/{module_id}/{filename}` resolves module-level files.
- `/{dojo_id}/{module_id}/{challenge_id}/{filename}` resolves challenge-level files.

Markdown renders as HTML, PDFs stream in the browser, and LaTeX (or other plain text assets) display in a dedicated template. Requests are constrained to the owning dojo repo and reject ambiguous matches, preventing traversal outside the allowed tree.

## Motivation
For the core material to be added for cryptography dojo, having long pdfs have their own dedicated page is a necessity. Previously, descriptions could only link to external hosting or expose bare markdown. This feature keeps assets in the dojo repository, preserving version control, discoverability, and offline deployability while giving students a single, predictable URL structure for supplementary content.

## Implementation Details
- **Routing**: `dojo_plugin/pages/dojo.py` now inspects deep paths and dispatches file requests after validating path segments. Files resolve relative to the dojo tree only when the match is unique. Safe extensions are rendered appropriately; everything else streams via `send_file`.
- **LaTeX/Plain Text Template**: `dojo_theme/templates/text_file.html` renders textual assets with dojo/module context headers.

## Files Changed
- `dojo_plugin/pages/dojo.py`: Added file-resolution helpers, sanitized segment checking, and expanded `view_dojo_path` routing.
- `dojo_theme/templates/text_file.html`: New template for text-based assets.

`UNDER CONSTRUCTION`