### PR TITLE
Site: Fix clipboard copy and paste

### DIFF
--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -263,7 +263,7 @@ function startChallenge(event) {
         $(".challenge-workspace").addClass("challenge-hidden");
         $(".iframe-wrapper").html("");
         if (result.success) {
-            item.find(".iframe-wrapper").html("<iframe id=\"workspace-iframe\" class=\"challenge-iframe\" src=\"\"></iframe>");
+            item.find(".iframe-wrapper").html("<iframe id=\"workspace-iframe\" class=\"challenge-iframe\" src=\"\" allow=\"clipboard-read *; clipboard-write *\"></iframe>");
             loadWorkspace();
             item.find(".challenge-init").addClass("challenge-hidden");
             item.find(".challenge-workspace").removeClass("challenge-hidden");

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -256,7 +256,7 @@
             <div class="challenge-workspace {{ "challenge-hidden" if not active }}">
               <div class="iframe-wrapper">
                 {% if active %}
-                <iframe id="workspace-iframe" class="challenge-iframe" src=""></iframe>
+                <iframe id="workspace-iframe" class="challenge-iframe" src="" allow="clipboard-read *; clipboard-write *"></iframe>
                 {% endif %}
               </div>
               <div class="workspace-ssh">

--- a/frontend/src/components/workspace/WorkspaceService.tsx
+++ b/frontend/src/components/workspace/WorkspaceService.tsx
@@ -189,7 +189,7 @@ export function WorkspaceService({
             transform: "translateZ(0)", // Force GPU layer
           }}
           title={`Workspace ${activeService}`}
-          allow="clipboard-write"
+          allow="clipboard-read *; clipboard-write *"
         />
       </div>
 


### PR DESCRIPTION
### Motivation
- Resolve issue where copy/paste is blocked inside the embedded workspace (issue #1003).
- Browsers require explicit iframe permission hints to allow clipboard access for framed content, especially across origins.

### Description
- Grant clipboard permissions to workspace iframes by adding `allow="clipboard-read *; clipboard-write *"` in three places:
  - `dojo_theme/templates/module.html` — static iframe in the module template.
  - `dojo_theme/static/js/dojo/challenges.js` — dynamically created challenge iframe inserted into the DOM.
  - `frontend/src/components/workspace/WorkspaceService.tsx` — React/TSX workspace iframe component used by the frontend.
- This is a minimal change that surfaces the appropriate permissions hint to browsers so clipboard read/write requests from the framed workspace can be granted.

### Testing
- Automated tests: none were run for this change.
- (No automated test suite executed as part of this patch.)

-----
Resolves #1003.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694574b3f6f08333a4bebf1310c328b3)