### PR TITLE
Workspace: Override python3 angr

### DIFF
--- a/workspace/flake.nix
+++ b/workspace/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     nixpkgs-24-11.url = "github:NixOS/nixpkgs/nixos-24.11";
     nixpkgs-pr-angr-management.url = "github:NixOS/nixpkgs/pull/360310/head";
-    angr.url = "github:pwncollege/nixpkgs/angr-update";
+    angr.url = "github:pwncollege/nixpkgs/update/angr";
     pwndbg.url = "github:pwndbg/pwndbg";
   };
 


### PR DESCRIPTION
## Summary
- override python3Packages.angr to use pwncollege/nixpkgs (angr-update)

## Testing
- not run (config-only change)
