### PR TITLE
CI: Update docker storage and test args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,9 @@ jobs:
         with:
           path: |
             /mnt/cache.img
-          key: dojo-cache2-${{ matrix.mode }}-${{ github.run_id }}
+          key: dojo-cache-${{ matrix.mode }}-${{ github.run_id }}
           restore-keys: |
-            dojo-cache2-
+            dojo-cache-
 
       - name: Setup cache filesystem
         run: |
@@ -183,7 +183,7 @@ jobs:
         with:
           path: |
             /mnt/cache.img
-          key: dojo-cache2-${{ matrix.mode }}-${{ github.run_id }}
+          key: dojo-cache-${{ matrix.mode }}-${{ github.run_id }}
 
       - name: Final filesystem information
         if: always()


### PR DESCRIPTION
## Summary
- move Docker storage to /mnt before buildx setup
- remove the disk cleanup step
- always enable coverage and simplify mode handling in test step

## Testing
- not run (CI only)