### PR TITLE
Add start_period to Prometheus healthcheck to prevent cold-start timeouts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -378,6 +378,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 3
+      start_period: 60s
     depends_on:
       prometheus-generate-targets:
         condition: service_completed_successfully


### PR DESCRIPTION
Add `start_period: 60s` to Prometheus healthcheck to prevent cold-start failures

On first deploy, Prometheus needs time to initialize its TSDB before responding to healthchecks. Without a startup grace period, Docker marks it unhealthy after ~30s, causing `dependency failed to start: container prometheus is unhealthy` and killing the entire compose stack.

`start_period: 60s` gives Prometheus a grace window where failed healthchecks don't count toward the retry limit.