### PR TITLE
Site: Remove Font Awesome icon padding

### DIFF
--- a/dojo_theme/static/css/custom.css
+++ b/dojo_theme/static/css/custom.css
@@ -372,11 +372,6 @@ p[data-hide="true"] {
     padding: 0 0.5rem;
 }
 
-.fas {
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
-}
-
 .card-small {
     width: 13em;
     height: 13em;


### PR DESCRIPTION
## Summary
- remove left/right padding from .fas icons to avoid hardcoded spacing
- let containers control icon spacing instead of a global padding rule

## Testing
- not run (CSS-only change)