### PR TITLE
Emojis: Prevent Duplicates

### DIFF
--- a/dojo_plugin/utils/awards.py
+++ b/dojo_plugin/utils/awards.py
@@ -125,7 +125,7 @@ def update_awards(user):
             
         display_name = dojo.name or dojo.reference_id
         description = f"Awarded for completing the {display_name} dojo."
-        db.session.add(Emojis(user=user, name="CURRENT", description=description, category=hex_dojo_id, icon=""))
+        db.session.add(Emojis(user=user, name="CURRENT", description=description, category=hex_dojo_id, icon=None))
         db.session.commit()
         
         if dojo.official or dojo.data.get("type") == "public":


### PR DESCRIPTION
Emojis originally populated the icon field with `None`. Newer emojis populate this field with empty string. While this difference did not matter for the checks related to fetching emoji icons, it did result in different keys when checking emoji uniqueness (user, category, icon).

closes #1084 