### PR TITLE
Site: Restrict access to other users' workspaces

### DIFF
--- a/dojo_plugin/api/v1/workspace.py
+++ b/dojo_plugin/api/v1/workspace.py
@@ -68,6 +68,10 @@ class view_desktop(Resource):
 
         signature = base64.urlsafe_b64encode(digest).decode()
 
+        if not service == "desktop":
+            if user_id and not is_admin():
+                abort(403)
+
         if service:
             if service == "desktop":
                 interact_password = container_password(container, "desktop", "interact")
@@ -95,9 +99,6 @@ class view_desktop(Resource):
                 iframe_src = forward_workspace(service=service_param, service_path="vnc.html", signature=signature, message=message, **vnc_params)
 
             elif service == "desktop-windows":
-                if user_id and not is_admin():
-                    abort(403)
-
                 service_param = "~".join(("desktop-windows", str(user.id), container_password(container, "desktop-windows")))
                 vnc_params = {
                     "autoconnect": 1,


### PR DESCRIPTION
Needs to be avoided now since an unauthenticated url would be returned in the api
Fixes #984 