### PR TITLE
feed: fix challenge_solve events showing wrong dojo

### DIFF
--- a/dojo_plugin/__init__.py
+++ b/dojo_plugin/__init__.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse, urlunparse
 from flask import Response, request, redirect, current_app
 from itsdangerous.exc import BadSignature
 from marshmallow_sqlalchemy import field_for
-from CTFd.models import db, Challenges, Users, Solves
+from CTFd.models import db, Challenges, Users
 from CTFd.utils.user import get_current_user
 from CTFd.plugins import register_admin_plugin_menu_bar
 from CTFd.plugins.challenges import CHALLENGE_CLASSES, BaseChallenge
@@ -21,7 +21,6 @@ from .config import DOJO_HOST, bootstrap
 from .utils import unserialize_user_flag, render_markdown
 from .utils.dojo import get_current_dojo_challenge
 from .utils.awards import update_awards
-from .utils.feed import publish_challenge_solve
 from .utils.query_timer import init_query_timer
 from .utils.request_logging import setup_logging, setup_trace_id_tracking, setup_uncaught_error_logging
 from .pages.dojos import dojos, dojos_override
@@ -51,15 +50,6 @@ class DojoChallenge(BaseChallenge):
     def solve(cls, user, team, challenge, request):
         super().solve(user, team, challenge, request)
         update_awards(user)
-
-        dojo_challenge = DojoChallenges.query.filter_by(challenge_id=challenge.id).first()
-        if dojo_challenge:
-            dojo = dojo_challenge.module.dojo
-            if dojo.official or dojo.data.get("type") == "public":
-                module = dojo_challenge.module
-                points = challenge.value
-                first_blood = Solves.query.filter_by(challenge_id=challenge.id).count() == 1
-                publish_challenge_solve(user, dojo_challenge, dojo, module, points, first_blood)
 
 
 class DojoFlag(BaseFlag):


### PR DESCRIPTION
## Summary

- Fix live feed showing the wrong dojo for challenge solves when a challenge exists in multiple dojos
- The root cause was `DojoChallenges.query.filter_by(challenge_id=...).first()` in `DojoChallenge.solve()`, which returned an arbitrary match rather than the dojo the user actually solved in
- Move feed event publishing to `DojoChallengeSolve.post()` where the correct dojo, module, and dojo_challenge are already resolved from the request URL

## Test plan

- [x] Add `test_feed_solve_shows_correct_dojo` regression test verifying feed events contain the correct dojo_id and module_id
- [x] All 146 tests pass (4 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)