### PR TITLE
Workspace: Add eternal-terminal and mosh

### DIFF
--- a/workspace/flake.nix
+++ b/workspace/flake.nix
@@ -112,7 +112,9 @@
               (lib.hiPrio ldd)
 
               exec-suid
+              eternal-terminal
               init
+              mosh
               ssh-entrypoint
               sudo
 


### PR DESCRIPTION
I've often had my ssh connection drop with the following message:
```
Connection to dojo.pwn.college closed by remote host.
Connection to dojo.pwn.college closed.
client_loop: send disconnect: Broken pipe
```
To mitigate this issue, I am adding two common ssh alternatives to the workspace.