### PR TITLE
Tests: Fix cache permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
             echo "SAVE_CACHE=yes" >> "$GITHUB_ENV"
           else
             echo "LOAD_CACHE=yes" >> "$GITHUB_ENV"
+            sudo chown $USER:$USER /mnt
           fi
 
       - name: Restore docker and workspace cache
@@ -66,6 +67,7 @@ jobs:
 
       - name: Setup cache filesystem
         run: |
+          sudo chown root:root /mnt
           set -x
           df -h
           sudo mkdir -p /mnt/cache


### PR DESCRIPTION
We have a new cache, but we cannot load the cache.img file to /mnt due to a permissions error.