### PR TITLE
testing: Add code coverage collection for stats-worker container

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -83,10 +83,16 @@ function test_container {
 
 function generate_coverage_report {
 	local CONTAINER="$1"
-    docker exec "$CONTAINER" docker kill -s SIGINT ctfd
+
+	docker exec "$CONTAINER" docker kill -s SIGINT stats-worker
+	docker exec "$CONTAINER" docker wait stats-worker
+
+	docker exec "$CONTAINER" docker kill -s SIGINT ctfd
 	docker exec "$CONTAINER" docker wait ctfd
-    docker exec "$CONTAINER" docker start ctfd
-    docker exec "$CONTAINER" docker exec ctfd coverage xml -o /var/coverage/coverage.xml
+	docker exec "$CONTAINER" docker start ctfd
+	docker exec "$CONTAINER" docker start stats-worker
+
+	docker exec "$CONTAINER" docker exec ctfd sh -c 'cd /var/coverage && coverage combine .coverage .coverage.worker && coverage xml -o coverage.xml'
 }
 
 ENV_ARGS=( )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -230,10 +230,27 @@ services:
     profiles:
       - main
     restart: always
-    command: ["flask", "shell", "/opt/CTFd/CTFd/plugins/dojo_plugin/worker/__main__.py"]
+    command:
+      - /bin/sh
+      - -c
+      - |
+        if [ "$DOJO_ENV" = "coverage" ]; then
+          exec coverage run --source=CTFd/plugins/dojo_plugin -m flask shell /opt/CTFd/CTFd/plugins/dojo_plugin/worker/__main__.py;
+        else
+          exec flask shell /opt/CTFd/CTFd/plugins/dojo_plugin/worker/__main__.py;
+        fi
     environment:
       <<: *ctfd-env
-    volumes: *ctfd-volumes
+      DOJO_ENV: ${DOJO_ENV}
+      COVERAGE_FILE: /var/coverage/.coverage.worker
+    volumes:
+      - /data/dojos:/var/dojos
+      - /data/workspace_nodes.json:/var/workspace_nodes.json:ro
+      - ./user_firewall.allowed:/var/user_firewall.allowed:ro
+      - /etc/docker/seccomp.json:/etc/docker/seccomp.json:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /opt/pwn.college/dojo_plugin:/opt/CTFd/CTFd/plugins/dojo_plugin:ro
+      - ./data/coverage:/var/coverage
     depends_on:
       <<: *ctfd-depends
 


### PR DESCRIPTION
## Summary
- Add code coverage collection to the stats-worker container when running in coverage mode (`DOJO_ENV=coverage`)
- Stats-worker now runs under `coverage run` and writes to a separate `.coverage.worker` file
- Modified `generate_coverage_report` to combine coverage data from both ctfd and stats-worker before generating XML report

Closes #1030

## Test plan
- [x] Verify stats-worker starts correctly in non-coverage mode
- [x] Verify `.coverage.worker` file is created when running with `-C` flag
- [x] Verify coverage data is valid (contains worker code paths)
- [ ] GitHub Actions CI should show worker files in Codecov report
- [ ] Compare Codecov percentage before/after to confirm increase

🤖 Generated with [Claude Code](https://claude.com/claude-code)