### PR TITLE
Workspace: Update nix to 25.11

### DIFF
--- a/dojo/dojo-init
+++ b/dojo/dojo-init
@@ -38,7 +38,7 @@ DEFAULT_DOJO_HOST=localhost.pwn.college
 define DOJO_HOST "${DEFAULT_DOJO_HOST}"
 define WORKSPACE_HOST workspace."${DEFAULT_DOJO_HOST}"
 define DOJO_ENV development
-define DOJO_WORKSPACE full
+define DOJO_WORKSPACE core
 define WORKSPACE_KEY
 define WORKSPACE_SECRET $(openssl rand -hex 16)
 define WORKSPACE_NODE 0


### PR DESCRIPTION
## Summary
- Bump nixpkgs input to nixos-25.11.

## Testing
- ./deploy.sh -t (fails: workspace-builder could not download idafree84_linux.run; ida-free 8.4.240320 build failed)

## Migration notes
- ida-free failed to download from its upstream mirror during the 25.11 build, so the workspace build did not complete.
