### PR TITLE
markdown: allow details and summary html tags

### DIFF
--- a/dojo_plugin/utils/__init__.py
+++ b/dojo_plugin/utils/__init__.py
@@ -134,6 +134,7 @@ def render_markdown(s):
         "img",
         "a",
         "sub", "sup",
+        "details", "summary",
     ]
     markdown_attrs = {
         "*": ["id"],


### PR DESCRIPTION
to use as spoiler syntax.

Drawback: I dont know how to test this inside the repository.
