### PR TITLE
markdown: preserve language-* classes for syntax highlighting

### DIFF
--- a/dojo_plugin/utils/__init__.py
+++ b/dojo_plugin/utils/__init__.py
@@ -116,6 +116,14 @@ def user_ipv4(user):
     ])
 
 
+def _filter_code_class(tag, name, value):
+    if name == "class":
+        classes = value.split()
+        allowed = [c for c in classes if c.startswith("language-")]
+        return " ".join(allowed) if allowed else None
+    return None
+
+
 def render_markdown(s):
     raw_html = build_markdown(s or "")
     if "dojo" in g and (g.dojo.official or g.dojo.privileged):
@@ -136,7 +144,8 @@ def render_markdown(s):
         "*": ["id"],
         "img": ["src", "alt", "title"],
         "a": ["href", "alt", "title"],
-        "p": ["data-hide"]
+        "p": ["data-hide"],
+        "code": _filter_code_class,
     }
     clean_html = bleach.clean(raw_html, tags=markdown_tags, attributes=markdown_attrs)
     return Markup(clean_html)


### PR DESCRIPTION
## Summary
- Fix syntax highlighting for fenced code blocks in markdown resources
- The bleach sanitizer was stripping `class` attributes from `<code>` elements, removing `language-*` classes that cmarkgfm generates from fenced code blocks (e.g., ` ```bash `)
- Without the language hint, highlight.js falls back to auto-detection and often guesses wrong (e.g., detecting "stylus" instead of "bash")
- Now `language-*` classes are preserved on code elements while still filtering out all other classes/attributes for security

## Test plan
- [x] Existing tests pass (1 unrelated flaky failure in `test_cold_start_initializes_cache`)
- [ ] Verify ` ```bash ` code blocks render with correct syntax highlighting on module pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)