### PR TITLE
Course: Fix student ordering stability

### DIFF
--- a/dojo_plugin/api/v1/dojos.py
+++ b/dojo_plugin/api/v1/dojos.py
@@ -238,7 +238,7 @@ class DojoCourseStudentList(Resource):
     @dojo_route
     @dojo_admins_only
     def get(self, dojo):
-        dojo_students = {student.token: student.user_id for student in DojoStudents.query.filter_by(dojo=dojo)}
+        dojo_students = {student.token: student.user_id for student in DojoStudents.query.filter_by(dojo=dojo).order_by(DojoStudents.user_id)}
         course_students = dojo.course.get("students", {})
         students = {
             token: course_data | dict(token=(token if token in dojo_students else None), user_id=dojo_students.get(token))


### PR DESCRIPTION
### Motivation
- Ensure the token-to-user mapping prefers newer users on token collisions by ordering `DojoStudents` by `user_id` so the dict comprehension keeps the higher `user_id` last.

### Description
- Update `DojoCourseStudentList.get` to use `order_by(DojoStudents.user_id)` (omitting explicit `asc()`) when building the `{student.token: student.user_id}` mapping.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e79da6bc48333b89b12cac8063daf)