### PR TITLE
Crews: crew scoreboards with cumulative and unique scoring

### DIFF
--- a/dojo_plugin/api/v1/scoreboard.py
+++ b/dojo_plugin/api/v1/scoreboard.py
@@ -9,6 +9,7 @@ from ...models import Dojos, DojoModules
 from ...utils.dojo import dojo_route
 from ...utils.awards import get_belts, get_viewable_emojis
 from ...utils.background_stats import get_cached_stat
+from ...utils.crews import aggregate_crews, parse_crew_tag
 
 logger = logging.getLogger(__name__)
 
@@ -25,24 +26,51 @@ def email_symbol_asset(email):
     return url_for("views.themes", path=f"img/dojo/{group}")
 
 
-def get_scoreboard_for(model, duration):
+def model_cache_key(model, kind, duration):
     if isinstance(model, Dojos):
-        cache_key = f"stats:scoreboard:dojo:{model.dojo_id}:{duration}"
-    elif isinstance(model, DojoModules):
-        cache_key = f"stats:scoreboard:module:{model.dojo_id}:{model.module_index}:{duration}"
-    else:
+        return f"stats:{kind}:dojo:{model.dojo_id}:{duration}"
+    if isinstance(model, DojoModules):
+        return f"stats:{kind}:module:{model.dojo_id}:{model.module_index}:{duration}"
+    return None
+
+
+def get_scoreboard_for(model, duration):
+    cache_key = model_cache_key(model, "scoreboard", duration)
+    if cache_key is None:
         return []
+    return get_cached_stat(cache_key) or []
 
-    logger.info(f"get_scoreboard_for: checking cache key {cache_key}")
+
+def get_crews_for(model, duration):
+    cache_key = model_cache_key(model, "crews", duration)
+    if cache_key is None:
+        return []
     cached = get_cached_stat(cache_key)
-    logger.info(f"get_scoreboard_for: cached={cached is not None}, len={len(cached) if cached else 0}")
-
-    if cached:
-        logger.info(f"Returning cached scoreboard with {len(cached)} entries")
+    if cached is not None:
         return cached
+    return aggregate_crews(get_scoreboard_for(model, duration))
 
-    logger.info(f"Cache miss/empty, returning []")
-    return []
+
+def standing_entry(item, belt_data, emojis):
+    if not item:
+        return None
+    user_id = item["user_id"]
+    belt_color = belt_data["users"].get(user_id, {"color": "white"})["color"]
+    result = {key: item[key] for key in item.keys()}
+    parsed = parse_crew_tag(result.get("name"))
+    result.update({
+        "url": url_for("pwncollege_users.view_other", user_id=user_id),
+        "symbol": email_symbol_asset(result.pop("email")),
+        "belt": url_for("pwncollege_belts.view_belt", color=belt_color),
+        "badges": emojis.get(user_id, []),
+        "crew": parsed and {"tag": parsed["tag"], "key": parsed["key"], "base_name": parsed["base_name"]},
+    })
+    return result
+
+
+def page_numbers(total, page, per_page):
+    pagination = Pagination(None, page, per_page, total, None)
+    return set(number for number in pagination.iter_pages() if number)
 
 
 def get_scoreboard_page(model, duration=None, page=1, per_page=20):
@@ -51,47 +79,74 @@ def get_scoreboard_page(model, duration=None, page=1, per_page=20):
 
     start_idx = (page - 1) * per_page
     end_idx = start_idx + per_page
-    pagination = Pagination(None, page, per_page, len(results), results[start_idx:end_idx])
     user = get_current_user()
     emojis = get_viewable_emojis(user)
 
-    def standing(item):
-        if not item:
-            return
-        user_id = item["user_id"]
-        belt_color = belt_data["users"].get(user_id, {"color": "white"})["color"]
-        result = {key: item[key] for key in item.keys()}
-        result.update({
-            "url": url_for("pwncollege_users.view_other", user_id=user_id),
-            "symbol": email_symbol_asset(result.pop("email")),
-            "belt": url_for("pwncollege_belts.view_belt", color=belt_color),
-            "badges": emojis.get(user_id, [])
-        })
-        return result
-
     standings_list = []
-    for item in pagination.items:
-        s = standing(item)
-        if s is not None:
-            standings_list.append(s)
+    for item in results[start_idx:end_idx]:
+        entry = standing_entry(item, belt_data, emojis)
+        if entry is not None:
+            standings_list.append(entry)
 
     result = {
         "standings": standings_list,
     }
 
-    pages = set(page for page in pagination.iter_pages() if page)
+    pages = page_numbers(len(results), page, per_page)
 
     if user and not user.hidden:
         me = None
-        for r in results:
-            if r["user_id"] == user.id:
-                me = standing(r)
+        for item in results:
+            if item["user_id"] == user.id:
+                me = standing_entry(item, belt_data, emojis)
                 break
         if me:
             pages.add((me["rank"] - 1) // per_page + 1)
             result["me"] = me
 
     result["pages"] = sorted(pages)
+
+    return result
+
+
+def get_crew_scoreboard_page(model, duration=None, page=1, per_page=20):
+    belt_data = get_belts()
+    user = get_current_user()
+    emojis = get_viewable_emojis(user)
+    crews = get_crews_for(model, duration)
+
+    def crew_entry(crew):
+        return {
+            "rank": crew["rank"],
+            "tag": crew["tag"],
+            "key": crew["key"],
+            "score": crew["score"],
+            "members": [
+                entry for entry in (standing_entry(member, belt_data, emojis) for member in crew["members"])
+                if entry is not None
+            ],
+        }
+
+    start_idx = (page - 1) * per_page
+    end_idx = start_idx + per_page
+    result = {
+        "standings": [crew_entry(crew) for crew in crews[start_idx:end_idx]],
+    }
+
+    pages = page_numbers(len(crews), page, per_page)
+
+    if user and not user.hidden:
+        parsed = parse_crew_tag(user.name)
+        if parsed:
+            my_crew = next((crew for crew in crews if crew["key"] == parsed["key"]), None)
+            if my_crew:
+                pages.add((my_crew["rank"] - 1) // per_page + 1)
+                result["me_crew"] = crew_entry(my_crew)
+
+    result["pages"] = sorted(pages)
+
+    if not crews:
+        result["board_empty"] = not get_scoreboard_for(model, duration)
 
     return result
 
@@ -108,3 +163,17 @@ class ScoreboardModule(Resource):
     @dojo_route
     def get(self, dojo, module, duration, page):
         return get_scoreboard_page(module, duration=duration, page=page)
+
+
+@scoreboard_namespace.route("/<dojo>/_/crews/<int:duration>/<int:page>")
+class ScoreboardDojoCrews(Resource):
+    @dojo_route
+    def get(self, dojo, duration, page):
+        return get_crew_scoreboard_page(dojo, duration=duration, page=page)
+
+
+@scoreboard_namespace.route("/<dojo>/<module>/crews/<int:duration>/<int:page>")
+class ScoreboardModuleCrews(Resource):
+    @dojo_route
+    def get(self, dojo, module, duration, page):
+        return get_crew_scoreboard_page(module, duration=duration, page=page)

--- a/dojo_plugin/api/v1/scoreboard.py
+++ b/dojo_plugin/api/v1/scoreboard.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import url_for
+from flask import request, url_for
 from flask_restx import Namespace, Resource
 from flask_sqlalchemy import Pagination
 from CTFd.utils.user import get_current_user
@@ -57,6 +57,7 @@ def standing_entry(item, belt_data, emojis):
     user_id = item["user_id"]
     belt_color = belt_data["users"].get(user_id, {"color": "white"})["color"]
     result = {key: item[key] for key in item.keys()}
+    result.pop("challenges", None)
     parsed = parse_crew_tag(result.get("name"))
     result.update({
         "url": url_for("pwncollege_users.view_other", user_id=user_id),
@@ -109,18 +110,25 @@ def get_scoreboard_page(model, duration=None, page=1, per_page=20):
     return result
 
 
-def get_crew_scoreboard_page(model, duration=None, page=1, per_page=20):
+def get_crew_scoreboard_page(model, duration=None, page=1, per_page=20, mode="cumulative"):
     belt_data = get_belts()
     user = get_current_user()
     emojis = get_viewable_emojis(user)
     crews = get_crews_for(model, duration)
 
+    if mode == "unique" and all(crew.get("unique_rank") is not None for crew in crews):
+        crews = sorted(crews, key=lambda crew: crew["unique_rank"])
+
+    def crew_rank(crew):
+        return crew["unique_rank"] if mode == "unique" and crew.get("unique_rank") is not None else crew["rank"]
+
     def crew_entry(crew):
         return {
-            "rank": crew["rank"],
+            "rank": crew_rank(crew),
             "tag": crew["tag"],
             "key": crew["key"],
             "score": crew["score"],
+            "unique": crew.get("unique"),
             "members": [
                 entry for entry in (standing_entry(member, belt_data, emojis) for member in crew["members"])
                 if entry is not None
@@ -131,6 +139,7 @@ def get_crew_scoreboard_page(model, duration=None, page=1, per_page=20):
     end_idx = start_idx + per_page
     result = {
         "standings": [crew_entry(crew) for crew in crews[start_idx:end_idx]],
+        "mode": mode,
     }
 
     pages = page_numbers(len(crews), page, per_page)
@@ -140,7 +149,7 @@ def get_crew_scoreboard_page(model, duration=None, page=1, per_page=20):
         if parsed:
             my_crew = next((crew for crew in crews if crew["key"] == parsed["key"]), None)
             if my_crew:
-                pages.add((my_crew["rank"] - 1) // per_page + 1)
+                pages.add((crew_rank(my_crew) - 1) // per_page + 1)
                 result["me_crew"] = crew_entry(my_crew)
 
     result["pages"] = sorted(pages)
@@ -149,6 +158,11 @@ def get_crew_scoreboard_page(model, duration=None, page=1, per_page=20):
         result["board_empty"] = not get_scoreboard_for(model, duration)
 
     return result
+
+
+def crew_mode_arg():
+    mode = request.args.get("mode", "cumulative")
+    return mode if mode in ("cumulative", "unique") else "cumulative"
 
 
 @scoreboard_namespace.route("/<dojo>/_/<int:duration>/<int:page>")
@@ -169,11 +183,11 @@ class ScoreboardModule(Resource):
 class ScoreboardDojoCrews(Resource):
     @dojo_route
     def get(self, dojo, duration, page):
-        return get_crew_scoreboard_page(dojo, duration=duration, page=page)
+        return get_crew_scoreboard_page(dojo, duration=duration, page=page, mode=crew_mode_arg())
 
 
 @scoreboard_namespace.route("/<dojo>/<module>/crews/<int:duration>/<int:page>")
 class ScoreboardModuleCrews(Resource):
     @dojo_route
     def get(self, dojo, module, duration, page):
-        return get_crew_scoreboard_page(module, duration=duration, page=page)
+        return get_crew_scoreboard_page(module, duration=duration, page=page, mode=crew_mode_arg())

--- a/dojo_plugin/utils/crews.py
+++ b/dojo_plugin/utils/crews.py
@@ -1,0 +1,47 @@
+import re
+import unicodedata
+
+CREW_TAG_RE = re.compile(r"^(.*?)\s*\[([^\[\]]{1,24})\]\s*$", re.DOTALL)
+CREW_STRIP_RE = re.compile(
+    "[\u0000-\u001f\u007f-\u009f\u00ad\u034f\u17b4\u17b5\u180b-\u180e"
+    "\u200b-\u200f\u2028-\u202e\u2060-\u2064\u2066-\u2069\ufeff\U000e0000-\U000e007f]"
+)
+CREW_KEY_STRIP_RE = re.compile("[\ufe00-\ufe0f]")
+
+
+def parse_crew_tag(name):
+    match = CREW_TAG_RE.match(name or "")
+    if not match:
+        return None
+    tag = CREW_STRIP_RE.sub("", match.group(2))
+    tag = re.sub(r"\s+", " ", tag).strip()
+    if not 1 <= len(tag) <= 20:
+        return None
+    key = unicodedata.normalize("NFKC", CREW_KEY_STRIP_RE.sub("", tag)).casefold()
+    return {"tag": tag, "key": key, "base_name": match.group(1).strip()}
+
+
+def aggregate_crews(standings):
+    crews = {}
+    for entry in standings or []:
+        parsed = parse_crew_tag(entry.get("name"))
+        if not parsed:
+            continue
+        crew = crews.get(parsed["key"])
+        if crew is None:
+            crew = crews[parsed["key"]] = {
+                "key": parsed["key"],
+                "tag": parsed["tag"],
+                "score": 0,
+                "best_rank": entry["rank"],
+                "members": [],
+            }
+        crew["score"] += entry["solves"]
+        crew["members"].append(entry)
+    ranked = sorted(
+        crews.values(),
+        key=lambda crew: (-crew["score"], len(crew["members"]), crew["best_rank"], crew["key"]),
+    )
+    for i, crew in enumerate(ranked):
+        crew["rank"] = i + 1
+    return ranked

--- a/dojo_plugin/utils/crews.py
+++ b/dojo_plugin/utils/crews.py
@@ -21,7 +21,7 @@ def parse_crew_tag(name):
     return {"tag": tag, "key": key, "base_name": match.group(1).strip()}
 
 
-def aggregate_crews(standings):
+def aggregate_crews(standings, member_challenges=None):
     crews = {}
     for entry in standings or []:
         parsed = parse_crew_tag(entry.get("name"))
@@ -37,11 +37,39 @@ def aggregate_crews(standings):
                 "members": [],
             }
         crew["score"] += entry["solves"]
-        crew["members"].append(entry)
+        member = dict(entry)
+        if member_challenges is not None:
+            member["challenges"] = sorted(member_challenges.get(entry["user_id"], []))
+        crew["members"].append(member)
+
     ranked = sorted(
         crews.values(),
         key=lambda crew: (-crew["score"], len(crew["members"]), crew["best_rank"], crew["key"]),
     )
     for i, crew in enumerate(ranked):
         crew["rank"] = i + 1
+        if member_challenges is not None:
+            crew["unique"] = len(set().union(*(member["challenges"] for member in crew["members"])) if crew["members"] else set())
+        else:
+            crew["unique"] = None
+
+    if member_challenges is not None:
+        by_unique = sorted(
+            ranked,
+            key=lambda crew: (-crew["unique"], len(crew["members"]), crew["best_rank"], crew["key"]),
+        )
+        for i, crew in enumerate(by_unique):
+            crew["unique_rank"] = i + 1
+    else:
+        for crew in ranked:
+            crew["unique_rank"] = None
+
     return ranked
+
+
+def member_challenges_from_crews(crews):
+    return {
+        member["user_id"]: set(member.get("challenges", []))
+        for crew in (crews or [])
+        for member in crew.get("members", [])
+    }

--- a/dojo_plugin/worker/handlers/scoreboard.py
+++ b/dojo_plugin/worker/handlers/scoreboard.py
@@ -5,11 +5,17 @@ from sqlalchemy import func
 from CTFd.models import db, Solves, Users
 from ...models import Dojos, DojoModules, DojoChallenges
 from ...utils.background_stats import get_cached_stat, set_cached_stat, is_event_stale
+from ...utils.crews import aggregate_crews
 from . import register_handler
 
 logger = logging.getLogger(__name__)
 
 COMMON_DURATIONS = [0, 7, 30]
+
+
+def set_scoreboard_cache(cache_key, scoreboard):
+    set_cached_stat(cache_key, scoreboard)
+    set_cached_stat(cache_key.replace("stats:scoreboard:", "stats:crews:", 1), aggregate_crews(scoreboard))
 
 
 def update_scoreboard(scoreboard, user_id, solve_delta=1):
@@ -144,7 +150,7 @@ def handle_scoreboard_update(payload, event_timestamp=None):
                 continue
             logger.info(f"Calculating scoreboard for {model_type} {model_id}, duration={duration}...")
             scoreboard = calculate_scoreboard(model, duration)
-            set_cached_stat(cache_key, scoreboard)
+            set_scoreboard_cache(cache_key, scoreboard)
             logger.info(f"Successfully updated scoreboard cache {cache_key} ({len(scoreboard)} entries)")
         except Exception as e:
             logger.error(f"Error calculating scoreboard for {model_type} {model_id}, duration={duration}: {e}", exc_info=True)
@@ -169,7 +175,7 @@ def initialize_all_scoreboards():
             try:
                 scoreboard = calculate_scoreboard(dojo, duration)
                 cache_key = f"stats:scoreboard:dojo:{dojo.dojo_id}:{duration}"
-                set_cached_stat(cache_key, scoreboard)
+                set_scoreboard_cache(cache_key, scoreboard)
                 logger.info(f"Initialized scoreboard for dojo {dojo.reference_id} (id={dojo.dojo_id}), duration={duration}")
             except Exception as e:
                 logger.error(f"Error initializing scoreboard for dojo {dojo.reference_id}, duration={duration}: {e}", exc_info=True)
@@ -179,7 +185,7 @@ def initialize_all_scoreboards():
                 try:
                     scoreboard = calculate_scoreboard(module, duration)
                     cache_key = f"stats:scoreboard:module:{module.dojo_id}:{module.module_index}:{duration}"
-                    set_cached_stat(cache_key, scoreboard)
+                    set_scoreboard_cache(cache_key, scoreboard)
                     logger.info(f"Initialized scoreboard for module {dojo.reference_id}/{module.id} (dojo_id={module.dojo_id}, module_index={module.module_index}), duration={duration}")
                 except Exception as e:
                     logger.error(f"Error initializing scoreboard for module {dojo.reference_id}/{module.id}, duration={duration}: {e}", exc_info=True)

--- a/dojo_plugin/worker/handlers/scoreboard.py
+++ b/dojo_plugin/worker/handlers/scoreboard.py
@@ -5,7 +5,7 @@ from sqlalchemy import func
 from CTFd.models import db, Solves, Users
 from ...models import Dojos, DojoModules, DojoChallenges
 from ...utils.background_stats import get_cached_stat, set_cached_stat, is_event_stale
-from ...utils.crews import aggregate_crews
+from ...utils.crews import aggregate_crews, member_challenges_from_crews, parse_crew_tag
 from . import register_handler
 
 logger = logging.getLogger(__name__)
@@ -13,9 +13,56 @@ logger = logging.getLogger(__name__)
 COMMON_DURATIONS = [0, 7, 30]
 
 
-def set_scoreboard_cache(cache_key, scoreboard):
+def duration_solves_filter(duration):
+    if not duration:
+        return True
+    return Solves.date >= datetime.datetime.utcnow() - datetime.timedelta(days=duration)
+
+
+def calculate_member_challenges(model, duration):
+    query = (
+        model.solves()
+        .filter(duration_solves_filter(duration))
+        .filter(DojoChallenges.required == True)
+        .filter(Users.name.like("%]"))
+        .with_entities(Solves.user_id, Solves.challenge_id)
+    )
+    result = {}
+    for user_id, challenge_id in query.all():
+        result.setdefault(user_id, set()).add(challenge_id)
+    return result
+
+
+def user_challenges(model, duration, user_id):
+    query = (
+        model.solves()
+        .filter(duration_solves_filter(duration))
+        .filter(DojoChallenges.required == True)
+        .filter(Solves.user_id == user_id)
+        .with_entities(Solves.challenge_id)
+    )
+    return set(challenge_id for (challenge_id,) in query.all())
+
+
+def set_scoreboard_cache(cache_key, scoreboard, member_challenges):
     set_cached_stat(cache_key, scoreboard)
-    set_cached_stat(cache_key.replace("stats:scoreboard:", "stats:crews:", 1), aggregate_crews(scoreboard))
+    set_cached_stat(cache_key.replace("stats:scoreboard:", "stats:crews:", 1),
+                    aggregate_crews(scoreboard, member_challenges))
+
+
+def update_scoreboard_cache(model, cache_key, user_id, challenge_id):
+    current_scoreboard = get_cached_stat(cache_key) or []
+    updated_scoreboard = update_scoreboard(current_scoreboard, user_id)
+    crews_key = cache_key.replace("stats:scoreboard:", "stats:crews:", 1)
+    member_challenges = member_challenges_from_crews(get_cached_stat(crews_key) or [])
+    entry = next((item for item in updated_scoreboard if item["user_id"] == user_id), None)
+    if entry and parse_crew_tag(entry.get("name")):
+        if user_id in member_challenges:
+            member_challenges[user_id].add(challenge_id)
+        else:
+            duration = int(cache_key.rsplit(":", 1)[1])
+            member_challenges[user_id] = user_challenges(model, duration, user_id)
+    set_scoreboard_cache(cache_key, updated_scoreboard, member_challenges)
 
 
 def update_scoreboard(scoreboard, user_id, solve_delta=1):
@@ -82,10 +129,7 @@ def update_challenge_solves(challenge_solves, challenge_id):
 
 
 def calculate_scoreboard(model, duration):
-    duration_filter = (
-        Solves.date >= datetime.datetime.utcnow() - datetime.timedelta(days=duration)
-        if duration else True
-    )
+    duration_filter = duration_solves_filter(duration)
     required_filter = DojoChallenges.required == True
     solves = func.count().label("solves")
     rank = (
@@ -150,7 +194,7 @@ def handle_scoreboard_update(payload, event_timestamp=None):
                 continue
             logger.info(f"Calculating scoreboard for {model_type} {model_id}, duration={duration}...")
             scoreboard = calculate_scoreboard(model, duration)
-            set_scoreboard_cache(cache_key, scoreboard)
+            set_scoreboard_cache(cache_key, scoreboard, calculate_member_challenges(model, duration))
             logger.info(f"Successfully updated scoreboard cache {cache_key} ({len(scoreboard)} entries)")
         except Exception as e:
             logger.error(f"Error calculating scoreboard for {model_type} {model_id}, duration={duration}: {e}", exc_info=True)
@@ -175,7 +219,7 @@ def initialize_all_scoreboards():
             try:
                 scoreboard = calculate_scoreboard(dojo, duration)
                 cache_key = f"stats:scoreboard:dojo:{dojo.dojo_id}:{duration}"
-                set_scoreboard_cache(cache_key, scoreboard)
+                set_scoreboard_cache(cache_key, scoreboard, calculate_member_challenges(dojo, duration))
                 logger.info(f"Initialized scoreboard for dojo {dojo.reference_id} (id={dojo.dojo_id}), duration={duration}")
             except Exception as e:
                 logger.error(f"Error initializing scoreboard for dojo {dojo.reference_id}, duration={duration}: {e}", exc_info=True)
@@ -185,7 +229,7 @@ def initialize_all_scoreboards():
                 try:
                     scoreboard = calculate_scoreboard(module, duration)
                     cache_key = f"stats:scoreboard:module:{module.dojo_id}:{module.module_index}:{duration}"
-                    set_scoreboard_cache(cache_key, scoreboard)
+                    set_scoreboard_cache(cache_key, scoreboard, calculate_member_challenges(module, duration))
                     logger.info(f"Initialized scoreboard for module {dojo.reference_id}/{module.id} (dojo_id={module.dojo_id}, module_index={module.module_index}), duration={duration}")
                 except Exception as e:
                     logger.error(f"Error initializing scoreboard for module {dojo.reference_id}/{module.id}, duration={duration}: {e}", exc_info=True)

--- a/dojo_plugin/worker/handlers/scoreboard.py
+++ b/dojo_plugin/worker/handlers/scoreboard.py
@@ -19,17 +19,20 @@ def duration_solves_filter(duration):
     return Solves.date >= datetime.datetime.utcnow() - datetime.timedelta(days=duration)
 
 
-def calculate_member_challenges(model, duration):
-    query = (
-        model.solves()
-        .filter(duration_solves_filter(duration))
-        .filter(DojoChallenges.required == True)
-        .filter(Users.name.like("%]"))
-        .with_entities(Solves.user_id, Solves.challenge_id)
-    )
+def calculate_member_challenges(model, duration, scoreboard):
+    tagged_user_ids = [entry["user_id"] for entry in scoreboard if parse_crew_tag(entry.get("name"))]
     result = {}
-    for user_id, challenge_id in query.all():
-        result.setdefault(user_id, set()).add(challenge_id)
+    for start in range(0, len(tagged_user_ids), 500):
+        chunk = tagged_user_ids[start:start + 500]
+        query = (
+            model.solves()
+            .filter(duration_solves_filter(duration))
+            .filter(DojoChallenges.required == True)
+            .filter(Solves.user_id.in_(chunk))
+            .with_entities(Solves.user_id, Solves.challenge_id)
+        )
+        for user_id, challenge_id in query.all():
+            result.setdefault(user_id, set()).add(challenge_id)
     return result
 
 
@@ -194,7 +197,7 @@ def handle_scoreboard_update(payload, event_timestamp=None):
                 continue
             logger.info(f"Calculating scoreboard for {model_type} {model_id}, duration={duration}...")
             scoreboard = calculate_scoreboard(model, duration)
-            set_scoreboard_cache(cache_key, scoreboard, calculate_member_challenges(model, duration))
+            set_scoreboard_cache(cache_key, scoreboard, calculate_member_challenges(model, duration, scoreboard))
             logger.info(f"Successfully updated scoreboard cache {cache_key} ({len(scoreboard)} entries)")
         except Exception as e:
             logger.error(f"Error calculating scoreboard for {model_type} {model_id}, duration={duration}: {e}", exc_info=True)
@@ -219,7 +222,7 @@ def initialize_all_scoreboards():
             try:
                 scoreboard = calculate_scoreboard(dojo, duration)
                 cache_key = f"stats:scoreboard:dojo:{dojo.dojo_id}:{duration}"
-                set_scoreboard_cache(cache_key, scoreboard, calculate_member_challenges(dojo, duration))
+                set_scoreboard_cache(cache_key, scoreboard, calculate_member_challenges(dojo, duration, scoreboard))
                 logger.info(f"Initialized scoreboard for dojo {dojo.reference_id} (id={dojo.dojo_id}), duration={duration}")
             except Exception as e:
                 logger.error(f"Error initializing scoreboard for dojo {dojo.reference_id}, duration={duration}: {e}", exc_info=True)
@@ -229,7 +232,7 @@ def initialize_all_scoreboards():
                 try:
                     scoreboard = calculate_scoreboard(module, duration)
                     cache_key = f"stats:scoreboard:module:{module.dojo_id}:{module.module_index}:{duration}"
-                    set_scoreboard_cache(cache_key, scoreboard, calculate_member_challenges(module, duration))
+                    set_scoreboard_cache(cache_key, scoreboard, calculate_member_challenges(module, duration, scoreboard))
                     logger.info(f"Initialized scoreboard for module {dojo.reference_id}/{module.id} (dojo_id={module.dojo_id}, module_index={module.module_index}), duration={duration}")
                 except Exception as e:
                     logger.error(f"Error initializing scoreboard for module {dojo.reference_id}/{module.id}, duration={duration}: {e}", exc_info=True)

--- a/dojo_plugin/worker/handlers/solve.py
+++ b/dojo_plugin/worker/handlers/solve.py
@@ -45,7 +45,7 @@ def handle_challenge_solve(payload, event_timestamp):
         is_member = dojo.is_member(user_id)
         is_public_or_official = dojo.is_public_or_official
 
-        if is_member:
+        if is_member and dojo_challenge.required:
             logger.info(f"Updating dojo scoreboard for dojo {dojo_ref_id}")
             _update_dojo_scoreboard(dojo, user_id, challenge_id, event_timestamp)
             logger.info(f"Updating module scoreboard for dojo {dojo_ref_id} module {module_index}")

--- a/dojo_plugin/worker/handlers/solve.py
+++ b/dojo_plugin/worker/handlers/solve.py
@@ -5,7 +5,7 @@ from CTFd.models import db
 from ...models import DojoChallenges
 from ...utils.background_stats import get_cached_stat, set_cached_stat, is_event_stale
 from . import register_handler
-from .scoreboard import update_scoreboard, update_challenge_solves, challenge_solves_cache_key, set_scoreboard_cache, COMMON_DURATIONS
+from .scoreboard import update_scoreboard_cache, update_challenge_solves, challenge_solves_cache_key, COMMON_DURATIONS
 from .dojo_stats import update_dojo_stats
 from .scores import update_dojo_scores, update_module_scores, dojo_scores_cache_key, module_scores_cache_key
 from .activity import update_activity
@@ -47,9 +47,9 @@ def handle_challenge_solve(payload, event_timestamp):
 
         if is_member:
             logger.info(f"Updating dojo scoreboard for dojo {dojo_ref_id}")
-            _update_dojo_scoreboard(dojo_id, user_id, event_timestamp)
+            _update_dojo_scoreboard(dojo, user_id, challenge_id, event_timestamp)
             logger.info(f"Updating module scoreboard for dojo {dojo_ref_id} module {module_index}")
-            _update_module_scoreboard(dojo_id, module_index, user_id, event_timestamp)
+            _update_module_scoreboard(dojo_challenge.module, user_id, challenge_id, event_timestamp)
             logger.info(f"Updating dojo stats for dojo {dojo_ref_id}")
             _update_dojo_stats(dojo_ref_id, challenge_name, event_timestamp)
             logger.info(f"Updating challenge solves for dojo {dojo_ref_id} module {module_index}")
@@ -68,32 +68,28 @@ def handle_challenge_solve(payload, event_timestamp):
     logger.info(f"Completed challenge_solve for user_id={user_id}, challenge_id={challenge_id}")
 
 
-def _update_dojo_scoreboard(dojo_id, user_id, event_timestamp):
-    cache_prefix = f"stats:scoreboard:dojo:{dojo_id}"
+def _update_dojo_scoreboard(dojo, user_id, challenge_id, event_timestamp):
+    cache_prefix = f"stats:scoreboard:dojo:{dojo.dojo_id}"
     for duration in COMMON_DURATIONS:
         try:
             cache_key = f"{cache_prefix}:{duration}"
             if is_event_stale(cache_key, event_timestamp):
                 continue
-            current_scoreboard = get_cached_stat(cache_key) or []
-            updated_scoreboard = update_scoreboard(current_scoreboard, user_id)
-            set_scoreboard_cache(cache_key, updated_scoreboard)
+            update_scoreboard_cache(dojo, cache_key, user_id, challenge_id)
         except Exception as e:
-            logger.error(f"Error updating dojo scoreboard for dojo {dojo_id}, duration={duration}: {e}", exc_info=True)
+            logger.error(f"Error updating dojo scoreboard for dojo {dojo.dojo_id}, duration={duration}: {e}", exc_info=True)
 
 
-def _update_module_scoreboard(dojo_id, module_index, user_id, event_timestamp):
-    cache_prefix = f"stats:scoreboard:module:{dojo_id}:{module_index}"
+def _update_module_scoreboard(module, user_id, challenge_id, event_timestamp):
+    cache_prefix = f"stats:scoreboard:module:{module.dojo_id}:{module.module_index}"
     for duration in COMMON_DURATIONS:
         try:
             cache_key = f"{cache_prefix}:{duration}"
             if is_event_stale(cache_key, event_timestamp):
                 continue
-            current_scoreboard = get_cached_stat(cache_key) or []
-            updated_scoreboard = update_scoreboard(current_scoreboard, user_id)
-            set_scoreboard_cache(cache_key, updated_scoreboard)
+            update_scoreboard_cache(module, cache_key, user_id, challenge_id)
         except Exception as e:
-            logger.error(f"Error updating module scoreboard for dojo {dojo_id} module {module_index}, duration={duration}: {e}", exc_info=True)
+            logger.error(f"Error updating module scoreboard for dojo {module.dojo_id} module {module.module_index}, duration={duration}: {e}", exc_info=True)
 
 
 def _update_dojo_stats(dojo_ref_id, challenge_name, event_timestamp):

--- a/dojo_plugin/worker/handlers/solve.py
+++ b/dojo_plugin/worker/handlers/solve.py
@@ -5,7 +5,7 @@ from CTFd.models import db
 from ...models import DojoChallenges
 from ...utils.background_stats import get_cached_stat, set_cached_stat, is_event_stale
 from . import register_handler
-from .scoreboard import update_scoreboard, update_challenge_solves, challenge_solves_cache_key, COMMON_DURATIONS
+from .scoreboard import update_scoreboard, update_challenge_solves, challenge_solves_cache_key, set_scoreboard_cache, COMMON_DURATIONS
 from .dojo_stats import update_dojo_stats
 from .scores import update_dojo_scores, update_module_scores, dojo_scores_cache_key, module_scores_cache_key
 from .activity import update_activity
@@ -77,7 +77,7 @@ def _update_dojo_scoreboard(dojo_id, user_id, event_timestamp):
                 continue
             current_scoreboard = get_cached_stat(cache_key) or []
             updated_scoreboard = update_scoreboard(current_scoreboard, user_id)
-            set_cached_stat(cache_key, updated_scoreboard)
+            set_scoreboard_cache(cache_key, updated_scoreboard)
         except Exception as e:
             logger.error(f"Error updating dojo scoreboard for dojo {dojo_id}, duration={duration}: {e}", exc_info=True)
 
@@ -91,7 +91,7 @@ def _update_module_scoreboard(dojo_id, module_index, user_id, event_timestamp):
                 continue
             current_scoreboard = get_cached_stat(cache_key) or []
             updated_scoreboard = update_scoreboard(current_scoreboard, user_id)
-            set_cached_stat(cache_key, updated_scoreboard)
+            set_scoreboard_cache(cache_key, updated_scoreboard)
         except Exception as e:
             logger.error(f"Error updating module scoreboard for dojo {dojo_id} module {module_index}, duration={duration}: {e}", exc_info=True)
 

--- a/dojo_theme/static/css/custom.css
+++ b/dojo_theme/static/css/custom.css
@@ -515,6 +515,276 @@ p[data-hide="true"] {
     display: flex;
 }
 
+.scoreboard tr > td[colspan] {
+    flex: 1;
+}
+
+.scoreboard-controls {
+    justify-content: space-between;
+    align-items: baseline;
+}
+
+.scoreboard-view-toggle {
+    display: inline-flex;
+    gap: 0.25em;
+    border: 1px dashed var(--brand-light-gray);
+    border-radius: 2em;
+    padding: 0.2em 0.3em;
+    font-size: 0.85em;
+}
+
+.scoreboard-view-toggle a {
+    padding: 0.1em 1em;
+    border-radius: 2em;
+    color: var(--brand-light-gray);
+    text-decoration: none;
+}
+
+.scoreboard-view-toggle a:hover:not(.scoreboard-view-selected) {
+    color: #eaeaea;
+    text-decoration: none;
+}
+
+.scoreboard-view-toggle a.scoreboard-view-selected {
+    background-color: var(--brand-green);
+    color: var(--brand-black);
+    font-weight: 700;
+}
+
+.scoreboard-crew-mode .table-striped tbody tr:nth-of-type(odd) {
+    background-color: transparent;
+}
+
+.scoreboard-crew-mode .table-striped tbody tr.crew-row-stripe {
+    background-color: rgba(255, 255, 255, 0.035);
+}
+
+.crew-row {
+    cursor: pointer;
+    user-select: none;
+}
+
+.crew-row:hover {
+    background-color: rgba(255, 255, 255, 0.07) !important;
+}
+
+.crew-row:focus {
+    outline: 1px dashed var(--brand-light-gray);
+    outline-offset: -1px;
+}
+
+.crew-caret {
+    display: inline-block;
+    width: 0.8em;
+    color: var(--brand-light-gray);
+    transition: transform 0.15s ease;
+}
+
+.crew-row-open .crew-caret {
+    transform: rotate(90deg);
+}
+
+.crew-rank-1 .crew-rank {
+    color: var(--brand-gold);
+}
+
+.crew-rank-2 .crew-rank {
+    color: #c0c0c0;
+}
+
+.crew-rank-3 .crew-rank {
+    color: #cd7f32;
+}
+
+.crew-crest {
+    margin: auto;
+    width: 2.4em;
+    height: 2.4em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid;
+    border-radius: 0.5em;
+    font-weight: 700;
+}
+
+.crew-tag {
+    display: inline-flex;
+    align-items: baseline;
+    border: 1px solid;
+    border-radius: 0.35em;
+    padding: 0 0.4em;
+    font-family: 'Space Mono', monospace;
+    font-weight: 700;
+    vertical-align: bottom;
+}
+
+.crew-tag .crew-tag-bracket {
+    opacity: 0.6;
+    font-weight: 400;
+}
+
+.crew-tag .crew-tag-text {
+    max-width: 24ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    unicode-bidi: isolate;
+}
+
+.scoreboard-name {
+    unicode-bidi: isolate;
+}
+
+.scoreboard-name .crew-tag {
+    font-size: 0.85em;
+    margin-left: 0.4em;
+}
+
+.crew-member-count {
+    margin-left: 0.75em;
+    color: var(--brand-light-gray);
+    font-size: 0.85em;
+}
+
+.crew-facepile {
+    display: flex;
+    align-items: center;
+}
+
+.crew-face {
+    height: 1.7em;
+    filter: drop-shadow(0px 0px 2px white);
+}
+
+.crew-face:not(:first-child) {
+    margin-left: -0.45em;
+}
+
+.crew-face-more {
+    margin-left: 0.4em;
+    color: var(--brand-light-gray);
+    font-size: 0.85em;
+}
+
+.crew-member-row {
+    background-color: rgba(255, 255, 255, 0.03) !important;
+    border-left: 3px solid var(--brand-light-gray);
+    animation: crew-member-in 0.18s ease-out;
+}
+
+.crew-member-row > td:first-child {
+    padding-left: 2.2em;
+}
+
+.crew-member-row .scoreboard-rank {
+    color: var(--brand-light-gray);
+    font-weight: 400;
+}
+
+.crew-member-row.scoreboard-row-me {
+    background-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+@keyframes crew-member-in {
+    from {
+        opacity: 0;
+        transform: translateY(-0.2em);
+    }
+    to {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+.crew-more-row {
+    background: none !important;
+}
+
+.crew-more-row td {
+    padding-left: 2.2em;
+}
+
+.crew-more-row a {
+    color: var(--brand-light-gray);
+    cursor: pointer;
+    font-size: 0.9em;
+}
+
+.crew-more-row a:hover {
+    color: #eaeaea;
+}
+
+.crew-loading td {
+    padding: 2em 20%;
+}
+
+.crew-loading-text {
+    color: var(--brand-light-gray);
+    text-align: center;
+    margin-bottom: 0.6em;
+}
+
+.crew-progress-track {
+    height: 6px;
+    background-color: #1e1e1e;
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.crew-progress-fill {
+    height: 100%;
+    width: 0;
+    background-color: var(--brand-green);
+    transition: width 0.2s ease;
+}
+
+.crew-note-row {
+    background: none !important;
+}
+
+.crew-note {
+    color: var(--brand-light-gray);
+    font-size: 0.85em;
+    text-align: center;
+    padding: 0.75em;
+}
+
+.crew-note-warn {
+    color: var(--brand-gold);
+}
+
+.crew-note-warn a {
+    color: var(--brand-gold);
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.crew-empty td {
+    text-align: center;
+    padding: 2.5em 1em;
+}
+
+.crew-empty .crew-tag-ghost {
+    border-style: dashed;
+    border-color: var(--brand-light-gray);
+    color: var(--brand-light-gray);
+    background: none;
+    font-size: 1.1em;
+}
+
+.crew-empty-title {
+    color: var(--brand-green);
+    font-size: 1.3em;
+    font-weight: 500;
+    margin-top: 0.6em;
+}
+
+.crew-empty-hint {
+    color: var(--brand-light-gray);
+    margin-top: 0.4em;
+}
+
 .discord-avatar {
     display: block;
     margin: auto;

--- a/dojo_theme/static/css/custom.css
+++ b/dojo_theme/static/css/custom.css
@@ -524,6 +524,12 @@ p[data-hide="true"] {
     align-items: baseline;
 }
 
+.scoreboard-view-controls {
+    display: inline-flex;
+    gap: 0.6em;
+    align-items: baseline;
+}
+
 .scoreboard-view-toggle {
     display: inline-flex;
     gap: 0.25em;

--- a/dojo_theme/static/css/custom.css
+++ b/dojo_theme/static/css/custom.css
@@ -715,30 +715,6 @@ p[data-hide="true"] {
     color: #eaeaea;
 }
 
-.crew-loading td {
-    padding: 2em 20%;
-}
-
-.crew-loading-text {
-    color: var(--brand-light-gray);
-    text-align: center;
-    margin-bottom: 0.6em;
-}
-
-.crew-progress-track {
-    height: 6px;
-    background-color: #1e1e1e;
-    border-radius: 3px;
-    overflow: hidden;
-}
-
-.crew-progress-fill {
-    height: 100%;
-    width: 0;
-    background-color: var(--brand-green);
-    transition: width 0.2s ease;
-}
-
 .crew-note-row {
     background: none !important;
 }

--- a/dojo_theme/static/js/dojo/scoreboard.js
+++ b/dojo_theme/static/js/dojo/scoreboard.js
@@ -1,36 +1,42 @@
-function loadScoreboard(duration, page) {
+const CREW_MAX_PAGES = 50;
+const CREW_FETCH_CONCURRENCY = 4;
+const CREW_CACHE_TTL_MS = 5 * 60 * 1000;
+const CREW_TAG_RE = /^(.*?)\s*\[([^\[\]]{1,24})\]\s*$/;
+const CREW_STRIP_RE = /[\u0000-\u001f\u007f-\u009f\u00ad\u034f\u17b4\u17b5\u180b-\u180e\u200b-\u200f\u2028-\u202e\u2060-\u2064\u2066-\u2069\ufeff\u{e0000}-\u{e007f}]/gu;
+const CREW_KEY_STRIP_RE = /[\ufe00-\ufe0f]/g;
+
+const scoreboardState = {
+    generation: 0,
+    view: location.hash === "#crews" ? "crews" : "hackers",
+    duration: 30,
+    crewCache: new Map(),
+};
+
+function parseCrewTag(name) {
+    const match = CREW_TAG_RE.exec(name);
+    if (!match) return null;
+    const tag = match[2].replace(CREW_STRIP_RE, "").replace(/\s+/g, " ").trim();
+    if (tag.length < 1 || tag.length > 20) return null;
+    return { tag: tag, key: tag.replace(CREW_KEY_STRIP_RE, "").normalize("NFKC").toLowerCase(), baseName: match[1].trim() };
+}
+window.parseCrewTag = parseCrewTag;
+
+function crewColors(key) {
+    let hash = 5381;
+    for (let i = 0; i < key.length; i++) hash = ((hash << 5) + hash + key.charCodeAt(i)) >>> 0;
+    const hue = hash % 360;
+    return {
+        text: `hsl(${hue}, 60%, 65%)`,
+        border: `hsla(${hue}, 60%, 65%, 0.55)`,
+        background: `hsla(${hue}, 60%, 65%, 0.12)`,
+    };
+}
+
+function fetchScoreboardPage(duration, page) {
     const dojo = init.dojo;
     const module = init.module || "_";
-    const scoreboard = $("#scoreboard");
-
     const endpoint = `/pwncollege_api/v1/scoreboard/${dojo}/${module}/${duration}/${page}`;
-    scoreboard.empty();
-    message = "Loading."
-    scoreboard.html(`<td colspan=6>${message}</td>`);
-    setTimeout(function loadmsg() {
-        if (scoreboard.html().includes(message)) {
-            message += "."
-            scoreboard.html(`<td colspan=6>${message}</td>`);
-            setTimeout(loadmsg, 1000);
-        }
-    }, 500);
-    $("#scoreboard-control-week").removeClass("scoreboard-page-selected");
-    $("#scoreboard-control-month").removeClass("scoreboard-page-selected");
-    $("#scoreboard-control-all").removeClass("scoreboard-page-selected");
-    if (duration == 7) {
-        $("#scoreboard-control-week").addClass("scoreboard-page-selected");
-        $("#scoreboard-heading").text("7-Day Scoreboard:");
-    }
-    if (duration == 30) {
-        $("#scoreboard-control-month").addClass("scoreboard-page-selected");
-        $("#scoreboard-heading").text("30-Day Scoreboard:");
-    }
-    if (duration == 0) {
-        $("#scoreboard-control-all").addClass("scoreboard-page-selected");
-        $("#scoreboard-heading").text("All-Time Scoreboard:");
-    }
-
-    CTFd.fetch(endpoint, {
+    return CTFd.fetch(endpoint, {
         method: "GET",
         credentials: "same-origin",
         headers: {
@@ -38,64 +44,445 @@ function loadScoreboard(duration, page) {
             "Content-Type": "application/json"
         },
     }).then(response => {
-        return response.json()
-    }).then(result => {
-        scoreboard.empty();
+        if (!response.ok) throw new Error(`scoreboard page ${page} returned ${response.status}`);
+        return response.json();
+    });
+}
 
-        const standings = result.standings;
-        if (result.me) {
-            if (result.me.rank < standings[0].rank)
-                standings.splice(0, 0, result.me)
-            else if (result.me.rank > standings[standings.length - 1].rank)
-                standings.splice(standings.length, 0, result.me)
+async function runCrewFetch(entry, duration) {
+    if (!entry.pagesByNumber.has(1)) {
+        const first = await fetchScoreboardPage(duration, 1);
+        entry.me = first.me || null;
+        entry.pagesByNumber.set(1, first.standings);
+        entry.totalPages = first.pages && first.pages.length ? Math.max.apply(null, first.pages) : 1;
+        entry.capped = entry.totalPages > CREW_MAX_PAGES;
+    }
+    const fetchCount = Math.min(entry.totalPages, CREW_MAX_PAGES);
+    const missing = [];
+    for (let page = 2; page <= fetchCount; page++) {
+        if (!entry.pagesByNumber.has(page)) missing.push(page);
+    }
+    entry.failedPages = [];
+    let done = fetchCount - missing.length;
+    const report = () => { if (entry.onProgress) entry.onProgress(done, fetchCount); };
+    report();
+    let next = 0;
+    const worker = async () => {
+        while (next < missing.length) {
+            const page = missing[next++];
+            try {
+                let result;
+                try {
+                    result = await fetchScoreboardPage(duration, page);
+                } catch (error) {
+                    result = await fetchScoreboardPage(duration, page);
+                }
+                entry.pagesByNumber.set(page, result.standings);
+            } catch (error) {
+                entry.failedPages.push(page);
+            }
+            done++;
+            report();
         }
-        standings.forEach(user => {
-            const row = $(`
-            <tr>
-              <td scope="row" class="col-md-1"><b>#${user.rank}</b></td>
-              <td class="col-md-1 p-0">
-                <img src="${user.symbol}" class="scoreboard-symbol">
-              </td>
-              <td class="col-md-4">
-                <a href="${user.url}" class="scoreboard-name brand-mono">
-                </a>
-              </td>
-              <td class="scoreboard-completions col-md-4">
-              </td>
-              <td class="col-md-1">
-                <img src="${user.belt}" class="scoreboard-belt">
-              </td>
-              <td class="col-md-1"><b>${user.solves}</b></td>
-            </tr>
-            `);
-            row.find(".scoreboard-name").text(user.name.slice(0, 50));
+    };
+    await Promise.all(Array.from({ length: CREW_FETCH_CONCURRENCY }, worker));
+    return entry;
+}
 
-            user.badges.forEach(badge => {
-                if (!badge.url) badge.url = "#";
-                var count = badge.count <= 1 ? "" : `<sub>x${badge.count}</sub>`
-                var staleStyle = badge.stale ? 'style="opacity: 0.4; filter: grayscale(100%);"' : '';
-                row.find(".scoreboard-completions").append($(`
-                    <span title="${badge.text}" ${staleStyle}>
-                    <a href="${badge.url}">${badge.emoji}</a>${count}
-                    </span><span> </span>
-                `));
+function fetchAllStandings(duration, gen) {
+    const key = `${init.dojo}|${init.module || "_"}|${duration}`;
+    let entry = scoreboardState.crewCache.get(key);
+    if (!entry || Date.now() - entry.fetchedAt >= CREW_CACHE_TTL_MS) {
+        entry = {
+            fetchedAt: Date.now(),
+            pagesByNumber: new Map(),
+            totalPages: 1,
+            capped: false,
+            failedPages: [],
+            me: null,
+            promise: null,
+            running: false,
+            onProgress: null,
+        };
+        scoreboardState.crewCache.set(key, entry);
+    }
+    entry.onProgress = (done, total) => {
+        if (gen === scoreboardState.generation) updateCrewProgress(done, total);
+    };
+    if (!entry.promise || (!entry.running && entry.failedPages.length)) {
+        entry.running = true;
+        entry.promise = runCrewFetch(entry, duration)
+            .catch(error => {
+                scoreboardState.crewCache.delete(key);
+                throw error;
             })
+            .finally(() => { entry.running = false; });
+    }
+    return entry.promise;
+}
 
-            if (result.me && user.user_id == result.me.user_id)
-                row.addClass("scoreboard-row-me");
-            scoreboard.append(row);
+function dedupStandings(entry) {
+    const byUser = new Map();
+    const pages = Array.from(entry.pagesByNumber.keys()).sort((a, b) => a - b);
+    pages.forEach(page => {
+        entry.pagesByNumber.get(page).forEach(user => {
+            if (!byUser.has(user.user_id)) byUser.set(user.user_id, user);
         });
+    });
+    return Array.from(byUser.values()).sort((a, b) => a.rank - b.rank);
+}
 
-        const scoreboardPages = $("#scoreboard-pages");
-        scoreboardPages.empty();//A
-        if (result.pages.length > 1) {
-            result.pages.forEach(i => {
-                const pageButton = $(`
-                <li class="scoreboard-page"><a href="javascript:loadScoreboard('${duration}', ${i})">${i}</a></li>
-                `);
-                pageButton.addClass(i == page ? "scoreboard-page-selected" : "scoreboard-page-unselected");
-                scoreboardPages.append(pageButton);
+function aggregateCrews(standings) {
+    const crews = new Map();
+    standings.forEach(user => {
+        const parsed = parseCrewTag(user.name);
+        if (!parsed) return;
+        if (!crews.has(parsed.key)) {
+            crews.set(parsed.key, { key: parsed.key, tag: parsed.tag, score: 0, bestRank: user.rank, members: [] });
+        }
+        const crew = crews.get(parsed.key);
+        crew.score += user.solves;
+        crew.members.push(user);
+    });
+    const ranked = Array.from(crews.values()).sort((a, b) =>
+        b.score - a.score
+        || a.members.length - b.members.length
+        || a.bestRank - b.bestRank
+        || a.key.localeCompare(b.key)
+    );
+    ranked.forEach((crew, i) => { crew.rank = i + 1; });
+    return ranked;
+}
+
+function buildCrewTagChip(tag, key) {
+    const colors = crewColors(key);
+    const chip = $(`
+        <span class="crew-tag"><span class="crew-tag-bracket">[</span><bdi class="crew-tag-text"></bdi><span class="crew-tag-bracket">]</span></span>
+    `);
+    chip.find(".crew-tag-text").text(tag);
+    chip.css({ "color": colors.text, "border-color": colors.border, "background-color": colors.background });
+    return chip;
+}
+
+function buildHackerRow(user, me, crew) {
+    const row = $(`
+    <tr>
+      <td scope="row" class="col-md-1"><b class="scoreboard-rank"></b></td>
+      <td class="col-md-1 p-0">
+        <img class="scoreboard-symbol">
+      </td>
+      <td class="col-md-4">
+        <a class="scoreboard-name brand-mono"></a>
+      </td>
+      <td class="scoreboard-completions col-md-4">
+      </td>
+      <td class="col-md-1">
+        <img class="scoreboard-belt">
+      </td>
+      <td class="col-md-1"><b class="scoreboard-score"></b></td>
+    </tr>
+    `);
+    row.find(".scoreboard-rank").text(`#${user.rank}`);
+    row.find(".scoreboard-symbol").attr("src", user.symbol);
+    row.find(".scoreboard-belt").attr("src", user.belt);
+    row.find(".scoreboard-score").text(user.solves);
+    const name = row.find(".scoreboard-name").attr("href", user.url).attr("title", user.name);
+    const parsed = parseCrewTag(user.name);
+    if (crew) {
+        row.addClass("crew-member-row").css("border-left-color", crewColors(crew.key).text);
+        name.text(((parsed && parsed.baseName) || user.name).slice(0, 50));
+    } else if (parsed) {
+        name.text(parsed.baseName.slice(0, 50));
+        name.append(buildCrewTagChip(parsed.tag, parsed.key));
+    } else {
+        name.text(user.name.slice(0, 50));
+    }
+    const completions = row.find(".scoreboard-completions");
+    (user.badges || []).forEach(badge => {
+        const span = $(`<span><a class="scoreboard-badge"></a><sub class="scoreboard-badge-count"></sub></span>`);
+        span.attr("title", badge.text);
+        span.find(".scoreboard-badge").attr("href", badge.url || "#").text(badge.emoji);
+        if (badge.count > 1) span.find(".scoreboard-badge-count").text(`x${badge.count}`);
+        else span.find(".scoreboard-badge-count").remove();
+        if (badge.stale) span.css({ "opacity": 0.4, "filter": "grayscale(100%)" });
+        completions.append(span, " ");
+    });
+    if (me && user.user_id === me.user_id) row.addClass("scoreboard-row-me");
+    return row;
+}
+
+function buildCrewRow(crew, me, myCrewKey) {
+    const colors = crewColors(crew.key);
+    const row = $(`
+    <tr class="crew-row" role="button" tabindex="0" aria-expanded="false">
+      <td scope="row" class="col-md-1"><i class="fas fa-caret-right crew-caret" aria-hidden="true"></i> <b class="crew-rank"></b></td>
+      <td class="col-md-1 p-0">
+        <span class="crew-crest brand-mono"></span>
+      </td>
+      <td class="col-md-4 crew-name-cell">
+      </td>
+      <td class="col-md-4 crew-facepile">
+      </td>
+      <td class="col-md-1">
+        <img class="scoreboard-belt">
+      </td>
+      <td class="col-md-1"><b class="crew-score"></b></td>
+    </tr>
+    `);
+    row.find(".crew-rank").text(`#${crew.rank}`);
+    if (crew.rank <= 3) row.addClass(`crew-rank-${crew.rank}`);
+    const crest = row.find(".crew-crest");
+    crest.text(Array.from(crew.tag)[0].toUpperCase());
+    crest.css({ "color": colors.text, "border-color": colors.border, "background-color": colors.background });
+    const nameCell = row.find(".crew-name-cell");
+    nameCell.append(buildCrewTagChip(crew.tag, crew.key));
+    const count = $(`<span class="crew-member-count"></span>`);
+    count.text(`${crew.members.length} member${crew.members.length === 1 ? "" : "s"}`);
+    nameCell.append(count);
+    const facepile = row.find(".crew-facepile");
+    crew.members.slice(0, 5).forEach(member => {
+        facepile.append($(`<img class="crew-face">`).attr("src", member.symbol));
+    });
+    if (crew.members.length > 5) {
+        facepile.append($(`<span class="crew-face-more brand-mono"></span>`).text(`+${crew.members.length - 5}`));
+    }
+    const names = crew.members.slice(0, 5).map(member => member.name).join(", ");
+    facepile.attr("title", crew.members.length > 5 ? `${names}, …` : names);
+    const top = crew.members[0];
+    row.find(".scoreboard-belt").attr("src", top.belt).attr("title", `Top member: ${top.name}`);
+    row.find(".crew-score").text(crew.score.toLocaleString()).attr("title", `Sum of ${crew.members.length} members' scores`);
+    if (myCrewKey && crew.key === myCrewKey) row.addClass("scoreboard-row-me");
+
+    let memberRows = null;
+    let expanded = false;
+    const attachMembers = () => {
+        const rows = crew.members.map(user => buildHackerRow(user, me, crew));
+        const head = rows.slice(0, 10);
+        const rest = rows.slice(10);
+        memberRows = head.slice();
+        if (rest.length) {
+            const moreRow = $(`<tr class="crew-more-row"><td colspan="6"><a role="button" tabindex="0"></a></td></tr>`);
+            moreRow.find("a").text(`▾ show ${rest.length} more member${rest.length === 1 ? "" : "s"}`);
+            const showRest = () => {
+                rest.forEach(memberRow => memberRow.insertBefore(moreRow));
+                moreRow.remove();
+                memberRows = head.concat(rest);
+            };
+            moreRow.on("click", showRest);
+            moreRow.find("a").on("keydown", event => {
+                if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    showRest();
+                }
             });
+            memberRows.push(moreRow);
+        }
+        let anchor = row;
+        memberRows.forEach(memberRow => {
+            anchor.after(memberRow);
+            anchor = memberRow;
+        });
+    };
+    const toggle = () => {
+        expanded = !expanded;
+        row.attr("aria-expanded", expanded ? "true" : "false");
+        row.toggleClass("crew-row-open", expanded);
+        if (expanded && !memberRows) attachMembers();
+        else if (memberRows) memberRows.forEach(memberRow => expanded ? memberRow.show() : memberRow.hide());
+    };
+    row.on("click", toggle);
+    row.on("keydown", event => {
+        if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            toggle();
         }
     });
+    return row;
+}
+
+function setScoreboardControls(view, duration) {
+    $("#scoreboard-control-week, #scoreboard-control-month, #scoreboard-control-all").removeClass("scoreboard-page-selected");
+    const labels = { 7: "7-Day", 30: "30-Day", 0: "All-Time" };
+    const controls = { 7: "#scoreboard-control-week", 30: "#scoreboard-control-month", 0: "#scoreboard-control-all" };
+    if (controls[duration]) $(controls[duration]).addClass("scoreboard-page-selected");
+    const crews = view === "crews";
+    $("#scoreboard-heading").text(`${labels[duration] || ""}${crews ? " Crew" : ""} Scoreboard:`);
+    $("#scoreboard-th-name").text(crews ? "Crew" : "Hacker");
+    $("#scoreboard-th-badges").text(crews ? "Members" : "Badges");
+    $("#scoreboard-view-hackers").toggleClass("scoreboard-view-selected", !crews).attr("aria-selected", String(!crews));
+    $("#scoreboard-view-crews").toggleClass("scoreboard-view-selected", crews).attr("aria-selected", String(crews));
+    $(".scoreboard").toggleClass("scoreboard-crew-mode", crews);
+}
+
+function renderPagination(duration, page, pages) {
+    const scoreboardPages = $("#scoreboard-pages");
+    scoreboardPages.empty();
+    if (pages.length > 1) {
+        pages.forEach(i => {
+            const pageButton = $(`<li class="scoreboard-page"><a></a></li>`);
+            pageButton.find("a").attr("href", `javascript:loadScoreboard(${Number(duration)}, ${Number(i)})`).text(i);
+            pageButton.addClass(i == page ? "scoreboard-page-selected" : "scoreboard-page-unselected");
+            scoreboardPages.append(pageButton);
+        });
+    }
+}
+
+function renderNoteRow(text) {
+    const row = $(`<tr class="crew-note-row"><td colspan="6" class="crew-note"></td></tr>`);
+    row.find(".crew-note").text(text);
+    $("#scoreboard").append(row);
+    return row;
+}
+
+function renderCrewLoading() {
+    $("#scoreboard").empty().append($(`
+      <tr class="crew-loading"><td colspan="6">
+        <div class="crew-loading-text brand-mono" aria-live="polite">Assembling crews…</div>
+        <div class="crew-progress-track"><div class="crew-progress-fill"></div></div>
+      </td></tr>
+    `));
+    $("#scoreboard-pages").empty();
+}
+
+function updateCrewProgress(done, total) {
+    if (total < 1) total = 1;
+    $("#scoreboard .crew-loading-text").text(`Assembling crews… page ${done} / ${total}`);
+    $("#scoreboard .crew-progress-fill").css("width", `${Math.round(done / total * 100)}%`);
+}
+
+function renderCrewEmptyState() {
+    const row = $(`
+      <tr class="crew-empty"><td colspan="6">
+        <div><span class="crew-tag crew-tag-ghost"><span class="crew-tag-bracket">[</span><bdi class="crew-tag-text">YOUR-CREW</bdi><span class="crew-tag-bracket">]</span></span></div>
+        <div class="crew-empty-title">No crews yet.</div>
+        <div class="crew-empty-hint">Start one: add a tag in brackets to your display name in <a>Settings</a> — e.g. <b>Zardus [Shellphish]</b> — and your crew appears here.</div>
+      </td></tr>
+    `);
+    row.find("a").attr("href", `${init.urlRoot}/settings`);
+    $("#scoreboard").append(row);
+}
+
+function renderCrewNotes(entry, duration, page) {
+    if (entry.capped) {
+        renderNoteRow(`Crew standings computed from the top ${(CREW_MAX_PAGES * 20).toLocaleString()} hackers on this board.`);
+    }
+    if (entry.failedPages.length) {
+        const warning = renderNoteRow("Some pages failed to load — standings may be incomplete. ");
+        warning.find(".crew-note").addClass("crew-note-warn");
+        const retry = $(`<a role="button" tabindex="0" href="javascript:void(0)">Retry</a>`);
+        retry.on("click", () => loadScoreboard(duration, page));
+        warning.find(".crew-note").append(retry);
+    }
+}
+
+function renderCrewBoard(entry, duration, page) {
+    const scoreboard = $("#scoreboard");
+    scoreboard.empty();
+    const standings = dedupStandings(entry);
+    const crews = aggregateCrews(standings);
+    const me = entry.me;
+    const myParsed = me ? parseCrewTag(me.name) : null;
+    const myCrewKey = myParsed ? myParsed.key : null;
+
+    if (!standings.length) {
+        renderNoteRow("No solves yet — no crews to show.");
+        renderCrewNotes(entry, duration, page);
+        renderPagination(duration, 1, []);
+        return;
+    }
+    if (!crews.length) {
+        renderCrewEmptyState();
+        renderCrewNotes(entry, duration, page);
+        renderPagination(duration, 1, []);
+        return;
+    }
+
+    const perPage = 20;
+    const pageCount = Math.ceil(crews.length / perPage);
+    if (page < 1 || page > pageCount) page = 1;
+    const pageCrews = crews.slice((page - 1) * perPage, page * perPage);
+    const display = pageCrews.slice();
+    if (myCrewKey) {
+        const myCrew = crews.find(crew => crew.key === myCrewKey);
+        if (myCrew && pageCrews.indexOf(myCrew) === -1) {
+            if (myCrew.rank < pageCrews[0].rank) display.unshift(myCrew);
+            else display.push(myCrew);
+        }
+    }
+    display.forEach((crew, i) => {
+        const row = buildCrewRow(crew, me, myCrewKey);
+        if (i % 2 === 0) row.addClass("crew-row-stripe");
+        scoreboard.append(row);
+    });
+    renderCrewNotes(entry, duration, page);
+    const pages = [];
+    for (let i = 1; i <= pageCount; i++) pages.push(i);
+    renderPagination(duration, page, pages);
+}
+
+function renderCrewView(duration, page, gen) {
+    renderCrewLoading();
+    fetchAllStandings(duration, gen).then(entry => {
+        if (gen !== scoreboardState.generation) return;
+        renderCrewBoard(entry, duration, page);
+    }).catch(() => {
+        if (gen !== scoreboardState.generation) return;
+        $("#scoreboard").empty();
+        const warning = renderNoteRow("Failed to load the crew scoreboard. ");
+        warning.find(".crew-note").addClass("crew-note-warn");
+        const retry = $(`<a role="button" tabindex="0" href="javascript:void(0)">Retry</a>`);
+        retry.on("click", () => loadScoreboard(duration, page));
+        warning.find(".crew-note").append(retry);
+    });
+}
+
+function renderHackerView(duration, page, gen) {
+    const scoreboard = $("#scoreboard");
+    scoreboard.empty().append($(`<tr class="scoreboard-loading"><td colspan="6">Loading...</td></tr>`));
+    $("#scoreboard-pages").empty();
+    fetchScoreboardPage(duration, page).then(result => {
+        if (gen !== scoreboardState.generation) return;
+        scoreboard.empty();
+        const standings = result.standings.slice();
+        if (result.me && standings.length) {
+            if (result.me.rank < standings[0].rank)
+                standings.splice(0, 0, result.me);
+            else if (result.me.rank > standings[standings.length - 1].rank)
+                standings.splice(standings.length, 0, result.me);
+        }
+        if (!standings.length) {
+            renderNoteRow("No solves yet.");
+        }
+        standings.forEach(user => {
+            scoreboard.append(buildHackerRow(user, result.me, null));
+        });
+        renderPagination(duration, page, result.pages);
+    }).catch(() => {
+        if (gen !== scoreboardState.generation) return;
+        scoreboard.empty();
+        const warning = renderNoteRow("Failed to load the scoreboard. ");
+        warning.find(".crew-note").addClass("crew-note-warn");
+        const retry = $(`<a role="button" tabindex="0" href="javascript:void(0)">Retry</a>`);
+        retry.on("click", () => loadScoreboard(duration, page));
+        warning.find(".crew-note").append(retry);
+    });
+}
+
+function loadScoreboard(duration, page) {
+    duration = Number(duration);
+    page = Number(page);
+    scoreboardState.duration = duration;
+    const gen = ++scoreboardState.generation;
+    setScoreboardControls(scoreboardState.view, duration);
+    if (scoreboardState.view === "crews") renderCrewView(duration, page, gen);
+    else renderHackerView(duration, page, gen);
+}
+
+function setScoreboardView(view) {
+    if (scoreboardState.view === view) return;
+    scoreboardState.view = view;
+    if (history.replaceState) {
+        history.replaceState(null, "", view === "crews" ? "#crews" : location.pathname + location.search);
+    }
+    loadScoreboard(scoreboardState.duration, 1);
 }

--- a/dojo_theme/static/js/dojo/scoreboard.js
+++ b/dojo_theme/static/js/dojo/scoreboard.js
@@ -1,25 +1,8 @@
-const CREW_MAX_PAGES = 50;
-const CREW_FETCH_CONCURRENCY = 4;
-const CREW_CACHE_TTL_MS = 5 * 60 * 1000;
-const CREW_TAG_RE = /^(.*?)\s*\[([^\[\]]{1,24})\]\s*$/;
-const CREW_STRIP_RE = /[\u0000-\u001f\u007f-\u009f\u00ad\u034f\u17b4\u17b5\u180b-\u180e\u200b-\u200f\u2028-\u202e\u2060-\u2064\u2066-\u2069\ufeff\u{e0000}-\u{e007f}]/gu;
-const CREW_KEY_STRIP_RE = /[\ufe00-\ufe0f]/g;
-
 const scoreboardState = {
     generation: 0,
     view: location.hash === "#crews" ? "crews" : "hackers",
     duration: 30,
-    crewCache: new Map(),
 };
-
-function parseCrewTag(name) {
-    const match = CREW_TAG_RE.exec(name);
-    if (!match) return null;
-    const tag = match[2].replace(CREW_STRIP_RE, "").replace(/\s+/g, " ").trim();
-    if (tag.length < 1 || tag.length > 20) return null;
-    return { tag: tag, key: tag.replace(CREW_KEY_STRIP_RE, "").normalize("NFKC").toLowerCase(), baseName: match[1].trim() };
-}
-window.parseCrewTag = parseCrewTag;
 
 function crewColors(key) {
     let hash = 5381;
@@ -32,10 +15,12 @@ function crewColors(key) {
     };
 }
 
-function fetchScoreboardPage(duration, page) {
+function fetchScoreboardPage(duration, page, crews) {
     const dojo = init.dojo;
     const module = init.module || "_";
-    const endpoint = `/pwncollege_api/v1/scoreboard/${dojo}/${module}/${duration}/${page}`;
+    const endpoint = crews
+        ? `/pwncollege_api/v1/scoreboard/${dojo}/${module}/crews/${duration}/${page}`
+        : `/pwncollege_api/v1/scoreboard/${dojo}/${module}/${duration}/${page}`;
     return CTFd.fetch(endpoint, {
         method: "GET",
         credentials: "same-origin",
@@ -47,111 +32,6 @@ function fetchScoreboardPage(duration, page) {
         if (!response.ok) throw new Error(`scoreboard page ${page} returned ${response.status}`);
         return response.json();
     });
-}
-
-async function runCrewFetch(entry, duration) {
-    if (!entry.pagesByNumber.has(1)) {
-        const first = await fetchScoreboardPage(duration, 1);
-        entry.me = first.me || null;
-        entry.pagesByNumber.set(1, first.standings);
-        entry.totalPages = first.pages && first.pages.length ? Math.max.apply(null, first.pages) : 1;
-        entry.capped = entry.totalPages > CREW_MAX_PAGES;
-    }
-    const fetchCount = Math.min(entry.totalPages, CREW_MAX_PAGES);
-    const missing = [];
-    for (let page = 2; page <= fetchCount; page++) {
-        if (!entry.pagesByNumber.has(page)) missing.push(page);
-    }
-    entry.failedPages = [];
-    let done = fetchCount - missing.length;
-    const report = () => { if (entry.onProgress) entry.onProgress(done, fetchCount); };
-    report();
-    let next = 0;
-    const worker = async () => {
-        while (next < missing.length) {
-            const page = missing[next++];
-            try {
-                let result;
-                try {
-                    result = await fetchScoreboardPage(duration, page);
-                } catch (error) {
-                    result = await fetchScoreboardPage(duration, page);
-                }
-                entry.pagesByNumber.set(page, result.standings);
-            } catch (error) {
-                entry.failedPages.push(page);
-            }
-            done++;
-            report();
-        }
-    };
-    await Promise.all(Array.from({ length: CREW_FETCH_CONCURRENCY }, worker));
-    return entry;
-}
-
-function fetchAllStandings(duration, gen) {
-    const key = `${init.dojo}|${init.module || "_"}|${duration}`;
-    let entry = scoreboardState.crewCache.get(key);
-    if (!entry || Date.now() - entry.fetchedAt >= CREW_CACHE_TTL_MS) {
-        entry = {
-            fetchedAt: Date.now(),
-            pagesByNumber: new Map(),
-            totalPages: 1,
-            capped: false,
-            failedPages: [],
-            me: null,
-            promise: null,
-            running: false,
-            onProgress: null,
-        };
-        scoreboardState.crewCache.set(key, entry);
-    }
-    entry.onProgress = (done, total) => {
-        if (gen === scoreboardState.generation) updateCrewProgress(done, total);
-    };
-    if (!entry.promise || (!entry.running && entry.failedPages.length)) {
-        entry.running = true;
-        entry.promise = runCrewFetch(entry, duration)
-            .catch(error => {
-                scoreboardState.crewCache.delete(key);
-                throw error;
-            })
-            .finally(() => { entry.running = false; });
-    }
-    return entry.promise;
-}
-
-function dedupStandings(entry) {
-    const byUser = new Map();
-    const pages = Array.from(entry.pagesByNumber.keys()).sort((a, b) => a - b);
-    pages.forEach(page => {
-        entry.pagesByNumber.get(page).forEach(user => {
-            if (!byUser.has(user.user_id)) byUser.set(user.user_id, user);
-        });
-    });
-    return Array.from(byUser.values()).sort((a, b) => a.rank - b.rank);
-}
-
-function aggregateCrews(standings) {
-    const crews = new Map();
-    standings.forEach(user => {
-        const parsed = parseCrewTag(user.name);
-        if (!parsed) return;
-        if (!crews.has(parsed.key)) {
-            crews.set(parsed.key, { key: parsed.key, tag: parsed.tag, score: 0, bestRank: user.rank, members: [] });
-        }
-        const crew = crews.get(parsed.key);
-        crew.score += user.solves;
-        crew.members.push(user);
-    });
-    const ranked = Array.from(crews.values()).sort((a, b) =>
-        b.score - a.score
-        || a.members.length - b.members.length
-        || a.bestRank - b.bestRank
-        || a.key.localeCompare(b.key)
-    );
-    ranked.forEach((crew, i) => { crew.rank = i + 1; });
-    return ranked;
 }
 
 function buildCrewTagChip(tag, key) {
@@ -187,13 +67,12 @@ function buildHackerRow(user, me, crew) {
     row.find(".scoreboard-belt").attr("src", user.belt);
     row.find(".scoreboard-score").text(user.solves);
     const name = row.find(".scoreboard-name").attr("href", user.url).attr("title", user.name);
-    const parsed = parseCrewTag(user.name);
     if (crew) {
         row.addClass("crew-member-row").css("border-left-color", crewColors(crew.key).text);
-        name.text(((parsed && parsed.baseName) || user.name).slice(0, 50));
-    } else if (parsed) {
-        name.text(parsed.baseName.slice(0, 50));
-        name.append(buildCrewTagChip(parsed.tag, parsed.key));
+        name.text(((user.crew && user.crew.base_name) || user.name).slice(0, 50));
+    } else if (user.crew) {
+        name.text(user.crew.base_name.slice(0, 50));
+        name.append(buildCrewTagChip(user.crew.tag, user.crew.key));
     } else {
         name.text(user.name.slice(0, 50));
     }
@@ -211,7 +90,7 @@ function buildHackerRow(user, me, crew) {
     return row;
 }
 
-function buildCrewRow(crew, me, myCrewKey) {
+function buildCrewRow(crew, myCrewKey) {
     const colors = crewColors(crew.key);
     const row = $(`
     <tr class="crew-row" role="button" tabindex="0" aria-expanded="false">
@@ -256,6 +135,7 @@ function buildCrewRow(crew, me, myCrewKey) {
     let memberRows = null;
     let expanded = false;
     const attachMembers = () => {
+        const me = init.userId ? { user_id: Number(init.userId) } : null;
         const rows = crew.members.map(user => buildHackerRow(user, me, crew));
         const head = rows.slice(0, 10);
         const rest = rows.slice(10);
@@ -334,20 +214,18 @@ function renderNoteRow(text) {
     return row;
 }
 
-function renderCrewLoading() {
-    $("#scoreboard").empty().append($(`
-      <tr class="crew-loading"><td colspan="6">
-        <div class="crew-loading-text brand-mono" aria-live="polite">Assembling crews…</div>
-        <div class="crew-progress-track"><div class="crew-progress-fill"></div></div>
-      </td></tr>
-    `));
+function renderLoadingRow() {
+    $("#scoreboard").empty().append($(`<tr class="scoreboard-loading"><td colspan="6">Loading...</td></tr>`));
     $("#scoreboard-pages").empty();
 }
 
-function updateCrewProgress(done, total) {
-    if (total < 1) total = 1;
-    $("#scoreboard .crew-loading-text").text(`Assembling crews… page ${done} / ${total}`);
-    $("#scoreboard .crew-progress-fill").css("width", `${Math.round(done / total * 100)}%`);
+function renderErrorRow(duration, page, message) {
+    $("#scoreboard").empty();
+    const warning = renderNoteRow(`${message} `);
+    warning.find(".crew-note").addClass("crew-note-warn");
+    const retry = $(`<a role="button" tabindex="0" href="javascript:void(0)">Retry</a>`);
+    retry.on("click", () => loadScoreboard(duration, page));
+    warning.find(".crew-note").append(retry);
 }
 
 function renderCrewEmptyState() {
@@ -362,86 +240,44 @@ function renderCrewEmptyState() {
     $("#scoreboard").append(row);
 }
 
-function renderCrewNotes(entry, duration, page) {
-    if (entry.capped) {
-        renderNoteRow(`Crew standings computed from the top ${(CREW_MAX_PAGES * 20).toLocaleString()} hackers on this board.`);
-    }
-    if (entry.failedPages.length) {
-        const warning = renderNoteRow("Some pages failed to load — standings may be incomplete. ");
-        warning.find(".crew-note").addClass("crew-note-warn");
-        const retry = $(`<a role="button" tabindex="0" href="javascript:void(0)">Retry</a>`);
-        retry.on("click", () => loadScoreboard(duration, page));
-        warning.find(".crew-note").append(retry);
-    }
-}
-
-function renderCrewBoard(entry, duration, page) {
-    const scoreboard = $("#scoreboard");
-    scoreboard.empty();
-    const standings = dedupStandings(entry);
-    const crews = aggregateCrews(standings);
-    const me = entry.me;
-    const myParsed = me ? parseCrewTag(me.name) : null;
-    const myCrewKey = myParsed ? myParsed.key : null;
-
-    if (!standings.length) {
-        renderNoteRow("No solves yet — no crews to show.");
-        renderCrewNotes(entry, duration, page);
-        renderPagination(duration, 1, []);
-        return;
-    }
-    if (!crews.length) {
-        renderCrewEmptyState();
-        renderCrewNotes(entry, duration, page);
-        renderPagination(duration, 1, []);
-        return;
-    }
-
-    const perPage = 20;
-    const pageCount = Math.ceil(crews.length / perPage);
-    if (page < 1 || page > pageCount) page = 1;
-    const pageCrews = crews.slice((page - 1) * perPage, page * perPage);
-    const display = pageCrews.slice();
-    if (myCrewKey) {
-        const myCrew = crews.find(crew => crew.key === myCrewKey);
-        if (myCrew && pageCrews.indexOf(myCrew) === -1) {
-            if (myCrew.rank < pageCrews[0].rank) display.unshift(myCrew);
-            else display.push(myCrew);
-        }
-    }
-    display.forEach((crew, i) => {
-        const row = buildCrewRow(crew, me, myCrewKey);
-        if (i % 2 === 0) row.addClass("crew-row-stripe");
-        scoreboard.append(row);
-    });
-    renderCrewNotes(entry, duration, page);
-    const pages = [];
-    for (let i = 1; i <= pageCount; i++) pages.push(i);
-    renderPagination(duration, page, pages);
-}
-
 function renderCrewView(duration, page, gen) {
-    renderCrewLoading();
-    fetchAllStandings(duration, gen).then(entry => {
+    renderLoadingRow();
+    fetchScoreboardPage(duration, page, true).then(result => {
         if (gen !== scoreboardState.generation) return;
-        renderCrewBoard(entry, duration, page);
+        const scoreboard = $("#scoreboard");
+        scoreboard.empty();
+        const crews = result.standings.slice();
+        const myCrew = result.me_crew || null;
+        const myCrewKey = myCrew ? myCrew.key : null;
+
+        if (!crews.length) {
+            if (result.board_empty) renderNoteRow("No solves yet — no crews to show.");
+            else renderCrewEmptyState();
+            renderPagination(duration, 1, []);
+            return;
+        }
+
+        if (myCrew && !crews.some(crew => crew.key === myCrew.key)) {
+            if (myCrew.rank < crews[0].rank) crews.splice(0, 0, myCrew);
+            else crews.push(myCrew);
+        }
+        crews.forEach((crew, i) => {
+            const row = buildCrewRow(crew, myCrewKey);
+            if (i % 2 === 0) row.addClass("crew-row-stripe");
+            scoreboard.append(row);
+        });
+        renderPagination(duration, page, result.pages);
     }).catch(() => {
         if (gen !== scoreboardState.generation) return;
-        $("#scoreboard").empty();
-        const warning = renderNoteRow("Failed to load the crew scoreboard. ");
-        warning.find(".crew-note").addClass("crew-note-warn");
-        const retry = $(`<a role="button" tabindex="0" href="javascript:void(0)">Retry</a>`);
-        retry.on("click", () => loadScoreboard(duration, page));
-        warning.find(".crew-note").append(retry);
+        renderErrorRow(duration, page, "Failed to load the crew scoreboard.");
     });
 }
 
 function renderHackerView(duration, page, gen) {
-    const scoreboard = $("#scoreboard");
-    scoreboard.empty().append($(`<tr class="scoreboard-loading"><td colspan="6">Loading...</td></tr>`));
-    $("#scoreboard-pages").empty();
-    fetchScoreboardPage(duration, page).then(result => {
+    renderLoadingRow();
+    fetchScoreboardPage(duration, page, false).then(result => {
         if (gen !== scoreboardState.generation) return;
+        const scoreboard = $("#scoreboard");
         scoreboard.empty();
         const standings = result.standings.slice();
         if (result.me && standings.length) {
@@ -459,12 +295,7 @@ function renderHackerView(duration, page, gen) {
         renderPagination(duration, page, result.pages);
     }).catch(() => {
         if (gen !== scoreboardState.generation) return;
-        scoreboard.empty();
-        const warning = renderNoteRow("Failed to load the scoreboard. ");
-        warning.find(".crew-note").addClass("crew-note-warn");
-        const retry = $(`<a role="button" tabindex="0" href="javascript:void(0)">Retry</a>`);
-        retry.on("click", () => loadScoreboard(duration, page));
-        warning.find(".crew-note").append(retry);
+        renderErrorRow(duration, page, "Failed to load the scoreboard.");
     });
 }
 

--- a/dojo_theme/static/js/dojo/scoreboard.js
+++ b/dojo_theme/static/js/dojo/scoreboard.js
@@ -1,6 +1,7 @@
 const scoreboardState = {
     generation: 0,
-    view: location.hash === "#crews" ? "crews" : "hackers",
+    view: location.hash === "#crews" || location.hash === "#crews-unique" ? "crews" : "hackers",
+    crewMode: location.hash === "#crews-unique" ? "unique" : "cumulative",
     duration: 30,
 };
 
@@ -19,7 +20,7 @@ function fetchScoreboardPage(duration, page, crews) {
     const dojo = init.dojo;
     const module = init.module || "_";
     const endpoint = crews
-        ? `/pwncollege_api/v1/scoreboard/${dojo}/${module}/crews/${duration}/${page}`
+        ? `/pwncollege_api/v1/scoreboard/${dojo}/${module}/crews/${duration}/${page}?mode=${scoreboardState.crewMode}`
         : `/pwncollege_api/v1/scoreboard/${dojo}/${module}/${duration}/${page}`;
     return CTFd.fetch(endpoint, {
         method: "GET",
@@ -129,7 +130,11 @@ function buildCrewRow(crew, myCrewKey) {
     facepile.attr("title", crew.members.length > 5 ? `${names}, …` : names);
     const top = crew.members[0];
     row.find(".scoreboard-belt").attr("src", top.belt).attr("title", `Top member: ${top.name}`);
-    row.find(".crew-score").text(crew.score.toLocaleString()).attr("title", `Sum of ${crew.members.length} members' scores`);
+    const unique = crew.unique === null || crew.unique === undefined ? "—" : crew.unique.toLocaleString();
+    const scoreCell = row.find(".crew-score");
+    if (scoreboardState.crewMode === "unique") scoreCell.text(unique);
+    else scoreCell.text(crew.score.toLocaleString());
+    scoreCell.attr("title", `Cumulative: ${crew.score.toLocaleString()} · Unique challenges: ${unique}`);
     if (myCrewKey && crew.key === myCrewKey) row.addClass("scoreboard-row-me");
 
     let memberRows = null;
@@ -186,11 +191,16 @@ function setScoreboardControls(view, duration) {
     const controls = { 7: "#scoreboard-control-week", 30: "#scoreboard-control-month", 0: "#scoreboard-control-all" };
     if (controls[duration]) $(controls[duration]).addClass("scoreboard-page-selected");
     const crews = view === "crews";
+    const unique = scoreboardState.crewMode === "unique";
     $("#scoreboard-heading").text(`${labels[duration] || ""}${crews ? " Crew" : ""} Scoreboard:`);
     $("#scoreboard-th-name").text(crews ? "Crew" : "Hacker");
     $("#scoreboard-th-badges").text(crews ? "Members" : "Badges");
+    $("#scoreboard-th-score").text(crews && unique ? "Unique" : "Score");
     $("#scoreboard-view-hackers").toggleClass("scoreboard-view-selected", !crews).attr("aria-selected", String(!crews));
     $("#scoreboard-view-crews").toggleClass("scoreboard-view-selected", crews).attr("aria-selected", String(crews));
+    $("#scoreboard-crew-mode-toggle").prop("hidden", !crews);
+    $("#scoreboard-crew-mode-cumulative").toggleClass("scoreboard-view-selected", !unique).attr("aria-selected", String(!unique));
+    $("#scoreboard-crew-mode-unique").toggleClass("scoreboard-view-selected", unique).attr("aria-selected", String(unique));
     $(".scoreboard").toggleClass("scoreboard-crew-mode", crews);
 }
 
@@ -309,11 +319,21 @@ function loadScoreboard(duration, page) {
     else renderHackerView(duration, page, gen);
 }
 
+function scoreboardHash() {
+    if (scoreboardState.view !== "crews") return location.pathname + location.search;
+    return scoreboardState.crewMode === "unique" ? "#crews-unique" : "#crews";
+}
+
 function setScoreboardView(view) {
     if (scoreboardState.view === view) return;
     scoreboardState.view = view;
-    if (history.replaceState) {
-        history.replaceState(null, "", view === "crews" ? "#crews" : location.pathname + location.search);
-    }
+    if (history.replaceState) history.replaceState(null, "", scoreboardHash());
+    loadScoreboard(scoreboardState.duration, 1);
+}
+
+function setCrewMode(mode) {
+    if (scoreboardState.crewMode === mode) return;
+    scoreboardState.crewMode = mode;
+    if (history.replaceState) history.replaceState(null, "", scoreboardHash());
     loadScoreboard(scoreboardState.duration, 1);
 }

--- a/dojo_theme/templates/macros/scoreboard.html
+++ b/dojo_theme/templates/macros/scoreboard.html
@@ -5,6 +5,10 @@
   <span id="scoreboard-control-month"><a href="javascript:loadScoreboard(30, 1)">30-Day</a></span> |
   <span id="scoreboard-control-all"><a href="javascript:loadScoreboard(0, 1)">All-Time</a></span>
   </p>
+  <div class="scoreboard-view-toggle brand-mono" role="tablist" aria-label="Scoreboard view">
+    <a id="scoreboard-view-hackers" role="tab" aria-selected="true" href="javascript:setScoreboardView('hackers')">Hackers</a>
+    <a id="scoreboard-view-crews" role="tab" aria-selected="false" href="javascript:setScoreboardView('crews')">Crews</a>
+  </div>
 </div>
 <div class="scoreboard row">
   <div class="col-md-12 p-0">
@@ -13,8 +17,8 @@
 	      <tr>
 	        <td scope="col" class="col-md-1"><b>Rank</b></td>
           <td scope="col" class="col-md-1"></td>
-	        <td scope="col" class="col-md-4"><b>Hacker</b></td>
-	        <td scope="col" class="col-md-4"><b>Badges</b></td>
+	        <td scope="col" class="col-md-4"><b id="scoreboard-th-name">Hacker</b></td>
+	        <td scope="col" class="col-md-4"><b id="scoreboard-th-badges">Badges</b></td>
 	        <td scope="col" class="col-md-1"></td>
 	        <td scope="col" class="col-md-1"><b>Score</b></td>
 	      </tr>

--- a/dojo_theme/templates/macros/scoreboard.html
+++ b/dojo_theme/templates/macros/scoreboard.html
@@ -5,9 +5,15 @@
   <span id="scoreboard-control-month"><a href="javascript:loadScoreboard(30, 1)">30-Day</a></span> |
   <span id="scoreboard-control-all"><a href="javascript:loadScoreboard(0, 1)">All-Time</a></span>
   </p>
-  <div class="scoreboard-view-toggle brand-mono" role="tablist" aria-label="Scoreboard view">
-    <a id="scoreboard-view-hackers" role="tab" aria-selected="true" href="javascript:setScoreboardView('hackers')">Hackers</a>
-    <a id="scoreboard-view-crews" role="tab" aria-selected="false" href="javascript:setScoreboardView('crews')">Crews</a>
+  <div class="scoreboard-view-controls">
+    <div id="scoreboard-crew-mode-toggle" class="scoreboard-view-toggle brand-mono" role="tablist" aria-label="Crew scoring" hidden>
+      <a id="scoreboard-crew-mode-cumulative" role="tab" aria-selected="true" href="javascript:setCrewMode('cumulative')">Cumulative</a>
+      <a id="scoreboard-crew-mode-unique" role="tab" aria-selected="false" href="javascript:setCrewMode('unique')">Unique</a>
+    </div>
+    <div class="scoreboard-view-toggle brand-mono" role="tablist" aria-label="Scoreboard view">
+      <a id="scoreboard-view-hackers" role="tab" aria-selected="true" href="javascript:setScoreboardView('hackers')">Hackers</a>
+      <a id="scoreboard-view-crews" role="tab" aria-selected="false" href="javascript:setScoreboardView('crews')">Crews</a>
+    </div>
   </div>
 </div>
 <div class="scoreboard row">
@@ -20,7 +26,7 @@
 	        <td scope="col" class="col-md-4"><b id="scoreboard-th-name">Hacker</b></td>
 	        <td scope="col" class="col-md-4"><b id="scoreboard-th-badges">Badges</b></td>
 	        <td scope="col" class="col-md-1"></td>
-	        <td scope="col" class="col-md-1"><b>Score</b></td>
+	        <td scope="col" class="col-md-1"><b id="scoreboard-th-score">Score</b></td>
 	      </tr>
 	    </thead>
 	    <tbody id="scoreboard">

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -5,12 +5,22 @@ RUN apt-get update && apt-get install -y \
     git \
     wget \
     jq \
-    firefox \
     ca-certificates \
     python3 \
     python3-pip \
     gnupg \
+    xz-utils \
+    libgtk-3-0 \
+    libasound2t64 \
+    libx11-xcb1 \
     && rm -rf /var/lib/apt/lists/*
+
+# Ubuntu 24.04's apt "firefox" is a snap shim that cannot run in a container;
+# install a real Firefox so Selenium Manager never downloads one at runtime.
+RUN wget -q -O /tmp/firefox.tar.xz "https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux64&lang=en-US" \
+    && tar -xJf /tmp/firefox.tar.xz -C /opt \
+    && rm /tmp/firefox.tar.xz \
+    && ln -s /opt/firefox/firefox /usr/local/bin/firefox
 
 RUN install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,5 @@
 import random
+import shutil
 import string
 import pytest
 import json
@@ -6,6 +7,7 @@ import json
 import requests
 import requests.adapters
 from urllib3.util.retry import Retry
+from selenium.webdriver.firefox.service import Service as FirefoxService
 
 #pylint:disable=redefined-outer-name,use-dict-literal,missing-timeout,unspecified-encoding,consider-using-with
 
@@ -239,7 +241,9 @@ def random_private_dojo(admin_session):
 def browser_fixture():
     options = FirefoxOptions()
     options.add_argument("--headless")
-    return Firefox(options=options)
+    geckodriver = shutil.which("geckodriver")
+    service = FirefoxService(executable_path=geckodriver) if geckodriver else None
+    return Firefox(options=options, service=service)
 
 @pytest.fixture
 def random_user_browser(browser_fixture, random_user_name):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,10 +3,28 @@ import string
 import pytest
 import json
 
+import requests
+import requests.adapters
+from urllib3.util.retry import Retry
+
 #pylint:disable=redefined-outer-name,use-dict-literal,missing-timeout,unspecified-encoding,consider-using-with
 
 from utils import TEST_DOJOS_LOCATION, DOJO_URL, login, make_dojo_official, create_dojo, create_dojo_yml, start_challenge, solve_challenge, wait_for_background_worker, db_sql
 from selenium.webdriver import Firefox, FirefoxOptions
+
+# Nested-docker port publishing drops for a few seconds while user containers
+# attach/detach networks; retry connection establishment (never sent requests)
+# so local test runs survive the window.
+_original_session_init = requests.Session.__init__
+
+def _retrying_session_init(self, *args, **kwargs):
+    _original_session_init(self, *args, **kwargs)
+    retry = Retry(total=None, connect=6, read=0, redirect=0, status=0, other=0, backoff_factor=0.5)
+    adapter = requests.adapters.HTTPAdapter(max_retries=retry)
+    self.mount("http://", adapter)
+    self.mount("https://", adapter)
+
+requests.Session.__init__ = _retrying_session_init
 
 @pytest.fixture(scope="session")
 def admin_session():

--- a/test/test_crew_scoreboard.py
+++ b/test/test_crew_scoreboard.py
@@ -139,6 +139,13 @@ def test_crew_scoreboard_happy_path(browser_fixture, crew_dojo):
     chip_tags = browser.execute_script("return $('#scoreboard .scoreboard-name .crew-tag-text').map((i, e) => e.textContent).get()")
     assert chip_tags.count(tag) == 2
 
+    browser.get(f"{DOJO_URL}/login")
+    browser.get(f"{DOJO_URL}/dojo/{crew_dojo}#crews-unique")
+    wait_until(lambda: browser.execute_script("return $('#scoreboard .crew-row').length > 0"))
+    assert browser.execute_script("return $('#scoreboard-th-score').text()") == "Unique"
+    assert browser.execute_script("return $('#scoreboard-crew-mode-unique').hasClass('scoreboard-view-selected')")
+    assert browser.execute_script("return $('#scoreboard-view-crews').hasClass('scoreboard-view-selected')")
+
 
 @pytest.mark.timeout(180)
 def test_crew_tag_xss_safe(browser_fixture, crew_dojo):
@@ -311,6 +318,54 @@ def test_crew_scoreboard_api(crew_dojo):
     module_crew = next(c for c in module_board["standings"] if c["key"] == tag.lower())
     assert module_crew["score"] == 3
     assert module_crew["unique"] == 2
+
+    solo_tag = "".join(random.choices(string.ascii_uppercase, k=8))
+    name_s, _, session_s = register_user(tag=solo_tag)
+    join_dojo(session_s, crew_dojo)
+    solve(crew_dojo, name_s, session_s, "apple")
+    solve(crew_dojo, name_s, session_s, "banana")
+    remove_workspace_container(name_s)
+    wait_for_background_worker(timeout=30)
+
+    def crew_order(mode):
+        board = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/_/crews/0/1?mode={mode}").json()
+        assert [c["rank"] for c in board["standings"]] == list(range(1, len(board["standings"]) + 1))
+        return [c["key"] for c in board["standings"]]
+
+    cumulative_order = crew_order("cumulative")
+    unique_order = crew_order("unique")
+    assert cumulative_order.index(tag.lower()) < cumulative_order.index(solo_tag.lower())
+    assert unique_order.index(solo_tag.lower()) < unique_order.index(tag.lower())
+
+    flask_exec(f"""
+from CTFd.plugins.dojo_plugin.models import Dojos
+from CTFd.plugins.dojo_plugin.worker.handlers.scoreboard import handle_scoreboard_update
+dojo = Dojos.from_id({crew_dojo!r}).first()
+handle_scoreboard_update({{"model_type": "dojo", "model_id": dojo.dojo_id}})
+print("RECALC-DONE", dojo.dojo_id)
+""")
+    recalc_board = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/_/crews/0/1").json()
+    recalc_crew = next(c for c in recalc_board["standings"] if c["key"] == tag.lower())
+    assert recalc_crew["score"] == 3
+    assert recalc_crew["unique"] == 2
+    recalc_solo = next(c for c in recalc_board["standings"] if c["key"] == solo_tag.lower())
+    assert recalc_solo["score"] == 2
+    assert recalc_solo["unique"] == 2
+
+    dojo_id = flask_exec(f"""
+from CTFd.plugins.dojo_plugin.models import Dojos
+print("DOJO-ID", Dojos.from_id({crew_dojo!r}).first().dojo_id)
+""")
+    dojo_id = re.search(r"DOJO-ID (-?\d+)", dojo_id).group(1)
+    dojo_run("docker", "exec", "cache", "redis-cli", "DEL", f"stats:crews:dojo:{dojo_id}:0")
+    fallback_board = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/_/crews/0/1").json()
+    fallback_crew = next(c for c in fallback_board["standings"] if c["key"] == tag.lower())
+    assert fallback_crew["score"] == 3
+    assert fallback_crew["unique"] is None
+    dojo_run("docker", "exec", "cache", "redis-cli", "DEL", f"stats:crews:dojo:{dojo_id}:0")
+    fallback_unique = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/_/crews/0/1?mode=unique")
+    assert fallback_unique.status_code == 200
+    assert fallback_unique.json()["mode"] == "unique"
 
     hacker_board = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/_/0/1").json()
     tagged = next(entry for entry in hacker_board["standings"] if entry["name"] == name_a)

--- a/test/test_crew_scoreboard.py
+++ b/test/test_crew_scoreboard.py
@@ -121,8 +121,19 @@ def test_crew_scoreboard_happy_path(browser_fixture, crew_dojo):
     assert member_titles == [name_a, name_b]
     assert name_c not in browser.execute_script("return $('#scoreboard').text()")
 
+    browser.execute_script("setCrewMode('unique')")
+    wait_until(lambda: browser.execute_script("return $('#scoreboard-th-score').text() === 'Unique' && $('#scoreboard .crew-row').length > 0"))
+    unique_crew_row = wait_until(lambda: next(
+        (row for row in browser.find_elements("css selector", ".crew-row")
+         if row.find_element("css selector", ".crew-tag-text").text == tag), None))
+    assert unique_crew_row.find_element("css selector", ".crew-score").text == "2"
+    assert browser.execute_script("return location.hash") == "#crews-unique"
+    browser.execute_script("setCrewMode('cumulative')")
+    wait_until(lambda: browser.execute_script("return $('#scoreboard-th-score').text() === 'Score' && $('#scoreboard .crew-row').length > 0"))
+
     browser.execute_script("setScoreboardView('hackers')")
     wait_until(lambda: browser.execute_script("return $('#scoreboard .crew-row').length === 0 && $('#scoreboard .scoreboard-name').length > 0"))
+    assert browser.execute_script("return $('#scoreboard-crew-mode-toggle').prop('hidden')")
     hacker_names = browser.execute_script("return $('#scoreboard .scoreboard-name').map((i, e) => e.getAttribute('title')).get()")
     assert name_c in hacker_names
     chip_tags = browser.execute_script("return $('#scoreboard .scoreboard-name .crew-tag-text').map((i, e) => e.textContent).get()")
@@ -202,6 +213,28 @@ standings = [
 ]
 crews = aggregate_crews(standings)
 assert [(c["tag"], c["score"], len(c["members"]), c["rank"]) for c in crews] == [("X", 9, 2, 1), ("Y", 3, 1, 2), ("__proto__", 2, 1, 3)]
+assert all(c["unique"] is None and c["unique_rank"] is None for c in crews)
+
+challenge_map = {1: {10, 11, 12, 13, 14}, 2: {10, 11, 12, 13}, 3: {10, 11, 12}, 4: {20, 21}}
+crews = aggregate_crews(standings, challenge_map)
+x = next(c for c in crews if c["key"] == "x")
+y = next(c for c in crews if c["key"] == "y")
+proto = next(c for c in crews if c["key"] == "__proto__")
+assert (x["score"], x["unique"], x["rank"]) == (9, 5, 1)
+assert (y["score"], y["unique"], y["rank"]) == (3, 3, 2)
+assert x["unique_rank"] == 1 and y["unique_rank"] == 2 and proto["unique_rank"] == 3
+assert x["members"][0]["challenges"] == [10, 11, 12, 13, 14]
+
+overlap = aggregate_crews([
+    {"user_id": 1, "name": "a [Dup]", "solves": 3, "rank": 1},
+    {"user_id": 2, "name": "b [Dup]", "solves": 3, "rank": 2},
+    {"user_id": 3, "name": "c [Wide]", "solves": 4, "rank": 3},
+], {1: {1, 2, 3}, 2: {1, 2, 3}, 3: {1, 2, 3, 4}})
+dup = next(c for c in overlap if c["key"] == "dup")
+wide = next(c for c in overlap if c["key"] == "wide")
+assert (dup["score"], dup["unique"], dup["rank"]) == (6, 3, 1)
+assert (wide["score"], wide["unique"], wide["rank"]) == (4, 4, 2)
+assert wide["unique_rank"] == 1 and dup["unique_rank"] == 2
 
 tie = aggregate_crews([
     {"user_id": 1, "name": "a [Big]", "solves": 3, "rank": 1},
@@ -242,23 +275,42 @@ def test_crew_scoreboard_api(crew_dojo):
     result = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/_/crews/0/1")
     assert result.status_code == 200
     board = result.json()
+    assert board["mode"] == "cumulative"
 
     crew = next(c for c in board["standings"] if c["key"] == tag.lower())
     assert crew["score"] == 2
+    assert crew["unique"] == 2
     assert len(crew["members"]) == 2
     member_names = [member["name"] for member in crew["members"]]
     assert name_a in member_names and name_b in member_names
     for member in crew["members"]:
         assert "email" not in member
+        assert "challenges" not in member
         assert member["crew"]["key"] == tag.lower()
     assert all(name_c != member["name"] for c in board["standings"] for member in c["members"])
 
     assert "me_crew" in board
     assert board["me_crew"]["key"] == tag.lower()
 
+    unique_board = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/_/crews/0/1?mode=unique").json()
+    assert unique_board["mode"] == "unique"
+    unique_crew = next(c for c in unique_board["standings"] if c["key"] == tag.lower())
+    assert unique_crew["unique"] == 2
+    unique_ranks = [c["rank"] for c in unique_board["standings"]]
+    assert unique_ranks == sorted(unique_ranks)
+
+    solve(crew_dojo, name_b, session_b, "apple")
+    remove_workspace_container(name_b)
+    wait_for_background_worker(timeout=30)
+    overlap_board = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/_/crews/0/1").json()
+    overlap_crew = next(c for c in overlap_board["standings"] if c["key"] == tag.lower())
+    assert overlap_crew["score"] == 3
+    assert overlap_crew["unique"] == 2
+
     module_board = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/hello/crews/0/1").json()
     module_crew = next(c for c in module_board["standings"] if c["key"] == tag.lower())
-    assert module_crew["score"] == 2
+    assert module_crew["score"] == 3
+    assert module_crew["unique"] == 2
 
     hacker_board = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/_/0/1").json()
     tagged = next(entry for entry in hacker_board["standings"] if entry["name"] == name_a)

--- a/test/test_crew_scoreboard.py
+++ b/test/test_crew_scoreboard.py
@@ -5,7 +5,7 @@ import time
 
 import pytest
 
-from utils import DOJO_URL, login, create_dojo_yml, start_challenge, solve_challenge, workspace_run, wait_for_background_worker, remove_workspace_container
+from utils import DOJO_URL, dojo_run, login, create_dojo_yml, start_challenge, solve_challenge, workspace_run, wait_for_background_worker, remove_workspace_container
 
 
 CREW_DOJO_SPEC = """
@@ -77,7 +77,7 @@ def open_crew_view(browser, dojo):
     browser.get(f"{DOJO_URL}/dojo/{dojo}")
     wait_until(lambda: browser.execute_script("return typeof setScoreboardView === 'function' && $('#scoreboard tr').length > 0"))
     browser.execute_script("setScoreboardView('crews')")
-    wait_until(lambda: browser.execute_script("return $('#scoreboard .crew-loading').length === 0"))
+    wait_until(lambda: browser.execute_script("return $('#scoreboard .scoreboard-loading').length === 0 && $('#scoreboard tr').length > 0"))
 
 
 @pytest.mark.timeout(300)
@@ -161,77 +161,112 @@ def test_crew_tag_xss_safe(browser_fixture, crew_dojo):
     assert browser.execute_script("return $('#scoreboard .crew-member-row img:not(.scoreboard-symbol):not(.scoreboard-belt)').length") == 0
 
 
-def test_crew_parse_tag(browser_fixture, example_dojo):
-    browser = browser_fixture
-    browser.get(f"{DOJO_URL}/dojo/{example_dojo}")
-    wait_until(lambda: browser.execute_script("return typeof window.parseCrewTag === 'function'"))
-
-    def parse(name):
-        return browser.execute_script("return window.parseCrewTag(arguments[0])", name)
-
-    assert parse("Zardus [Shellphish]") == {"tag": "Shellphish", "key": "shellphish", "baseName": "Zardus"}
-    assert parse("[Shellphish]") == {"tag": "Shellphish", "key": "shellphish", "baseName": ""}
-    assert parse("[abc] Zardus") is None
-    assert parse("A [x] [y]") == {"tag": "y", "key": "y", "baseName": "A [x]"}
-    assert parse("A [[x]]") is None
-    assert parse("A []") is None
-    assert parse("A [ ]") is None
-    assert parse("A [\u200b]") is None
-    assert parse("plain") is None
-    assert parse("[") is None
-    assert parse("]") is None
-    assert parse("A [" + "x" * 25 + "]") is None
-    assert parse("A [" + "x" * 21 + "]") is None
-    assert parse("x [a\u200bb]")["key"] == parse("x [ab]")["key"]
-    assert parse("x [Shell  phish]")["key"] == parse("x [Shell phish]")["key"]
-    assert parse("x [SHELLPHISH]")["key"] == parse("x [shellphish]")["key"]
-    assert parse("x [Shell\u00adphish]")["key"] == parse("x [Shellphish]")["key"]
-    assert parse("x [ｓｈｅｌｌｐｈｉｓｈ]")["key"] == "shellphish"
-    assert parse("x [Shellphish\ufe0f]")["key"] == "shellphish"
-    assert parse("x [💀🔥]") == {"tag": "💀🔥", "key": "💀🔥", "baseName": "x"}
-    assert parse("x [  padded  ]") == {"tag": "padded", "key": "padded", "baseName": "x"}
+def flask_exec(code):
+    import base64
+    encoded = base64.b64encode(code.encode()).decode()
+    result = dojo_run("dojo", "flask", input=f'import base64; exec(base64.b64decode("{encoded}").decode())\n')
+    return result.stdout
 
 
-def test_crew_aggregation_logic(browser_fixture, example_dojo):
-    browser = browser_fixture
-    browser.get(f"{DOJO_URL}/dojo/{example_dojo}")
-    wait_until(lambda: browser.execute_script("return typeof window.parseCrewTag === 'function'"))
+CREW_PARSE_UNIT = r"""
+from CTFd.plugins.dojo_plugin.utils.crews import parse_crew_tag, aggregate_crews
 
-    result = browser.execute_script("""
-        const pages = new Map();
-        pages.set(1, [
-            {user_id: 1, name: "a [X]", solves: 5, rank: 1},
-            {user_id: 2, name: "b [X]", solves: 4, rank: 2},
-        ]);
-        pages.set(2, [
-            {user_id: 2, name: "b [X]", solves: 4, rank: 2},
-            {user_id: 3, name: "c [Y]", solves: 3, rank: 3},
-            {user_id: 4, name: "d [__proto__]", solves: 2, rank: 4},
-            {user_id: 5, name: "e", solves: 1, rank: 5},
-        ]);
-        const standings = dedupStandings({pagesByNumber: pages});
-        const crews = aggregateCrews(standings);
-        return {
-            standings: standings.length,
-            crews: crews.map(crew => ({tag: crew.tag, score: crew.score, members: crew.members.length, rank: crew.rank})),
-        };
-    """)
-    assert result["standings"] == 5
-    assert result["crews"] == [
-        {"tag": "X", "score": 9, "members": 2, "rank": 1},
-        {"tag": "Y", "score": 3, "members": 1, "rank": 2},
-        {"tag": "__proto__", "score": 2, "members": 1, "rank": 3},
-    ]
+assert parse_crew_tag("Zardus [Shellphish]") == {"tag": "Shellphish", "key": "shellphish", "base_name": "Zardus"}
+assert parse_crew_tag("[Shellphish]") == {"tag": "Shellphish", "key": "shellphish", "base_name": ""}
+assert parse_crew_tag("[abc] Zardus") is None
+assert parse_crew_tag("A [x] [y]") == {"tag": "y", "key": "y", "base_name": "A [x]"}
+assert parse_crew_tag("A [[x]]") is None
+assert parse_crew_tag("A []") is None
+assert parse_crew_tag("A [ ]") is None
+assert parse_crew_tag("A [\u200b]") is None
+assert parse_crew_tag("plain") is None
+assert parse_crew_tag("[") is None
+assert parse_crew_tag("]") is None
+assert parse_crew_tag("A [" + "x" * 25 + "]") is None
+assert parse_crew_tag("A [" + "x" * 21 + "]") is None
+assert parse_crew_tag("x [a\u200bb]")["key"] == parse_crew_tag("x [ab]")["key"]
+assert parse_crew_tag("x [Shell  phish]")["key"] == parse_crew_tag("x [Shell phish]")["key"]
+assert parse_crew_tag("x [SHELLPHISH]")["key"] == parse_crew_tag("x [shellphish]")["key"]
+assert parse_crew_tag("x [Shell\u00adphish]")["key"] == parse_crew_tag("x [Shellphish]")["key"]
+assert parse_crew_tag("x [\uff53\uff48\uff45\uff4c\uff4c]")["key"] == "shell"
+assert parse_crew_tag("x [Shellphish\ufe0f]")["key"] == "shellphish"
+assert parse_crew_tag("x [\U0001f480\U0001f525]") == {"tag": "\U0001f480\U0001f525", "key": "\U0001f480\U0001f525", "base_name": "x"}
+assert parse_crew_tag("x [  padded  ]") == {"tag": "padded", "key": "padded", "base_name": "x"}
 
-    tiebreaks = browser.execute_script("""
-        const standings = [
-            {user_id: 1, name: "a [Big]", solves: 3, rank: 1},
-            {user_id: 2, name: "b [Big]", solves: 3, rank: 2},
-            {user_id: 3, name: "c [Small]", solves: 6, rank: 3},
-        ];
-        return aggregateCrews(standings).map(crew => crew.tag);
-    """)
-    assert tiebreaks == ["Small", "Big"]
+standings = [
+    {"user_id": 1, "name": "a [X]", "solves": 5, "rank": 1},
+    {"user_id": 2, "name": "b [X]", "solves": 4, "rank": 2},
+    {"user_id": 3, "name": "c [Y]", "solves": 3, "rank": 3},
+    {"user_id": 4, "name": "d [__proto__]", "solves": 2, "rank": 4},
+    {"user_id": 5, "name": "e", "solves": 1, "rank": 5},
+]
+crews = aggregate_crews(standings)
+assert [(c["tag"], c["score"], len(c["members"]), c["rank"]) for c in crews] == [("X", 9, 2, 1), ("Y", 3, 1, 2), ("__proto__", 2, 1, 3)]
+
+tie = aggregate_crews([
+    {"user_id": 1, "name": "a [Big]", "solves": 3, "rank": 1},
+    {"user_id": 2, "name": "b [Big]", "solves": 3, "rank": 2},
+    {"user_id": 3, "name": "c [Small]", "solves": 6, "rank": 3},
+])
+assert [c["tag"] for c in tie] == ["Small", "Big"]
+assert aggregate_crews([]) == []
+
+print("CREW-UNIT-OK")
+"""
+
+
+def test_crew_parse_and_aggregation_unit():
+    assert "CREW-UNIT-OK" in flask_exec(CREW_PARSE_UNIT)
+
+
+@pytest.mark.timeout(300)
+def test_crew_scoreboard_api(crew_dojo):
+    tag = "".join(random.choices(string.ascii_uppercase, k=8))
+    name_a, _, session_a = register_user(tag=tag)
+    name_b, _, session_b = register_user(tag=tag.lower())
+    name_c, _, session_c = register_user()
+
+    for name, session in [(name_a, session_a), (name_b, session_b), (name_c, session_c)]:
+        join_dojo(session, crew_dojo)
+
+    solve(crew_dojo, name_a, session_a, "apple")
+    solve(crew_dojo, name_b, session_b, "banana")
+    solve(crew_dojo, name_c, session_c, "apple")
+    for name in [name_a, name_b, name_c]:
+        remove_workspace_container(name)
+    wait_for_background_worker(timeout=30)
+
+    result = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/crews/0/1")
+    assert result.status_code == 404
+
+    result = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/_/crews/0/1")
+    assert result.status_code == 200
+    board = result.json()
+
+    crew = next(c for c in board["standings"] if c["key"] == tag.lower())
+    assert crew["score"] == 2
+    assert len(crew["members"]) == 2
+    member_names = [member["name"] for member in crew["members"]]
+    assert name_a in member_names and name_b in member_names
+    for member in crew["members"]:
+        assert "email" not in member
+        assert member["crew"]["key"] == tag.lower()
+    assert all(name_c != member["name"] for c in board["standings"] for member in c["members"])
+
+    assert "me_crew" in board
+    assert board["me_crew"]["key"] == tag.lower()
+
+    module_board = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/hello/crews/0/1").json()
+    module_crew = next(c for c in module_board["standings"] if c["key"] == tag.lower())
+    assert module_crew["score"] == 2
+
+    hacker_board = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/_/0/1").json()
+    tagged = next(entry for entry in hacker_board["standings"] if entry["name"] == name_a)
+    assert tagged["crew"]["tag"] == tag
+    assert tagged["crew"]["key"] == tag.lower()
+    untagged = next(entry for entry in hacker_board["standings"] if entry["name"] == name_c)
+    assert untagged["crew"] is None
+
 
 
 def test_crew_view_toggle_race(browser_fixture, example_dojo):
@@ -253,10 +288,10 @@ def test_crew_view_toggle_race(browser_fixture, example_dojo):
     assert browser.execute_script("return $('#scoreboard-th-name').text()") == "Hacker"
 
     browser.execute_script("setScoreboardView('crews')")
-    wait_until(lambda: browser.execute_script("return $('#scoreboard .crew-loading').length === 0 && $('#scoreboard tr').length > 0"))
+    wait_until(lambda: browser.execute_script("return $('#scoreboard .scoreboard-loading').length === 0 && $('#scoreboard tr').length > 0"))
     rows = browser.execute_script("return $('#scoreboard .crew-row').length")
     browser.execute_script("setScoreboardView('hackers'); setScoreboardView('crews');")
-    wait_until(lambda: browser.execute_script("return $('#scoreboard .crew-loading').length === 0 && $('#scoreboard tr').length > 0"))
+    wait_until(lambda: browser.execute_script("return $('#scoreboard .scoreboard-loading').length === 0 && $('#scoreboard tr').length > 0"))
     time.sleep(1)
     assert browser.execute_script("return $('#scoreboard .crew-row').length") == rows
     assert browser.execute_script("return $('#scoreboard-heading').text()") == "All-Time Crew Scoreboard:"

--- a/test/test_crew_scoreboard.py
+++ b/test/test_crew_scoreboard.py
@@ -1,0 +1,283 @@
+import random
+import re
+import string
+import time
+
+import pytest
+
+from utils import DOJO_URL, login, create_dojo_yml, start_challenge, solve_challenge, workspace_run, wait_for_background_worker
+
+
+CREW_DOJO_SPEC = """
+id: crew-dojo
+name: Crew Dojo
+modules:
+  - id: hello
+    name: Hello
+    challenges:
+      - id: apple
+        import:
+          dojo: example
+          module: hello
+          challenge: apple
+      - id: banana
+        import:
+          dojo: example
+          module: hello
+          challenge: banana
+"""
+
+
+@pytest.fixture(scope="module")
+def crew_dojo(admin_session, example_dojo):
+    suffix = "".join(random.choices(string.ascii_lowercase, k=8))
+    spec = CREW_DOJO_SPEC.replace("crew-dojo", f"crew-dojo-{suffix}")
+    return create_dojo_yml(spec, session=admin_session)
+
+
+def register_user(tag=None, name_prefix=None):
+    user_id = "".join(random.choices(string.ascii_lowercase, k=12))
+    name = f"{name_prefix or ''}{user_id}"
+    if tag is not None:
+        name = f"{name} [{tag}]"
+    session = login(name, user_id, register=True, email=f"{user_id}@example.com")
+    return name, user_id, session
+
+
+def join_dojo(session, dojo):
+    response = session.get(f"{DOJO_URL}/dojo/{dojo}/join/")
+    assert response.status_code == 200
+
+
+def solve(dojo, user_name, session, challenge):
+    start_challenge(dojo, "hello", challenge, session=session)
+    result = workspace_run(f"/challenge/{challenge}", user=user_name)
+    flag = re.search(r"pwn\.college{\S+}", result.stdout).group()
+    solve_challenge(dojo, "hello", challenge, session=session, flag=flag)
+
+
+def browser_login(browser, name, password):
+    browser.get(f"{DOJO_URL}/login")
+    browser.find_element("id", "name").send_keys(name)
+    browser.find_element("id", "password").send_keys(password)
+    browser.find_element("id", "_submit").click()
+
+
+def wait_until(predicate, timeout=15):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        result = predicate()
+        if result:
+            return result
+        time.sleep(0.5)
+    raise AssertionError("timed out waiting for condition")
+
+
+def open_crew_view(browser, dojo):
+    browser.get(f"{DOJO_URL}/dojo/{dojo}")
+    wait_until(lambda: browser.execute_script("return typeof setScoreboardView === 'function' && $('#scoreboard tr').length > 0"))
+    browser.execute_script("setScoreboardView('crews')")
+    wait_until(lambda: browser.execute_script("return $('#scoreboard .crew-loading').length === 0"))
+
+
+@pytest.mark.timeout(300)
+def test_crew_scoreboard_happy_path(browser_fixture, crew_dojo):
+    browser = browser_fixture
+    tag = "".join(random.choices(string.ascii_uppercase, k=8))
+    name_a, password_a, session_a = register_user(tag=tag)
+    name_b, _, session_b = register_user(tag=tag)
+    name_c, _, session_c = register_user()
+
+    for name, session in [(name_a, session_a), (name_b, session_b), (name_c, session_c)]:
+        join_dojo(session, crew_dojo)
+
+    solve(crew_dojo, name_a, session_a, "apple")
+    solve(crew_dojo, name_a, session_a, "banana")
+    solve(crew_dojo, name_b, session_b, "apple")
+    solve(crew_dojo, name_c, session_c, "apple")
+    wait_for_background_worker(timeout=30)
+
+    browser_login(browser, name_a, password_a)
+    open_crew_view(browser, crew_dojo)
+
+    crew_row = wait_until(lambda: next(
+        (row for row in browser.find_elements("css selector", ".crew-row")
+         if row.find_element("css selector", ".crew-tag-text").text == tag), None))
+    assert crew_row.find_element("css selector", ".crew-member-count").text == "2 members"
+    assert crew_row.find_element("css selector", ".crew-score").text == "3"
+    assert "scoreboard-row-me" in crew_row.get_attribute("class")
+
+    assert name_c not in browser.execute_script("return $('#scoreboard').text()")
+
+    browser.execute_script("arguments[0].scrollIntoView({block: 'center'}); arguments[0].click();", crew_row)
+    member_names = wait_until(lambda: browser.execute_script(
+        "return $('#scoreboard .crew-member-row .scoreboard-name').map((i, e) => e.textContent).get()") or None)
+    assert member_names == [name_a.replace(f" [{tag}]", ""), name_b.replace(f" [{tag}]", "")]
+
+    member_titles = browser.execute_script(
+        "return $('#scoreboard .crew-member-row .scoreboard-name').map((i, e) => e.getAttribute('title')).get()")
+    assert member_titles == [name_a, name_b]
+    assert name_c not in browser.execute_script("return $('#scoreboard').text()")
+
+    browser.execute_script("setScoreboardView('hackers')")
+    wait_until(lambda: browser.execute_script("return $('#scoreboard .crew-row').length === 0 && $('#scoreboard .scoreboard-name').length > 0"))
+    hacker_names = browser.execute_script("return $('#scoreboard .scoreboard-name').map((i, e) => e.getAttribute('title')).get()")
+    assert name_c in hacker_names
+    chip_tags = browser.execute_script("return $('#scoreboard .scoreboard-name .crew-tag-text').map((i, e) => e.textContent).get()")
+    assert chip_tags.count(tag) == 2
+
+
+@pytest.mark.timeout(180)
+def test_crew_tag_xss_safe(browser_fixture, crew_dojo):
+    browser = browser_fixture
+    prefix = "<img src=x onerror=window.__xss2=1>"
+    tag = "<svg onload=__x=1>"
+    name, password, session = register_user(tag=tag, name_prefix=prefix)
+    join_dojo(session, crew_dojo)
+    solve(crew_dojo, name, session, "apple")
+    wait_for_background_worker(timeout=30)
+
+    browser_login(browser, name, password)
+    open_crew_view(browser, crew_dojo)
+    wait_until(lambda: browser.execute_script("return $('#scoreboard .crew-row').length > 0"))
+
+    assert browser.execute_script("return window.__x") is None
+    assert browser.execute_script("return window.__xss2") is None
+    assert browser.execute_script("return $('#scoreboard svg, #scoreboard img:not(.scoreboard-symbol):not(.scoreboard-belt):not(.crew-face)').length") == 0
+    tag_texts = browser.execute_script("return $('#scoreboard .crew-tag-text').map((i, e) => e.textContent).get()")
+    assert tag in tag_texts
+
+    xss_crew_row = next(row for row in browser.find_elements("css selector", ".crew-row")
+                        if row.find_element("css selector", ".crew-tag-text").text == tag)
+    browser.execute_script("arguments[0].scrollIntoView({block: 'center'}); arguments[0].click();", xss_crew_row)
+    wait_until(lambda: browser.execute_script("return $('#scoreboard .crew-member-row').length > 0"))
+    assert browser.execute_script("return window.__x") is None
+    assert browser.execute_script("return window.__xss2") is None
+    member_name = browser.execute_script("return $('#scoreboard .crew-member-row .scoreboard-name').first().text()")
+    assert prefix in member_name
+    assert browser.execute_script("return $('#scoreboard .crew-member-row img:not(.scoreboard-symbol):not(.scoreboard-belt)').length") == 0
+
+
+def test_crew_parse_tag(browser_fixture, example_dojo):
+    browser = browser_fixture
+    browser.get(f"{DOJO_URL}/dojo/{example_dojo}")
+    wait_until(lambda: browser.execute_script("return typeof window.parseCrewTag === 'function'"))
+
+    def parse(name):
+        return browser.execute_script("return window.parseCrewTag(arguments[0])", name)
+
+    assert parse("Zardus [Shellphish]") == {"tag": "Shellphish", "key": "shellphish", "baseName": "Zardus"}
+    assert parse("[Shellphish]") == {"tag": "Shellphish", "key": "shellphish", "baseName": ""}
+    assert parse("[abc] Zardus") is None
+    assert parse("A [x] [y]") == {"tag": "y", "key": "y", "baseName": "A [x]"}
+    assert parse("A [[x]]") is None
+    assert parse("A []") is None
+    assert parse("A [ ]") is None
+    assert parse("A [\u200b]") is None
+    assert parse("plain") is None
+    assert parse("[") is None
+    assert parse("]") is None
+    assert parse("A [" + "x" * 25 + "]") is None
+    assert parse("A [" + "x" * 21 + "]") is None
+    assert parse("x [a\u200bb]")["key"] == parse("x [ab]")["key"]
+    assert parse("x [Shell  phish]")["key"] == parse("x [Shell phish]")["key"]
+    assert parse("x [SHELLPHISH]")["key"] == parse("x [shellphish]")["key"]
+    assert parse("x [Shell\u00adphish]")["key"] == parse("x [Shellphish]")["key"]
+    assert parse("x [ｓｈｅｌｌｐｈｉｓｈ]")["key"] == "shellphish"
+    assert parse("x [Shellphish\ufe0f]")["key"] == "shellphish"
+    assert parse("x [💀🔥]") == {"tag": "💀🔥", "key": "💀🔥", "baseName": "x"}
+    assert parse("x [  padded  ]") == {"tag": "padded", "key": "padded", "baseName": "x"}
+
+
+def test_crew_aggregation_logic(browser_fixture, example_dojo):
+    browser = browser_fixture
+    browser.get(f"{DOJO_URL}/dojo/{example_dojo}")
+    wait_until(lambda: browser.execute_script("return typeof window.parseCrewTag === 'function'"))
+
+    result = browser.execute_script("""
+        const pages = new Map();
+        pages.set(1, [
+            {user_id: 1, name: "a [X]", solves: 5, rank: 1},
+            {user_id: 2, name: "b [X]", solves: 4, rank: 2},
+        ]);
+        pages.set(2, [
+            {user_id: 2, name: "b [X]", solves: 4, rank: 2},
+            {user_id: 3, name: "c [Y]", solves: 3, rank: 3},
+            {user_id: 4, name: "d [__proto__]", solves: 2, rank: 4},
+            {user_id: 5, name: "e", solves: 1, rank: 5},
+        ]);
+        const standings = dedupStandings({pagesByNumber: pages});
+        const crews = aggregateCrews(standings);
+        return {
+            standings: standings.length,
+            crews: crews.map(crew => ({tag: crew.tag, score: crew.score, members: crew.members.length, rank: crew.rank})),
+        };
+    """)
+    assert result["standings"] == 5
+    assert result["crews"] == [
+        {"tag": "X", "score": 9, "members": 2, "rank": 1},
+        {"tag": "Y", "score": 3, "members": 1, "rank": 2},
+        {"tag": "__proto__", "score": 2, "members": 1, "rank": 3},
+    ]
+
+    tiebreaks = browser.execute_script("""
+        const standings = [
+            {user_id: 1, name: "a [Big]", solves: 3, rank: 1},
+            {user_id: 2, name: "b [Big]", solves: 3, rank: 2},
+            {user_id: 3, name: "c [Small]", solves: 6, rank: 3},
+        ];
+        return aggregateCrews(standings).map(crew => crew.tag);
+    """)
+    assert tiebreaks == ["Small", "Big"]
+
+
+def test_crew_view_toggle_race(browser_fixture, example_dojo):
+    browser = browser_fixture
+    browser.get(f"{DOJO_URL}/dojo/{example_dojo}")
+    wait_until(lambda: browser.execute_script("return typeof setScoreboardView === 'function' && $('#scoreboard tr').length > 0"))
+
+    browser.execute_script("loadScoreboard(7, 1); loadScoreboard(0, 1);")
+    wait_until(lambda: browser.execute_script("return $('#scoreboard .scoreboard-loading').length === 0 && $('#scoreboard tr').length > 0"))
+    time.sleep(1)
+    assert browser.execute_script("return $('#scoreboard-heading').text()") == "All-Time Scoreboard:"
+    assert browser.execute_script("return $('#scoreboard-control-all').hasClass('scoreboard-page-selected')")
+
+    browser.execute_script("setScoreboardView('crews'); setScoreboardView('hackers');")
+    wait_until(lambda: browser.execute_script("return $('#scoreboard .scoreboard-loading').length === 0 && $('#scoreboard tr').length > 0"))
+    time.sleep(1)
+    assert browser.execute_script("return $('#scoreboard .crew-row').length") == 0
+    assert browser.execute_script("return $('#scoreboard-heading').text()") == "All-Time Scoreboard:"
+    assert browser.execute_script("return $('#scoreboard-th-name').text()") == "Hacker"
+
+    browser.execute_script("setScoreboardView('crews')")
+    wait_until(lambda: browser.execute_script("return $('#scoreboard .crew-loading').length === 0 && $('#scoreboard tr').length > 0"))
+    rows = browser.execute_script("return $('#scoreboard .crew-row').length")
+    browser.execute_script("setScoreboardView('hackers'); setScoreboardView('crews');")
+    wait_until(lambda: browser.execute_script("return $('#scoreboard .crew-loading').length === 0 && $('#scoreboard tr').length > 0"))
+    time.sleep(1)
+    assert browser.execute_script("return $('#scoreboard .crew-row').length") == rows
+    assert browser.execute_script("return $('#scoreboard-heading').text()") == "All-Time Crew Scoreboard:"
+
+
+@pytest.mark.timeout(180)
+def test_crew_empty_states(browser_fixture, admin_session, example_dojo):
+    browser = browser_fixture
+    suffix = "".join(random.choices(string.ascii_lowercase, k=8))
+    spec = CREW_DOJO_SPEC.replace("crew-dojo", f"crew-empty-{suffix}")
+    dojo = create_dojo_yml(spec, session=admin_session)
+
+    name, password, session = register_user()
+    join_dojo(session, dojo)
+
+    browser_login(browser, name, password)
+    open_crew_view(browser, dojo)
+    note = wait_until(lambda: browser.execute_script("return $('#scoreboard .crew-note').text()") or None)
+    assert note == "No solves yet — no crews to show."
+
+    solve(dojo, name, session, "apple")
+    wait_for_background_worker(timeout=30)
+
+    open_crew_view(browser, dojo)
+    title = wait_until(lambda: browser.execute_script("return $('#scoreboard .crew-empty-title').text()") or None)
+    assert title == "No crews yet."
+    assert "add a tag in brackets" in browser.execute_script("return $('#scoreboard .crew-empty-hint').text()")

--- a/test/test_crew_scoreboard.py
+++ b/test/test_crew_scoreboard.py
@@ -5,7 +5,7 @@ import time
 
 import pytest
 
-from utils import DOJO_URL, login, create_dojo_yml, start_challenge, solve_challenge, workspace_run, wait_for_background_worker
+from utils import DOJO_URL, login, create_dojo_yml, start_challenge, solve_challenge, workspace_run, wait_for_background_worker, remove_workspace_container
 
 
 CREW_DOJO_SPEC = """
@@ -95,6 +95,8 @@ def test_crew_scoreboard_happy_path(browser_fixture, crew_dojo):
     solve(crew_dojo, name_a, session_a, "banana")
     solve(crew_dojo, name_b, session_b, "apple")
     solve(crew_dojo, name_c, session_c, "apple")
+    for name in [name_a, name_b, name_c]:
+        remove_workspace_container(name)
     wait_for_background_worker(timeout=30)
 
     browser_login(browser, name_a, password_a)
@@ -135,6 +137,7 @@ def test_crew_tag_xss_safe(browser_fixture, crew_dojo):
     name, password, session = register_user(tag=tag, name_prefix=prefix)
     join_dojo(session, crew_dojo)
     solve(crew_dojo, name, session, "apple")
+    remove_workspace_container(name)
     wait_for_background_worker(timeout=30)
 
     browser_login(browser, name, password)
@@ -275,6 +278,7 @@ def test_crew_empty_states(browser_fixture, admin_session, example_dojo):
     assert note == "No solves yet — no crews to show."
 
     solve(dojo, name, session, "apple")
+    remove_workspace_container(name)
     wait_for_background_worker(timeout=30)
 
     open_crew_view(browser, dojo)

--- a/test/test_dojos.py
+++ b/test/test_dojos.py
@@ -238,6 +238,7 @@ def test_challenge_transfer(transfer_src_dojo, transfer_dst_dojo, random_user_na
     assert random_user_session.get(f"{DOJO_URL}/dojo/{transfer_dst_dojo}/join/").status_code == 200
     start_challenge(transfer_dst_dojo, "dst-module", "dst-challenge", session=random_user_session)
     solve_challenge(transfer_dst_dojo, "dst-module", "dst-challenge", session=random_user_session, user=random_user_name)
+    wait_for_background_worker()
     scoreboard = random_user_session.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{transfer_src_dojo}/_/0/1").json()
     us = next(u for u in scoreboard["standings"] if u["name"] == random_user_name)
     assert us["solves"] == 1

--- a/test/test_integrations.py
+++ b/test/test_integrations.py
@@ -55,7 +55,7 @@ def validate_restart(username, mode):
         result = workspace_run(command, user=username)
         assert False, f"\"dojo restart\" should not have result: {(result.stdout, result.stderr)}"
     except subprocess.CalledProcessError as error:
-        pass
+        restart_error = (error.returncode, error.stdout, error.stderr)
 
     # Validate that the container is the same, and it is not the same container.
     assert validate_current_container(
@@ -65,7 +65,7 @@ def validate_restart(username, mode):
         labels["dojo.challenge_id"],
         mode = labels["dojo.mode"] if mode == "current" else mode,
         after = datetime.datetime.fromisoformat(container["Created"]) # Should be created after the old container.
-    ), f"Failed to restart:\nOriginal Container:\n{container}\nNewest Container:\n{inspect_container(username)}"
+    ), f"Failed to restart (\"dojo restart\" exited {restart_error[0]}, stdout={restart_error[1]!r}, stderr={restart_error[2]!r}):\nOriginal Container:\n{container}\nNewest Container:\n{inspect_container(username)}"
 
 def test_whoami(random_user, welcome_dojo):
     name, session = random_user

--- a/test/test_integrations.py
+++ b/test/test_integrations.py
@@ -21,7 +21,7 @@ def inspect_container(username) -> dict[str, Any]:
     except:
         return {}
 
-def validate_current_container(username, dojo, module, challenge, attempts=10, mode:str=None, before:datetime.datetime=None, after:datetime.datetime=None) -> bool:
+def validate_current_container(username, dojo, module, challenge, attempts=30, mode:str=None, before:datetime.datetime=None, after:datetime.datetime=None) -> bool:
     for _ in range(attempts):
         container = inspect_container(username)
         try:

--- a/test/test_integrations.py
+++ b/test/test_integrations.py
@@ -51,11 +51,17 @@ def validate_restart(username, mode):
         "standard": "dojo restart -N",
         "current": "dojo restart"
     }[mode]
-    try:
-        result = workspace_run(command, user=username)
-        assert False, f"\"dojo restart\" should not have result: {(result.stdout, result.stderr)}"
-    except subprocess.CalledProcessError as error:
-        restart_error = (error.returncode, error.stdout, error.stderr)
+    # The previous start's per-user docker lock is held until the workspace is
+    # fully ready, which can outlast container creation on slow machines.
+    for _ in range(15):
+        try:
+            result = workspace_run(command, user=username)
+            assert False, f"\"dojo restart\" should not have result: {(result.stdout, result.stderr)}"
+        except subprocess.CalledProcessError as error:
+            restart_error = (error.returncode, error.stdout, error.stderr)
+            if "Already starting a challenge" not in (error.stderr or ""):
+                break
+            time.sleep(3)
 
     # Validate that the container is the same, and it is not the same container.
     assert validate_current_container(

--- a/test/test_scoreboard.py
+++ b/test/test_scoreboard.py
@@ -1,6 +1,9 @@
+import random
+import string
+
 import pytest
 
-from utils import DOJO_URL, workspace_run, start_challenge, solve_challenge, wait_for_background_worker, get_user_id
+from utils import DOJO_URL, login, create_dojo_yml, workspace_run, start_challenge, solve_challenge, wait_for_background_worker, get_user_id
 
 
 def get_all_standings(session, dojo, module=None):
@@ -55,6 +58,56 @@ def test_scoreboard(random_user_name, random_user_session, example_dojo):
             found_me = True
             break
     assert found_me, f"Unable to find new user {random_user_name} in new standings after solving a challenge"
+
+
+def bracket_name_solver(example_dojo, tag):
+    user_id = "".join(random.choices(string.ascii_lowercase, k=12))
+    name = f"{user_id} [{tag}]"
+    session = login(name, user_id, register=True, email=f"{user_id}@example.com")
+    start_challenge(example_dojo, "hello", "apple", session=session)
+    result = workspace_run("/challenge/apple", user=name)
+    solve_challenge(example_dojo, "hello", "apple", session=session, flag=result.stdout.strip())
+    wait_for_background_worker()
+    return name, session
+
+
+@pytest.mark.timeout(180)
+def test_scoreboard_bracket_name_passthrough(example_dojo):
+    name, session = bracket_name_solver(example_dojo, "CrewTag")
+    standings = get_all_standings(session, example_dojo)
+    assert any(standing["name"] == name for standing in standings), \
+        f"user {name!r} not found verbatim in standings"
+
+
+@pytest.mark.timeout(180)
+def test_scoreboard_hostile_tag_passthrough(example_dojo):
+    name, session = bracket_name_solver(example_dojo, '<b x="y">&amp;')
+    standings = get_all_standings(session, example_dojo)
+    assert any(standing["name"] == name for standing in standings), \
+        f"user {name!r} not found verbatim in standings"
+
+
+def test_scoreboard_empty_module_contract(admin_session, example_dojo):
+    suffix = "".join(random.choices(string.ascii_lowercase, k=8))
+    spec = f"""
+id: empty-board-{suffix}
+name: Empty Board
+modules:
+  - id: hello
+    name: Hello
+    challenges:
+      - id: apple
+        import:
+          dojo: example
+          module: hello
+          challenge: apple
+"""
+    dojo = create_dojo_yml(spec, session=admin_session)
+    response = admin_session.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{dojo}/hello/0/1")
+    assert response.status_code == 200
+    result = response.json()
+    assert result["standings"] == []
+    assert result["pages"] == []
 
 
 def test_folder_awards(admin_session, event_dojo, random_user, example_dojo):

--- a/test/test_scoreboard.py
+++ b/test/test_scoreboard.py
@@ -3,7 +3,7 @@ import string
 
 import pytest
 
-from utils import DOJO_URL, login, create_dojo_yml, workspace_run, start_challenge, solve_challenge, wait_for_background_worker, get_user_id
+from utils import DOJO_URL, login, create_dojo_yml, workspace_run, start_challenge, solve_challenge, wait_for_background_worker, get_user_id, remove_workspace_container
 
 
 def get_all_standings(session, dojo, module=None):
@@ -67,7 +67,8 @@ def bracket_name_solver(example_dojo, tag):
     start_challenge(example_dojo, "hello", "apple", session=session)
     result = workspace_run("/challenge/apple", user=name)
     solve_challenge(example_dojo, "hello", "apple", session=session, flag=result.stdout.strip())
-    wait_for_background_worker()
+    remove_workspace_container(name)
+    wait_for_background_worker(timeout=30)
     return name, session
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -159,6 +159,15 @@ def get_outer_container_for(container_name):
     
     raise RuntimeError(f"container {container_name} not found on any nodes")
 
+def remove_workspace_container(user):
+    container_name = f"user_{get_user_id(user)}"
+    try:
+        outer_container = get_outer_container_for(container_name)
+    except RuntimeError:
+        return
+    dojo_run("docker", "rm", "-f", container_name, check=False, container=outer_container)
+
+
 def workspace_run(cmd, *, user, root=False, **kwargs):
     container_name = f"user_{get_user_id(user)}"
     outer_container = get_outer_container_for(container_name)

--- a/test/utils.py
+++ b/test/utils.py
@@ -89,21 +89,27 @@ def make_dojo_official(dojo_rid, admin_session):
     assert response.status_code == 200, f"Expected status code 200, but got {response.status_code} - {response.json()}"
 
 
+def _create_dojo_with_retries(create_dojo_json, *, session):
+    # Dojo creation fetches external resources (git clone, file downloads);
+    # transient network failures are retried, permanent errors are not.
+    for _ in range(3):
+        response = session.post(f"{DOJO_URL}/pwncollege_api/v1/dojos/create", json=create_dojo_json)
+        if response.status_code == 200 or "already exists" in response.text:
+            break
+        time.sleep(5)
+    assert response.status_code == 200, f"Expected status code 200, but got {response.status_code} - {response.json()}"
+    return response.json()["dojo"]
+
+
 def create_dojo(repository, *, session):
     test_public_key = f"public/{repository}"
     test_private_key = f"private/{repository}"
     create_dojo_json = { "repository": repository, "public_key": test_public_key, "private_key": test_private_key }
-    response = session.post(f"{DOJO_URL}/pwncollege_api/v1/dojos/create", json=create_dojo_json)
-    assert response.status_code == 200, f"Expected status code 200, but got {response.status_code} - {response.json()}"
-    dojo_reference_id = response.json()["dojo"]
-    return dojo_reference_id
+    return _create_dojo_with_retries(create_dojo_json, session=session)
 
 
 def create_dojo_yml(spec, *, session):
-    response = session.post(f"{DOJO_URL}/pwncollege_api/v1/dojos/create", json={"spec": spec})
-    assert response.status_code == 200, f"Expected status code 200, but got {response.status_code} - {response.json()}"
-    dojo_reference_id = response.json()["dojo"]
-    return dojo_reference_id
+    return _create_dojo_with_retries({"spec": spec}, session=session)
 
 
 def dojo_run(*args, **kwargs):


### PR DESCRIPTION
Adds a clan-like **Crew** system to the scoreboard. No database changes.

## How it works

Joining a crew is honor-system name convention: add a `[TAG]` suffix to your display name (e.g. `Zardus [Shellphish]`) in Settings. Registration and name changes already accept `[]`, so no auth changes are needed.

Crew standings are computed **exactly like the user scoreboards**: the stats worker derives them from every scoreboard it caches — both full recalculations and incremental solve updates — and stores them under `stats:crews:*` keys; the scoreboard API serves them paginated from that cache (`/<dojo>/<module or _>/crews/<duration>/<page>?mode=cumulative|unique`), with an on-the-fly fallback when the crews cache is absent. Totals are exact on boards of any size, and the crews view is a single request. Every dojo and module scoreboard gets a **Hackers | Crews** toggle.

Crews are ranked under **two scoring modes**, switchable with a Cumulative | Unique toggle:
- **Cumulative** — the sum of member solves: a challenge solved by three members counts three times. Rewards big, active crews.
- **Unique** — the number of *distinct* challenges the crew has solved: a challenge solved by three members counts once. Rewards breadth over pile-ons.

For unique counting the worker tracks per-member solved-challenge sets for tagged users only: full recalculations query just the solves of users whose scoreboard names parse as tagged (boards without crews skip the query entirely), and solve events maintain the sets incrementally with a one-off backfill when a tagged member first appears. Both rankings are precomputed in the crews cache. Non-required solves are now excluded from incremental updates, matching what full recalculations count.

### Crew scoreboard
![crews](https://raw.githubusercontent.com/pwncollege/dojo/crew-scoreboard-assets/crews_collapsed.png)

### Unique mode — a different race
The same crews, ranked by distinct challenges solved: r00tless takes #1 on the fewer-members tie-break while the cumulative champion drops to #3.
![unique](https://raw.githubusercontent.com/pwncollege/dojo/crew-scoreboard-assets/crews_unique.png)

### Expandable member rows
Members show their global rank, badges, belt, and score; names render tag-stripped inside their crew.
![expanded](https://raw.githubusercontent.com/pwncollege/dojo/crew-scoreboard-assets/crews_expanded.png)

### Crew chips on the hacker board
Every scoreboard entry now carries its parsed crew from the server; tags render as per-crew colored chips (deterministic hue from the tag) on the regular board too — ambient discovery for the feature.
![hackers](https://raw.githubusercontent.com/pwncollege/dojo/crew-scoreboard-assets/hackers_chips.png)

### Your crew is highlighted
![mycrew](https://raw.githubusercontent.com/pwncollege/dojo/crew-scoreboard-assets/crews_my_crew.png)

### Empty state teaches the mechanic
![empty](https://raw.githubusercontent.com/pwncollege/dojo/crew-scoreboard-assets/crews_empty_state.png)

## Design details

**Tag parsing** (`dojo_plugin/utils/crews.py`, single source of truth):
- Suffix-only: the final bracket group at the end of the name. `John [the] Ripper` founds no crew; `A [x] [y]` → crew `y`.
- 1–20 chars after sanitization (Unicode control/bidi/zero-width/format chars stripped, whitespace collapsed); anything longer or empty doesn't parse.
- Grouping key: variation selectors stripped → NFKC → casefold, so `[Shellphish]`/`[SHELLPHISH]`/`[ｓｈｅｌｌｐｈｉｓｈ]` are one crew. Display keeps the top member's casing.

**Ranking**: per mode — cumulative score is the sum of member solves; unique score is the size of the union of members' solved-challenge sets, on the current board/duration. Ties in both modes: fewer members, then best individual rank, then tag. Solo crews are shown — the founding member should see their crew immediately.

**Client**: the crews view renders server data; user-controlled text goes through `.text()`/`.attr()` only; a generation counter guards async renders during rapid view/duration switching; `#crews` deep link; teaching empty state pointing at Settings.

## Pre-existing scoreboard.js bugs fixed along the way

- **Badge attribute injection**: `badge.text`/`badge.emoji`/`badge.url` were interpolated raw into HTML (`title="${badge.text}"`) — award descriptions and dojo names reached the DOM unescaped.
- **"Loading." innerHTML sniff**: the loading animation polled `scoreboard.html().includes("Loading.")` — a user named `Loading..` would wipe the board for every viewer mid-render.
- **Empty-board crash**: `standings[0].rank` threw on boards with zero solvers.
- **`me`-splice mutation**: the current user was spliced into the fetched standings array in place.

## Tests

- `test/test_crew_scoreboard.py`: server-side parse/aggregation unit tests (run inside the app via `dojo flask`, covering both metrics, overlap dedup, and both rank orders), crews API contract tests (grouping, case-insensitive keys, module scoping, `me_crew`, mode ordering, incremental overlap updates, no email/challenge-set leakage), and selenium UI tests: happy path (crew totals, member expansion, tag-stripped names, my-crew highlight, untagged exclusion, hacker-view chips), XSS-safety with hostile tag + name, view/duration toggle race, and both empty states.
- `test/test_scoreboard.py`: bracket and hostile-HTML names pass through the scoreboard JSON verbatim; empty module boards return the degenerate shape the client guards.
- Test-infra hardening that fell out of validation: a real Firefox in the test image (Ubuntu 24.04's apt `firefox` is a snap shim that can't run in a container — every CI session was silently downloading a browser at runtime), connect-only request retries, dojo-creation retries for transient clone failures, missing background-worker waits in two racy tests, restart-validation now reports the swallowed `dojo restart` error, and container-starting tests clean up their workspaces.

## Accepted limitations (by design)

- Tags are honor-system: anyone can wear `[Shellphish]`. Verified crews would need real membership state — out of scope.
- Homoglyph tags (Cyrillic vs Latin lookalikes) don't merge; normalization covers case, width, and invisible characters only.
- Renames propagate on the server's next scoreboard recalculation, same as the hacker board.

Screenshots live on the `crew-scoreboard-assets` branch (never to be merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwozfHrH3JYUrJP1h2xFga
