### PR TITLE
Feat / Add docker-compose.yaml support for challenges

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -487,6 +487,15 @@ services:
     networks:
       - workspace_net
 
+  compose-orchestrator:
+    privileged: true
+    container_name: compose-orchestrator
+    hostname: compose-orchestrator
+    image: nementon/dojo-challenge-compose-orchestrator-sidecar:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /data/dojos:/var/dojos:rw
+
 volumes:
   prometheus_targets:
 


### PR DESCRIPTION
# TODO - WIP

[add compose-orchestrator service, sidecar to manage challenges `doc…](https://github.com/pwncollege/dojo/commit/832a70a2232d4568d0296c82666ef8bddeaa9051) 

…ker-compose.yaml' file

  - PoC only:
    - raw external import in PoC state
    - privileged flags is likely not required
   
# Ref
- [Sidecar](https://github.com/Nementon/dojo-challenge-compose-sidecar)
- [Dojo with compose sample](https://github.com/Nementon/Open5GS-dojo)