### PR TITLE
Site: Allow clipboard access in workspace iframe

### DIFF
--- a/dojo_theme/templates/workspace.html
+++ b/dojo_theme/templates/workspace.html
@@ -46,7 +46,7 @@
 
 {% block content %}
 <div class="challenge-workspace">
-  <iframe src="" id="workspace-iframe"></iframe>
+  <iframe src="" id="workspace-iframe" allow="clipboard-read *; clipboard-write *"></iframe>
   {% include "components/actionbar.html" %}
 </div>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- The workspace iframe was missing clipboard permission attributes, which prevented clipboard read/write interactions between the host page and embedded workspace services.
- Enabling clipboard access improves usability for copy/paste workflows inside the workspace iframe.

### Description
- Updated `dojo_theme/templates/workspace.html` to add `allow="clipboard-read *; clipboard-write *"` on the `iframe` with id `workspace-iframe`.
- No other template or backend logic was changed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69669d3875348333b8e6c1867a00f403)