### PR TITLE
Site: Add future.pwn.college announcement popup

### DIFF
--- a/dojo_theme/static/css/custom.css
+++ b/dojo_theme/static/css/custom.css
@@ -207,6 +207,47 @@ p[data-hide="true"] {
     border-color: #6c757d !important;
 }
 
+.announcement {
+    position: fixed;
+    z-index: 9999;
+    left: 1rem;
+    bottom: 1rem;
+    max-width: 30rem;
+    margin-right: 1rem;
+    padding: 2rem;
+    background-color: #1a1a1a;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    border: 3px solid var(--brand-green);
+    border-radius: 1rem;
+    font-size: 1.1rem;
+}
+
+.announcement-btn-wrap {
+    display: flex;
+    justify-content: center;
+    column-gap: 2rem;
+}
+
+.announcement-btn {
+    padding: 0.5rem;
+    border-radius: 0.3rem;
+    border: 2px var(--blue) solid;
+    width: 100%;
+}
+
+#later-btn {
+    background: none;
+    color: var(--blue);
+}
+
+#check-it-out-btn {
+    background-color: var(--blue);
+    color: white;
+}
+
 .challenge-button {
     margin-bottom: 1.5rem !important
 }

--- a/dojo_theme/templates/base.html
+++ b/dojo_theme/templates/base.html
@@ -132,5 +132,39 @@
     {{ current_dojo_custom_js | safe }}
     </script>
     {% endif %}
+
+  <div id="future-announcement" class="announcement" style="display: none">
+    <div class="announcement-content">
+      <p>Hey! We are developing a new look for our website, currently live at <a href="https://future.pwn.college">future.pwn.college</a>.</p>
+      <div class="announcement-btn-wrap">
+        <button id="check-it-out-btn" class="announcement-btn">I'll check it out</button>
+        <button id="later-btn" class="announcement-btn">Go away</button>
+      </div>
+    </div>
+  </div>
+  <script>
+    document.addEventListener("DOMContentLoaded", function() {
+      const announcement = document.getElementById("future-announcement");
+      const checkItOutBtn = document.getElementById("check-it-out-btn");
+      const laterBtn = document.getElementById("later-btn");
+
+      if (!localStorage.getItem("announcementDismissed")) {
+        announcement.style.display = "flex";
+      }
+
+      function goToFuture() {
+        localStorage.setItem("announcementDismissed", "true");
+        window.location.href = "https://future.pwn.college";
+      }
+
+      function dismiss() {
+        announcement.style.display = "none";
+        localStorage.setItem("announcementDismissed", "true");
+      }
+
+      checkItOutBtn.onclick = goToFuture;
+      laterBtn.onclick = dismiss;
+    });
+  </script>
   </body>
 </html>


### PR DESCRIPTION
Created a aesthetically pleasing, non-intrusive popup to notify pwn.college users of https://future.pwn.college. The popup disappears after the user interacts with it, using local storage to check if they had interacted with it at any point.

Let me know if anything such as layout, or words need to be tweaked. Feel free to edit the wording as well.

# Preview

<img width="1907" height="928" alt="image" src="https://github.com/user-attachments/assets/ce99373c-e3b8-4f4d-a356-ab765d27484f" />

# Preview on mobile

Phone screens have been accounted for. The popup adapts responsively:

<img width="790" height="892" alt="image" src="https://github.com/user-attachments/assets/7dc815b8-553d-46c6-9c51-af063d970d36" />
