### PR TITLE
Workspace: replace the inline service dropdown with pop-out service buttons

### DIFF
--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -36,7 +36,7 @@ NAME_REGEX = Regex(r"^[\S ]{1,128}$")
 IMAGE_REGEX = Regex(r"^[\S]{1,256}$")
 FILE_PATH_REGEX = Regex(r"^[A-Za-z0-9_][A-Za-z0-9-_./]*$")
 FILE_URL_REGEX = Regex(r"^https://www.dropbox.com/[a-zA-Z0-9]*/[a-zA-Z0-9]*/[a-zA-Z0-9]*/[a-zA-Z0-9.-_]*?rlkey=[a-zA-Z0-9]*&dl=1")
-INTERFACES_LIST = [Or({"name": Regex(r"[a-zA-Z]{1,32}"),"port": int},{"name": "SSH"})]
+INTERFACES_LIST = [Or({"name": Regex(r"^[a-zA-Z][a-zA-Z0-9 _-]{0,31}$"),"port": int},{"name": "SSH"})]
 DATE = Use(datetime.datetime.fromisoformat)
 
 ID_NAME_DESCRIPTION = {

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -345,6 +345,7 @@ function actionStartChallenge(event) {
             .removeClass("disabled")
             .removeClass("btn-disabled")
             .prop("disabled", false);
+            context(event).find("#workspace-change-privilege input").prop("disabled", false);
         })
     });
 }
@@ -360,11 +361,6 @@ function actionStartCallback(event) {
     if (context(event).find("#challenge-restart")[0].contains(event.target)) {
         actionStartChallenge(event);
     }
-    else if (context(event).find("#workspace-change-privilege").length > 0 && context(event).find("#workspace-change-privilege")[0].contains(event.target)) {
-        context(event).find("#workspace-change-privilege").attr("data-privileged", (_, v) => v !== "true");
-        displayPrivileged(event, false);
-        actionStartChallenge(event);
-    }
     else {
         console.log("Failed to start challenge.");
 
@@ -375,17 +371,21 @@ function actionStartCallback(event) {
     }
 }
 
-function displayPrivileged(event, invert) {
-    const button = context(event).find("#workspace-change-privilege");
-    const privileged = button.attr("data-privileged") === "true";
-    const lockStatus = privileged === invert;
-
-    button.find(".fas")
-        .toggleClass("fa-lock", lockStatus)
-        .toggleClass("fa-unlock", !lockStatus);
-
-    button.attr("title", privileged ? "Restart unprivileged"
-                                    : "Restart privileged");
+function privilegeChangeCallback(event) {
+    const checkbox = event.currentTarget;
+    const mode = checkbox.checked ? "with sudo access" : "without sudo access";
+    if (!window.confirm(`Restart the challenge ${mode}? The running container will be replaced.`)) {
+        checkbox.checked = !checkbox.checked;
+        return;
+    }
+    context(event).find("#workspace-change-privilege")
+        .attr("data-privileged", checkbox.checked ? "true" : "false");
+    context(event).find(".btn-challenge-start")
+        .addClass("disabled")
+        .addClass("btn-disabled")
+        .prop("disabled", true);
+    checkbox.disabled = true;
+    actionStartChallenge(event);
 }
 
 function loadWorkspace(log=true) {
@@ -449,13 +449,7 @@ $(() => {
 
         $(this).find(".btn-challenge-start").click(actionStartCallback);
 
-        if ($(this).find("#workspace-change-privilege").length) {
-            $(this).find("#workspace-change-privilege").on("mouseenter", function(event) {
-                displayPrivileged(event, true);
-            }).on("mouseleave", function(event) {
-                displayPrivileged(event, false);
-            });
-        }
+        $(this).find("#workspace-change-privilege input").on("change", privilegeChangeCallback);
 
         $(this).find("#fullscreen").click((event) => {
             event.preventDefault();

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -1,12 +1,31 @@
 // To use the actionbar, the following parameters should be met:
 // 1. There is an iframe for controlled workspace content with the id "workspace-iframe"
 // 2. The actionbar and iframe are descendants of a common ancestor with the class "challenge-workspace"
-// 3. The page implements a function, doFullscreen(event) to handle a fullscreen event
-// 4. Optionally, the page can have a div with the class "workspace-ssh" which will be displayed when the SSH option is selected.
+// 3. In fullpage mode (data-popout="false"), the page implements a function, doFullscreen(event), to handle a fullscreen event
+// 4. Optionally, the page can have a div with the class "workspace-ssh" which will be displayed when the SSH service is selected.
 
 // Returns the controls object containing the origin of the event.
 function context(event) {
     return $(event.target).closest(".workspace-controls");
+}
+
+function isPopout(root) {
+    return root.attr("data-popout") === "true";
+}
+
+function serviceName(service) {
+    return service.split(": ")[0];
+}
+
+function servicePort(service) {
+    return service.split(": ")[1];
+}
+
+function isSpecialService(service) {
+    const specialServices = ["terminal", "code", "desktop"];
+    const specialPorts = ["7681", "8080", "6080"];
+    const index = specialServices.indexOf(serviceName(service));
+    return index > -1 && index == specialPorts.indexOf(servicePort(service));
 }
 
 function getServiceHistory() {
@@ -31,12 +50,11 @@ function logService(service) {
     localStorage.setItem("service_history", service);
 }
 
-// Get most recent service which is allowed by the selector within the given root actionbar.
+// Get most recent service which is offered by the given root actionbar.
 function getRecentService(root) {
     var options = [];
-    var allowed = root.find("#workspace-select").find("option");
-    allowed.each((index, value) => {
-        options.push($(value).prop("value"));
+    root.find(".workspace-service").each((index, element) => {
+        options.push($(element).attr("data-service"));
     });
     var history = getServiceHistory();
     var match = null;
@@ -52,15 +70,15 @@ function getRecentService(root) {
 function showWorkspaceLoadError(content, result) {
     content.src = "";
     animateBanner(
-        {target: $(content).closest(".challenge-workspace").find("#workspace-select")[0]},
+        {target: $(content).closest(".challenge-workspace").find(".workspace-controls")[0]},
         result.error,
         "error"
     );
 }
 
-function specialSelect(serviceName, content) {
+function specialSelect(name, content) {
     const url = new URL("/pwncollege_api/v1/workspace", window.location.origin);
-    url.searchParams.set("service", serviceName);
+    url.searchParams.set("service", name);
     fetch(url, {
         method: "GET",
         credentials: "same-origin"
@@ -106,6 +124,22 @@ function portSelect(port, content) {
     });
 }
 
+function loadIframe(service, content) {
+    if (isSpecialService(service)) {
+        specialSelect(serviceName(service), content);
+    }
+    else {
+        portSelect(servicePort(service), content);
+    }
+}
+
+function popoutUrl(service) {
+    if (isSpecialService(service)) {
+        return "/workspace/" + serviceName(service);
+    }
+    return "/workspace/" + servicePort(service);
+}
+
 function selectService(service, log=true) {
     const content = document.getElementById("workspace-iframe");
     if (!content) {
@@ -113,9 +147,11 @@ function selectService(service, log=true) {
         return;
     }
     if (log) {logService(service);}
-    port = service.split(": ")[1];
-    service = service.split(": ")[0];
-    if (service == "ssh" && port == "") {
+    const root = $(content).closest(".challenge-workspace").find(".workspace-controls");
+    root.find(".workspace-service").each(function () {
+        $(this).toggleClass("active", $(this).attr("data-service") === service);
+    });
+    if (serviceName(service) == "ssh" && servicePort(service) == "") {
         content.src = "";
         $(content).addClass("SSH");
         $(".workspace-ssh").show();
@@ -125,13 +161,18 @@ function selectService(service, log=true) {
         $(content).removeClass("SSH");
         $(".workspace-ssh").hide();
     }
-    const specialServices = ["terminal", "code", "desktop"];
-    const specialPorts = ["7681", "8080", "6080"];
-    if (specialServices.indexOf(service) > -1 && specialServices.indexOf(service) == specialPorts.indexOf(port)) {
-        specialSelect(service, content);
+    loadIframe(service, content);
+}
+
+function serviceClickCallback(event) {
+    event.preventDefault();
+    const button = $(event.currentTarget);
+    const service = button.attr("data-service");
+    if (isPopout(context(event))) {
+        window.open(popoutUrl(service), "workspace-" + serviceName(service));
     }
     else {
-        portSelect(port, content);
+        selectService(service);
     }
 }
 
@@ -192,19 +233,10 @@ function actionSubmitFlag(event) {
 }
 
 function sendChallengeInfo(root, channel) {
-    options = []
-    root.find("#workspace-select option").each((index, element) => {
-        options.push({
-            "value": $(element).prop("value"),
-            "text": $(element).text(),
-        });
-    })
-
     challenge = root.find("#current-challenge-id");
     privilege = root.find("#workspace-change-privilege");
 
     challengeData = {
-        "options": options,
         "challenge-id": challenge.prop("value"),
         "challenge-name": challenge.attr("data-challenge-name"),
         "challenge-privilege": privilege.length > 0 ? privilege.attr("data-privileged") : "false",
@@ -262,7 +294,7 @@ function actionStartChallenge(event) {
                 return;
             }
 
-            selectService(context(event).find("#workspace-select").prop("value"));
+            refreshWorkspace(context(event));
             postStartChallenge(event, channel);
 
             context(event).find(".btn-challenge-start")
@@ -313,34 +345,46 @@ function displayPrivileged(event, invert) {
 }
 
 function loadWorkspace(log=true) {
-    if ($("#workspace-iframe").length == 0 ) {
+    const content = $("#workspace-iframe");
+    if (content.length == 0) {
         return;
     }
-    var workspaceRoot = $("#workspace-iframe").closest(".challenge-workspace");
-    var recent = getRecentService(workspaceRoot);
+    var root = content.closest(".challenge-workspace").find(".workspace-controls");
+    if (isPopout(root)) {
+        var service = root.find(".workspace-service").first().attr("data-service");
+        if (service) {
+            loadIframe(service, content[0]);
+        }
+        return;
+    }
+    var recent = getRecentService(root);
     if (recent == null) {
-        recent = workspaceRoot.find("#workspace-select").prop("value");
+        recent = root.find(".workspace-service").first().attr("data-service");
+    }
+    if (recent) {
+        selectService(recent, log);
+    }
+}
+
+function refreshWorkspace(root) {
+    if (isPopout(root)) {
+        loadWorkspace(false);
+        return;
+    }
+    var active = root.find(".workspace-service.active").attr("data-service");
+    if (active) {
+        selectService(active, false);
     }
     else {
-        workspaceRoot.find("#workspace-select").prop("value", recent);
+        loadWorkspace(false);
     }
-    selectService(recent, log=log);
 }
 
 const channel = new BroadcastChannel("Challenge-Sync-Channel");
 $(() => {
     loadWorkspace();
     $(".workspace-controls").each(function () {
-        if ($(this).find("option").length < 2) {
-            $(this).find("#workspace-select")
-                .prop("disabled", true)
-                .prop("title", "");
-        }
-
-        $(this).find("#workspace-select").change((event) => {
-            event.preventDefault();
-            selectService(event.target.value);
-        });
+        $(this).find(".workspace-service").click(serviceClickCallback);
 
         $(this).find("#flag-input").on("input", function(event) {
             event.preventDefault();

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -169,7 +169,19 @@ function serviceClickCallback(event) {
     const button = $(event.currentTarget);
     const service = button.attr("data-service");
     if (isPopout(context(event))) {
-        window.open(popoutUrl(service), "workspace-" + serviceName(service));
+        const popout = window.open("", "workspace-" + serviceName(service));
+        if (!popout) {
+            animateBanner(event, "Pop-up blocked — please allow pop-ups for this site.", "warn");
+            return;
+        }
+        let needsNavigation = true;
+        try {
+            needsNavigation = popout.location.pathname !== popoutUrl(service);
+        } catch (error) {}
+        if (needsNavigation) {
+            popout.location = popoutUrl(service);
+        }
+        popout.focus();
     }
     else {
         selectService(service);
@@ -353,7 +365,11 @@ function loadWorkspace(log=true) {
     if (isPopout(root)) {
         var service = root.find(".workspace-service").first().attr("data-service");
         if (service) {
+            content.removeClass("SSH");
             loadIframe(service, content[0]);
+        }
+        else {
+            content.attr("src", "").addClass("SSH");
         }
         return;
     }

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -2,7 +2,8 @@
 // 1. There is an iframe for controlled workspace content with the id "workspace-iframe"
 // 2. The actionbar and iframe are descendants of a common ancestor with the class "challenge-workspace"
 // 3. In fullpage mode (data-popout="false"), the page implements a function, doFullscreen(event), to handle a fullscreen event
-// 4. Optionally, the page can have a div with the class "workspace-ssh" which will be displayed when the SSH service is selected.
+// 4. Optionally, the page can have a div with the class "workspace-ssh" which is displayed when the SSH service is
+//    selected (fullpage mode) or toggled in place of the iframe via the portless service button (pop-out mode).
 
 // Returns the controls object containing the origin of the event.
 function context(event) {
@@ -164,28 +165,59 @@ function selectService(service, log=true) {
     loadIframe(service, content);
 }
 
+function portlessButton(root) {
+    return root.find(".workspace-service").filter(function () {
+        return servicePort($(this).attr("data-service")) === "";
+    });
+}
+
+function portedService(root) {
+    var service = null;
+    root.find(".workspace-service").each(function () {
+        const candidate = $(this).attr("data-service");
+        if (service === null && servicePort(candidate) !== "") {
+            service = candidate;
+        }
+    });
+    return service;
+}
+
+function toggleSshInstructions(root, show=null) {
+    const workspace = root.closest(".challenge-workspace");
+    const button = portlessButton(root);
+    const active = show === null ? !button.hasClass("active") : show;
+    button.toggleClass("active", active);
+    workspace.find(".workspace-ssh").toggle(active);
+    workspace.find("#workspace-iframe").toggleClass("SSH", active);
+}
+
 function serviceClickCallback(event) {
     event.preventDefault();
     const button = $(event.currentTarget);
     const service = button.attr("data-service");
-    if (isPopout(context(event))) {
-        const popout = window.open("", "workspace-" + serviceName(service));
-        if (!popout) {
-            animateBanner(event, "Pop-up blocked — please allow pop-ups for this site.", "warn");
-            return;
-        }
-        let needsNavigation = true;
-        try {
-            needsNavigation = popout.location.pathname !== popoutUrl(service);
-        } catch (error) {}
-        if (needsNavigation) {
-            popout.location = popoutUrl(service);
-        }
-        popout.focus();
-    }
-    else {
+    if (!isPopout(context(event))) {
         selectService(service);
+        return;
     }
+    if (servicePort(service) === "") {
+        if (portedService(context(event))) {
+            toggleSshInstructions(context(event));
+        }
+        return;
+    }
+    const popout = window.open("", "workspace-" + serviceName(service));
+    if (!popout) {
+        animateBanner(event, "Pop-up blocked — please allow pop-ups for this site.", "warn");
+        return;
+    }
+    let needsNavigation = true;
+    try {
+        needsNavigation = popout.location.pathname !== popoutUrl(service);
+    } catch (error) {}
+    if (needsNavigation) {
+        popout.location = popoutUrl(service);
+    }
+    popout.focus();
 }
 
 function animateBanner(event, message, type) {
@@ -363,13 +395,14 @@ function loadWorkspace(log=true) {
     }
     var root = content.closest(".challenge-workspace").find(".workspace-controls");
     if (isPopout(root)) {
-        var service = root.find(".workspace-service").first().attr("data-service");
+        const service = portedService(root);
         if (service) {
-            content.removeClass("SSH");
+            toggleSshInstructions(root, portlessButton(root).hasClass("active"));
             loadIframe(service, content[0]);
         }
         else {
-            content.attr("src", "").addClass("SSH");
+            content.attr("src", "");
+            toggleSshInstructions(root, true);
         }
         return;
     }

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -136,9 +136,9 @@ function loadIframe(service, content) {
 
 function popoutUrl(service) {
     if (isSpecialService(service)) {
-        return "/workspace/" + serviceName(service);
+        return "/workspace/" + encodeURIComponent(serviceName(service));
     }
-    return "/workspace/" + servicePort(service);
+    return "/workspace/" + encodeURIComponent(servicePort(service));
 }
 
 function selectService(service, log=true) {
@@ -150,7 +150,9 @@ function selectService(service, log=true) {
     if (log) {logService(service);}
     const root = $(content).closest(".challenge-workspace").find(".workspace-controls");
     root.find(".workspace-service").each(function () {
-        $(this).toggleClass("active", $(this).attr("data-service") === service);
+        const active = $(this).attr("data-service") === service;
+        $(this).toggleClass("active", active);
+        $(this).attr("aria-pressed", active ? "true" : "false");
     });
     if (serviceName(service) == "ssh" && servicePort(service) == "") {
         content.src = "";
@@ -187,6 +189,7 @@ function toggleSshInstructions(root, show=null) {
     const button = portlessButton(root);
     const active = show === null ? !button.hasClass("active") : show;
     button.toggleClass("active", active);
+    button.attr("aria-pressed", active ? "true" : "false");
     workspace.find(".workspace-ssh").toggle(active);
     workspace.find("#workspace-iframe").toggleClass("SSH", active);
 }
@@ -196,6 +199,9 @@ function serviceClickCallback(event) {
     const button = $(event.currentTarget);
     const service = button.attr("data-service");
     if (!isPopout(context(event))) {
+        if (button.hasClass("active")) {
+            return;
+        }
         selectService(service);
         return;
     }
@@ -205,7 +211,7 @@ function serviceClickCallback(event) {
         }
         return;
     }
-    const popout = window.open("", "workspace-" + serviceName(service));
+    const popout = window.open("", "workspace-" + popoutUrl(service).split("/").pop());
     if (!popout) {
         animateBanner(event, "Pop-up blocked — please allow pop-ups for this site.", "warn");
         return;
@@ -244,7 +250,7 @@ function actionSubmitFlag(event) {
         return;
     }
 
-    context(event).find("input").prop("disabled", true).addClass("disabled");
+    context(event).find("#flag-input").prop("disabled", true).addClass("disabled");
     context(event).find(".input-icon").toggleClass("fa-flag fa-spinner fa-spin");
     const challenge_id = parseInt(context(event).find("#current-challenge-id").val());
 
@@ -271,7 +277,7 @@ function actionSubmitFlag(event) {
         else {
             animateBanner(event, "Submission failed.", "warn");
         }
-        context(event).find("input").prop("disabled", false).removeClass("disabled");
+        context(event).find("#flag-input").prop("disabled", false).removeClass("disabled");
         context(event).find(".input-icon").toggleClass("fa-flag fa-spinner fa-spin");
     });
 }
@@ -294,8 +300,26 @@ function postStartChallenge(event, channel) {
     sendChallengeInfo(root, channel);
 }
 
-function actionStartChallenge(event) {
-    const privileged = context(event).find("#workspace-change-privilege").attr("data-privileged") === "true";
+function setActionbarBusy(root, busy) {
+    root.find(".btn-challenge-start")
+        .toggleClass("disabled", busy)
+        .toggleClass("btn-disabled", busy)
+        .prop("disabled", busy);
+    root.find("#workspace-change-privilege input").prop("disabled", busy);
+}
+
+function actionStartChallenge(event, privileged) {
+    const root = context(event);
+    const privilegeControl = root.find("#workspace-change-privilege");
+    if (privileged === undefined) {
+        privileged = privilegeControl.attr("data-privileged") === "true";
+    }
+
+    function startFailed(message) {
+        setActionbarBusy(root, false);
+        privilegeControl.find("input").prop("checked", privilegeControl.attr("data-privileged") === "true");
+        animateBanner(event, message || "Failed to start challenge.", "error");
+    }
 
     CTFd.fetch("/pwncollege_api/v1/docker", {
         method: "GET",
@@ -313,6 +337,7 @@ function actionStartChallenge(event) {
         return response.json();
     }).then(function (result) {
         if (result.success == false) {
+            startFailed(result.error);
             return;
         }
 
@@ -323,7 +348,7 @@ function actionStartChallenge(event) {
             "practice": privileged,
         };
 
-        CTFd.fetch('/pwncollege_api/v1/docker', {
+        return CTFd.fetch('/pwncollege_api/v1/docker', {
             method: 'POST',
             credentials: 'same-origin',
             headers: {
@@ -332,43 +357,30 @@ function actionStartChallenge(event) {
             },
             body: JSON.stringify(params)
         }).then(function (response) {
-            return response.json;
+            return response.json();
         }).then(function (result) {
             if (result.success == false) {
+                startFailed(result.error);
                 return;
             }
 
-            refreshWorkspace(context(event));
+            privilegeControl.attr("data-privileged", privileged ? "true" : "false");
+            privilegeControl.find("input").prop("checked", privileged);
+
+            refreshWorkspace(root);
             postStartChallenge(event, channel);
 
-            context(event).find(".btn-challenge-start")
-            .removeClass("disabled")
-            .removeClass("btn-disabled")
-            .prop("disabled", false);
-            context(event).find("#workspace-change-privilege input").prop("disabled", false);
-        })
+            setActionbarBusy(root, false);
+        });
+    }).catch(function () {
+        startFailed();
     });
 }
 
 function actionStartCallback(event) {
     event.preventDefault();
-
-    context(event).find(".btn-challenge-start")
-    .addClass("disabled")
-    .addClass("btn-disabled")
-    .prop("disabled", true);
-
-    if (context(event).find("#challenge-restart")[0].contains(event.target)) {
-        actionStartChallenge(event);
-    }
-    else {
-        console.log("Failed to start challenge.");
-
-        context(event).find(".btn-challenge-start")
-        .removeClass("disabled")
-        .removeClass("btn-disabled")
-        .prop("disabled", false);
-    }
+    setActionbarBusy(context(event), true);
+    actionStartChallenge(event);
 }
 
 function privilegeChangeCallback(event) {
@@ -378,14 +390,8 @@ function privilegeChangeCallback(event) {
         checkbox.checked = !checkbox.checked;
         return;
     }
-    context(event).find("#workspace-change-privilege")
-        .attr("data-privileged", checkbox.checked ? "true" : "false");
-    context(event).find(".btn-challenge-start")
-        .addClass("disabled")
-        .addClass("btn-disabled")
-        .prop("disabled", true);
-    checkbox.disabled = true;
-    actionStartChallenge(event);
+    setActionbarBusy(context(event), true);
+    actionStartChallenge(event, checkbox.checked);
 }
 
 function loadWorkspace(log=true) {

--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -268,11 +268,9 @@ function startChallenge(event) {
             item.find(".challenge-init").addClass("challenge-hidden");
             item.find(".challenge-workspace").removeClass("challenge-hidden");
             item.find("#workspace-change-privilege")
-                .attr("title", practice ? "Restart unprivileged" : "Restart privileged")
                 .attr("data-privileged", practice)
-                .find(".fas")
-                    .toggleClass("fa-lock", !practice)
-                    .toggleClass("fa-unlock", practice);
+                .find("input")
+                    .prop("checked", practice);
             windowResizeCallback("");
             moduleStartChallenge(event, channel);
         }
@@ -385,7 +383,7 @@ $(() => {
                 var priv = $(item).find("#workspace-change-privilege");
                 if (priv.length > 0) {
                     priv.attr("data-privileged", event.data["challenge-privilege"]);
-                    displayPrivileged({"target": priv[0]}, false);
+                    priv.find("input").prop("checked", event.data["challenge-privilege"] === "true");
                 }
 
                 refreshWorkspace($(item));

--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -367,44 +367,8 @@ function markChallengeAsSolved(item) {
         .catch(error => console.error("Award check failed:", error));
 }
 
-var scroll_pos_x;
-var scroll_pos_y;
-
-function scrollDisable() {
-    scroll_pos_x = window.pageXOffset;
-    scroll_pos_y = window.pageYOffset;
-    document.body.classList.add("scroll-disabled");
-}
-
-function scrollRestore() {
-    document.body.classList.remove("scroll-disabled");
-    window.pageXOffset = scroll_pos_x;
-    window.pageYOffset = scroll_pos_y;
-}
-
-function contentExpand(event) {
-    $(event.target).closest(".challenge-workspace").addClass("workspace-fullscreen");
-    $(".challenge-iframe").addClass("challenge-iframe-fs");
-    scrollDisable();
-}
-
-function contentContract(event) {
-    $(event.target).closest(".challenge-workspace").removeClass("workspace-fullscreen");
-    $(".challenge-iframe").removeClass("challenge-iframe-fs");
-    scrollRestore();
-}
-
-function doFullscreen(event) {
-    if ($(".workspace-fullscreen")[0]) {
-        contentContract(event);
-    }
-    else {
-        contentExpand(event);
-    }
-}
-
 function windowResizeCallback(event) {
-    $(".challenge-iframe").not(".challenge-iframe-fs").css("aspect-ratio", `${window.innerWidth} / ${window.innerHeight}`);
+    $(".challenge-iframe").css("aspect-ratio", `${window.innerWidth} / ${window.innerHeight}`);
 }
 
 function moduleStartChallenge(event, channel) {
@@ -424,7 +388,7 @@ $(() => {
                     displayPrivileged({"target": priv[0]}, false);
                 }
 
-                selectService($(item).find("#workspace-select").prop("value"), log=false);
+                refreshWorkspace($(item));
             }
         })
     });

--- a/dojo_theme/static/js/dojo/navbar.js
+++ b/dojo_theme/static/js/dojo/navbar.js
@@ -1,35 +1,3 @@
-const broadcast = new BroadcastChannel('broadcast');
-
-broadcast.onmessage = (event) => {
-    if (event.data.msg === 'New challenge started') {
-        if (window.location.pathname === '/workspace/code') {
-            window.location.reload();
-        }
-        else if (window.location.pathname === '/workspace/desktop') {
-            get_and_set_iframe_url()
-        }
-    }
-};
-function get_and_set_iframe_url() {
-    // check if the window location pathname starts with /workspace/ and set the rest of the path as an variable service
-    const service = window.location.pathname.startsWith('/workspace/') ? window.location.pathname.substring(11) : '';
-    fetch("/pwncollege_api/v1/workspace?service=" + service)
-        .then(response => response.json())
-        .then(data => {
-            if (data.active) {
-                const iframe = $("#workspace_iframe")[0];
-                if (iframe.src !== window.location.origin + data.iframe_src) {
-                    const url = new URL(data.iframe_src);
-                    if (data.setPort) {
-                        url.port = window.location.port;
-                    }
-
-                    iframe.src = url.toString();
-                }
-            }
-        });
-}
-
 $(() => {
     $("#show_description").click((event) =>{
         $("#dropdown-description").toggle();

--- a/dojo_theme/static/js/dojo/workspace.js
+++ b/dojo_theme/static/js/dojo/workspace.js
@@ -17,32 +17,6 @@ function doFullscreen() {
     }
 }
 
-function updateWorkspace(data) {
-    $("#current-challenge-id").prop("value", data["challenge-id"])
-                              .attr("data-challenge-name", data["challenge-name"]);
-    
-    var priv = $("#workspace-change-privilege");
-    if (priv.length > 0) {
-        priv.attr("data-privileged", data["challenge-privilege"]);
-        displayPrivileged({"target": priv[0]}, false);
-    }
-
-    var selector = $("#workspace-select");
-    var current = selector.prop("value");
-    var loadedService = false;
-    selector.empty();
-    data.options.forEach((item, index) => {
-        selector.append($("<option></option>").attr("value", item.value).text(item.text))
-        if (item.value == current) {
-            selector.prop("value", item.value)
-            selectService(item.value, log=true);
-            loadedService = true;
-        }
-    })
-    if (!loadedService) {loadWorkspace(log=false);}
-    selector.prop("disabled", data.options.length < 2);
-}
-
 $(() => {
     if (new URLSearchParams(window.location.search).has("hide-navbar")) {
         hideNavbar();
@@ -51,6 +25,6 @@ $(() => {
     $("footer").hide();
 
     channel.addEventListener("message", (event) => {
-        updateWorkspace(event.data);
+        window.location.reload();
     });
 })

--- a/dojo_theme/templates/components/actionbar.html
+++ b/dojo_theme/templates/components/actionbar.html
@@ -123,6 +123,11 @@
     cursor: pointer;
   }
 
+  label#workspace-change-privilege input:focus-visible {
+    outline: 0;
+    box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5);
+  }
+
   label#workspace-change-privilege input:checked {
     background-color: var(--brand-green);
     border-color: var(--brand-green);
@@ -204,6 +209,7 @@
   {% set service_key = service.name | lower %}
   <button class="workspace-control workspace-service btn btn-md btn-outline-secondary"
       data-service="{{ service_key }}: {{ service.port }}"
+      aria-pressed="false"
       title="{% if not popout %}Switch to {{ service.name }}{% elif service.port %}Open {{ service.name }} in a new tab{% else %}Show {{ service.name }} connection info{% endif %}">
     <i class="fas {{ service_icons.get(service_key, 'fa-network-wired') }}"></i>
     <span class="workspace-service-name">{{ service.name }}</span>

--- a/dojo_theme/templates/components/actionbar.html
+++ b/dojo_theme/templates/components/actionbar.html
@@ -54,7 +54,12 @@
 
   .workspace-service.active {
     color: #fff;
+    background-color: var(--foreground) !important;
     box-shadow: inset 0 0 0 1px var(--highlight) !important;
+  }
+
+  .workspace-service.active:focus {
+    box-shadow: inset 0 0 0 1px var(--highlight), 0 0 0 0.2rem rgba(108, 117, 125, 0.5) !important;
   }
 
   .workspace-control input {

--- a/dojo_theme/templates/components/actionbar.html
+++ b/dojo_theme/templates/components/actionbar.html
@@ -46,7 +46,8 @@
     margin-left: 0.4em;
   }
 
-  .workspace-service .popout-icon {
+  .workspace-service .popout-icon,
+  .workspace-service .hint-icon {
     margin-left: 0.5em;
     font-size: 0.7em;
     opacity: 0.6;
@@ -171,15 +172,14 @@
   <div id="workspace-notification-banner"></div>
   {% for service in challenge.interfaces %}
   {% set service_key = service.name | lower %}
-  {% if not popout or service.port %}
   <button class="workspace-control workspace-service btn btn-md btn-outline-secondary"
       data-service="{{ service_key }}: {{ service.port }}"
-      title="{% if popout %}Open {{ service.name }} in a new tab{% else %}Switch to {{ service.name }}{% endif %}">
+      title="{% if not popout %}Switch to {{ service.name }}{% elif service.port %}Open {{ service.name }} in a new tab{% else %}Show {{ service.name }} connection info{% endif %}">
     <i class="fas {{ service_icons.get(service_key, 'fa-network-wired') }}"></i>
     <span class="workspace-service-name">{{ service.name }}</span>
-    {% if popout %}<i class="fas fa-external-link-alt popout-icon"></i>{% endif %}
+    {% if popout and service.port %}<i class="fas fa-external-link-alt popout-icon"></i>{% endif %}
+    {% if popout and not service.port %}<i class="fas fa-question-circle hint-icon"></i>{% endif %}
   </button>
-  {% endif %}
   {% endfor %}
   <div title="Enter flag" class="workspace-control workspace-input">
     <i class="fas fa-flag workspace-highlight input-icon"></i>

--- a/dojo_theme/templates/components/actionbar.html
+++ b/dojo_theme/templates/components/actionbar.html
@@ -102,6 +102,35 @@
     flex: 1;
   }
 
+  label#workspace-change-privilege {
+    display: flex;
+    align-items: center;
+    width: auto;
+    margin-bottom: 0;
+    padding-left: 0.75em;
+    padding-right: 0.75em;
+    cursor: pointer;
+  }
+
+  label#workspace-change-privilege input {
+    appearance: none;
+    width: 1.05em;
+    height: 1.05em;
+    margin: 0 0.45em 0 0;
+    border: 1px solid var(--highlight);
+    border-radius: 0.25em;
+    background-color: var(--background);
+    cursor: pointer;
+  }
+
+  label#workspace-change-privilege input:checked {
+    background-color: var(--highlight);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='none' stroke='%23fff' stroke-width='3' d='M2.5 8.5l4 4 7-8'/%3E%3C/svg%3E");
+    background-size: 0.8em;
+    background-position: center;
+    background-repeat: no-repeat;
+  }
+
   .workspace-ssh {
     padding: 1em;
     margin-bottom: 1em;
@@ -191,12 +220,13 @@
     <i class="fas fa-redo"></i>
   </button>
   {% if challenge.allow_privileged %}
-  <button id="workspace-change-privilege"
-      title="Restart {{'unprivileged' if practice else 'privileged'}}"
-      class="workspace-control btn btn-md btn-outline-secondary btn-challenge-start"
+  <label id="workspace-change-privilege"
+      title="Restart the challenge with or without sudo access"
+      class="workspace-control btn btn-md btn-outline-secondary"
       data-privileged="{{'true' if practice else 'false'}}">
-    <i class="fas fa-{{'unlock' if practice else 'lock'}}"></i>
-  </button>
+    <input type="checkbox" {{'checked' if practice}}>
+    <span>sudo</span>
+  </label>
   {% endif %}
   {% if not popout %}
   <button id="fullscreen" title="Toggle fullscreen" class="workspace-control btn btn-md btn-outline-secondary">

--- a/dojo_theme/templates/components/actionbar.html
+++ b/dojo_theme/templates/components/actionbar.html
@@ -197,7 +197,7 @@
   }
 </style>
 
-{% set service_icons = {"terminal": "fa-terminal", "code": "fa-code", "desktop": "fa-desktop", "ssh": "fa-key"} %}
+{% set service_icons = {"terminal": "fa-terminal", "code": "fa-code", "desktop": "fa-desktop", "ssh": "fa-key", "lecture": "fa-video"} %}
 <div class="workspace-controls" data-popout="{{ 'true' if popout else 'false' }}">
   <div id="workspace-notification-banner"></div>
   {% for service in challenge.interfaces %}

--- a/dojo_theme/templates/components/actionbar.html
+++ b/dojo_theme/templates/components/actionbar.html
@@ -63,7 +63,7 @@
     box-shadow: inset 0 0 0 1px var(--highlight), 0 0 0 0.2rem rgba(108, 117, 125, 0.5) !important;
   }
 
-  .workspace-control input {
+  .workspace-input input {
     height: 100% !important;
     box-sizing: border-box;
     padding-left: 0.5em;
@@ -76,17 +76,17 @@
     box-shadow: none !important;
   }
 
-  .workspace-control input::placeholder {
+  .workspace-input input::placeholder {
     color: var(--highlight);
     opacity: 1;
   }
 
-  .workspace-control input.disabled {
+  .workspace-input input.disabled {
     color: var(--highlight);
   }
 
-  .workspace-control input:focus,
-  .workspace-control input:hover {
+  .workspace-input input:focus,
+  .workspace-input input:hover {
     outline: 0 !important;
   }
 
@@ -114,19 +114,20 @@
 
   label#workspace-change-privilege input {
     appearance: none;
-    width: 1.05em;
-    height: 1.05em;
+    width: 1.2em;
+    height: 1.2em;
     margin: 0 0.45em 0 0;
-    border: 1px solid var(--highlight);
+    border: 2px solid #adb5bd;
     border-radius: 0.25em;
-    background-color: var(--background);
+    background-color: transparent;
     cursor: pointer;
   }
 
   label#workspace-change-privilege input:checked {
-    background-color: var(--highlight);
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='none' stroke='%23fff' stroke-width='3' d='M2.5 8.5l4 4 7-8'/%3E%3C/svg%3E");
-    background-size: 0.8em;
+    background-color: var(--brand-green);
+    border-color: var(--brand-green);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='none' stroke='%23111' stroke-width='3' d='M2.5 8.5l4 4 7-8'/%3E%3C/svg%3E");
+    background-size: 0.85em;
     background-position: center;
     background-repeat: no-repeat;
   }

--- a/dojo_theme/templates/components/actionbar.html
+++ b/dojo_theme/templates/components/actionbar.html
@@ -10,6 +10,7 @@
   .SSH {
     height: 0 !important;
     min-height: 0 !important;
+    flex: none !important;
   }
 
   .workspace-controls {
@@ -35,6 +36,27 @@
     justify-content: center;
   }
 
+  button.workspace-control.workspace-service {
+    width: auto;
+    padding-left: 0.75em;
+    padding-right: 0.75em;
+  }
+
+  .workspace-service .workspace-service-name {
+    margin-left: 0.4em;
+  }
+
+  .workspace-service .popout-icon {
+    margin-left: 0.5em;
+    font-size: 0.7em;
+    opacity: 0.6;
+  }
+
+  .workspace-service.active {
+    color: #fff;
+    box-shadow: inset 0 0 0 1px var(--highlight) !important;
+  }
+
   .workspace-control input {
     height: 100% !important;
     box-sizing: border-box;
@@ -57,23 +79,9 @@
     color: var(--highlight);
   }
 
-  .workspace-control select,
   .workspace-control input:focus,
   .workspace-control input:hover {
     outline: 0 !important;
-  }
-
-  .workspace-control select {
-    height: 100%;
-    padding-left: 1.5rem;
-    border: 0;
-    background-color: transparent;
-    color: var(--highlight);
-    font-weight: 700;
-    appearance: none;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    z-index: 2;
   }
 
   .workspace-highlight {
@@ -84,17 +92,15 @@
     padding-left: 1em;
   }
 
-  .workspace-selector-body {
-    padding-left: 1em;
-    padding-right: 1em;
-    position: relative;
-    display: flex;
-    align-items: center;
-    z-index: 1;
-  }
-
   .workspace-control-spacer {
     flex: 1;
+  }
+
+  .workspace-ssh {
+    padding: 1em;
+    margin-bottom: 1em;
+    background-color: var(--foreground);
+    border-radius: 0.5em;
   }
 
   @keyframes banner-animation {
@@ -153,23 +159,23 @@
     overflow: hidden;
     display: none;
   }
-
-  .burger {
-    position: absolute;
-    z-index: 1;
-  }
 </style>
 
-<div class="workspace-controls">
+{% set service_icons = {"terminal": "fa-terminal", "code": "fa-code", "desktop": "fa-desktop", "ssh": "fa-key"} %}
+<div class="workspace-controls" data-popout="{{ 'true' if popout else 'false' }}">
   <div id="workspace-notification-banner"></div>
-  <div title="Change workspace" class="workspace-selector-body workspace-control">
-    <i class="fas fa-bars workspace-highlight burger"></i>
-    <select id="workspace-select">
-      {% for service in challenge.interfaces %}
-      <option value="{{ service.name | lower }}: {{ service.port }}">&#160;&#160;{{ service.name }}</option><!-- I hate it :( -->
-      {% endfor %}
-    </select>
-  </div>
+  {% for service in challenge.interfaces %}
+  {% set service_key = service.name | lower %}
+  {% if not popout or service.port %}
+  <button class="workspace-control workspace-service btn btn-md btn-outline-secondary"
+      data-service="{{ service_key }}: {{ service.port }}"
+      title="{% if popout %}Open {{ service.name }} in a new tab{% else %}Switch to {{ service.name }}{% endif %}">
+    <i class="fas {{ service_icons.get(service_key, 'fa-network-wired') }}"></i>
+    <span class="workspace-service-name">{{ service.name }}</span>
+    {% if popout %}<i class="fas fa-external-link-alt popout-icon"></i>{% endif %}
+  </button>
+  {% endif %}
+  {% endfor %}
   <div title="Enter flag" class="workspace-control workspace-input">
     <i class="fas fa-flag workspace-highlight input-icon"></i>
     <input id="flag-input" type="text" placeholder="Flag">
@@ -187,7 +193,9 @@
     <i class="fas fa-{{'unlock' if practice else 'lock'}}"></i>
   </button>
   {% endif %}
+  {% if not popout %}
   <button id="fullscreen" title="Toggle fullscreen" class="workspace-control btn btn-md btn-outline-secondary">
     <i class="fas fa-expand"></i>
   </button>
+  {% endif %}
 </div>

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -226,7 +226,7 @@
                 <iframe id="workspace-iframe" class="challenge-iframe" src="" allow="clipboard-read *; clipboard-write *"></iframe>
                 {% endif %}
               </div>
-              <div class="workspace-ssh">
+              <div class="workspace-ssh" style="display: none;">
                 <h3>Connect with SSH</h3>
                 Link your <a href="/settings#ssh-key" target="_blank">SSH key</a>, then connect with: <code>ssh hacker@dojo.pwn.college</code>
               </div>

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -6,10 +6,6 @@
 {{ super() }}
 
 <style>
-.scroll-disabled {
-  overflow: hidden;
-}
-
 .challenge-workspace {
   margin-bottom: 16px;
   margin-top: 16px;
@@ -23,11 +19,6 @@
   border: 0;
 }
 
-.challenge-iframe-fs {
-  aspect-ratio: unset !important;
-  height: calc(100vh - 2.5em - 10px);
-}
-
 .challenge-init {
   height: 100% !important;
   width: 100% !important;
@@ -37,30 +28,6 @@
   visibility: hidden;
   max-height: 0 !important;
 }
-
-.workspace-fullscreen {
-  display: flex;
-  flex-direction: column;
-  position: fixed;
-  z-index: 1031;/* Navbar z-index + 1 */
-  bottom: -16px;
-  right: 0;
-  background-color: #111;
-  width: 100% !important;
-  height: 100% !important;
-}
-
-.workspace-fullscreen .iframe-wrapper {
-  display: flex;
-}
-
-.workspace-ssh {
-  padding: 1em;
-  margin-bottom: 1em;
-  background-color: var(--foreground);
-  border-radius: 0.5em;
-}
-
 
 .challenge-hidden .workspace-ssh {
   display: none !important;
@@ -263,7 +230,9 @@
                 <h3>Connect with SSH</h3>
                 Link your <a href="/settings#ssh-key" target="_blank">SSH key</a>, then connect with: <code>ssh hacker@dojo.pwn.college</code>
               </div>
+              {% with popout=true %}
               {% include "components/actionbar.html" %}
+              {% endwith %}
             </div>
             <div class="row notification-row">
               <div class="col-md-12">

--- a/dojo_theme/templates/workspace.html
+++ b/dojo_theme/templates/workspace.html
@@ -40,6 +40,11 @@
         display:flex;
         flex-direction: column;
     }
+
+    .workspace-ssh {
+        flex: none;
+        margin: 1em;
+    }
 </style>
 {% endblock %}
 
@@ -47,6 +52,10 @@
 {% block content %}
 <div class="challenge-workspace">
   <iframe src="" id="workspace-iframe" allow="clipboard-read *; clipboard-write *"></iframe>
+  <div class="workspace-ssh" style="display: none;">
+    <h3>Connect with SSH</h3>
+    Link your <a href="/settings#ssh-key" target="_blank">SSH key</a>, then connect with: <code>ssh hacker@dojo.pwn.college</code>
+  </div>
   {% include "components/actionbar.html" %}
 </div>
 {% endblock %}

--- a/dojo_theme/templates/workspace_port.html
+++ b/dojo_theme/templates/workspace_port.html
@@ -39,12 +39,15 @@
     name="{{ iframe_name }}"
     src=""
     class="d-none"
+    allow="clipboard-read *; clipboard-write *"
 ></iframe>
 <h1 class="inactive">Loading...</h1>
 
 {% endblock %} {% block scripts %} {{ super() }}
 
 <script>
+    const channel = new BroadcastChannel("Challenge-Sync-Channel");
+    channel.addEventListener("message", () => window.location.reload());
     let response = fetch("/pwncollege_api/v1/workspace?port={{ port }}")
         .then((response) => response.json())
         .then((data) => {

--- a/dojo_theme/templates/workspace_service.html
+++ b/dojo_theme/templates/workspace_service.html
@@ -39,12 +39,15 @@
     name="{{ iframe_name }}"
     src=""
     class="d-none"
+    allow="clipboard-read *; clipboard-write *"
 ></iframe>
 <h1 class="inactive">Loading...</h1>
 
 {% endblock %} {% block scripts %} {{ super() }}
 
 <script>
+    const channel = new BroadcastChannel("Challenge-Sync-Channel");
+    channel.addEventListener("message", () => window.location.reload());
     let response = fetch("/pwncollege_api/v1/workspace?service={{ service }}")
         .then((response) => response.json())
         .then((data) => {

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -243,7 +243,9 @@ def browser_fixture():
     options.add_argument("--headless")
     geckodriver = shutil.which("geckodriver")
     service = FirefoxService(executable_path=geckodriver) if geckodriver else None
-    return Firefox(options=options, service=service)
+    browser = Firefox(options=options, service=service)
+    yield browser
+    browser.quit()
 
 @pytest.fixture
 def random_user_browser(browser_fixture, random_user_name):

--- a/test/dojos/custom_interfaces.yml
+++ b/test/dojos/custom_interfaces.yml
@@ -21,6 +21,15 @@ modules:
         interfaces:
         - name: Terminal
           port: 7681
+      - id: test4
+        name: test4
+        interfaces:
+        - name: Web
+          port: 80
+      - id: test5
+        name: test5
+        interfaces:
+        - name: SSH
 files:
   - type: text
     path: test/test1/test
@@ -34,6 +43,16 @@ files:
       cat /flag
   - type: text
     path: test/test3/test
+    content: |
+      #!/opt/pwn.college/bash
+      cat /flag
+  - type: text
+    path: test/test4/test
+    content: |
+      #!/opt/pwn.college/bash
+      cat /flag
+  - type: text
+    path: test/test5/test
     content: |
       #!/opt/pwn.college/bash
       cat /flag

--- a/test/dojos/custom_interfaces.yml
+++ b/test/dojos/custom_interfaces.yml
@@ -30,6 +30,11 @@ modules:
         name: test5
         interfaces:
         - name: SSH
+      - id: test6
+        name: test6
+        interfaces:
+        - name: Lecture
+          port: 80
 files:
   - type: text
     path: test/test1/test
@@ -53,6 +58,11 @@ files:
       cat /flag
   - type: text
     path: test/test5/test
+    content: |
+      #!/opt/pwn.college/bash
+      cat /flag
+  - type: text
+    path: test/test6/test
     content: |
       #!/opt/pwn.college/bash
       cat /flag

--- a/test/test_welcome.py
+++ b/test/test_welcome.py
@@ -220,7 +220,7 @@ def test_interface_inherit(random_user_browser, random_user_name, interfaces_doj
     idx = challenge_idx(random_user_browser, "test1")
     interfaces = get_interfaces(random_user_browser, idx)
 
-    values = ["terminal: 7681"]
+    values = ["ssh: ", "terminal: 7681"]
     match_interfaces(interfaces, values)
 
 def test_interface_chal_override(random_user_browser, random_user_name, interfaces_dojo):
@@ -304,13 +304,63 @@ def test_actionbar_ssh_only_challenge(random_user_browser, random_user_name, int
     idx = challenge_idx(random_user_browser, "test5")
     challenge_start(random_user_browser, idx)
     body = random_user_browser.find_element("id", f"challenges-body-{idx}")
-    assert not body.find_elements(By.CSS_SELECTOR, ".workspace-service")
-    assert body.find_element(By.CSS_SELECTOR, ".workspace-ssh").is_displayed()
+    buttons = body.find_elements(By.CSS_SELECTOR, ".workspace-service")
+    assert [button.get_attribute("data-service") for button in buttons] == ["ssh: "]
 
     wait = WebDriverWait(random_user_browser, 30)
     iframe = wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, f"#challenges-body-{idx} #workspace-iframe")))
     wait.until(lambda driver: "SSH" in (iframe.get_attribute("class") or ""))
     assert iframe.size["height"] == 0
+    assert body.find_element(By.CSS_SELECTOR, ".workspace-ssh").is_displayed()
+    assert "active" in buttons[0].get_attribute("class")
+
+    buttons[0].click()
+    time.sleep(1)
+    assert body.find_element(By.CSS_SELECTOR, ".workspace-ssh").is_displayed()
+    assert "active" in buttons[0].get_attribute("class")
+    assert "SSH" in (iframe.get_attribute("class") or "")
+    random_user_browser.close()
+
+def test_actionbar_ssh_toggle(random_user_browser, random_user_name, interfaces_dojo):
+    random_user_browser.get(f"{DOJO_URL}/testing-interfaces/test")
+    idx = challenge_idx(random_user_browser, "test1")
+    challenge_start(random_user_browser, idx)
+    body = random_user_browser.find_element("id", f"challenges-body-{idx}")
+    wait = WebDriverWait(random_user_browser, 30)
+    iframe = wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, f"#challenges-body-{idx} #workspace-iframe")))
+    wait.until(lambda driver: "/7681/" in (iframe.get_attribute("src") or ""))
+
+    ssh_button = body.find_element(By.CSS_SELECTOR, '.workspace-service[data-service="ssh: "]')
+    terminal_button = body.find_element(By.CSS_SELECTOR, '.workspace-service[data-service="terminal: 7681"]')
+    assert ssh_button.find_elements(By.CSS_SELECTOR, ".hint-icon")
+    assert not ssh_button.find_elements(By.CSS_SELECTOR, ".popout-icon")
+    assert terminal_button.find_elements(By.CSS_SELECTOR, ".popout-icon")
+    assert not terminal_button.find_elements(By.CSS_SELECTOR, ".hint-icon")
+
+    ssh_box = body.find_element(By.CSS_SELECTOR, ".workspace-ssh")
+    assert not ssh_box.is_displayed()
+    handles = len(random_user_browser.window_handles)
+
+    ssh_button.click()
+    wait.until(lambda driver: ssh_box.is_displayed())
+    assert "active" in ssh_button.get_attribute("class")
+    assert "SSH" in (iframe.get_attribute("class") or "")
+    assert iframe.size["height"] == 0
+    assert len(random_user_browser.window_handles) == handles
+
+    restart_button = body.find_element(By.CSS_SELECTOR, "#challenge-restart")
+    restart_button.click()
+    wait.until(lambda driver: restart_button.get_attribute("disabled") is None)
+    time.sleep(1)
+    assert ssh_box.is_displayed()
+    assert "active" in ssh_button.get_attribute("class")
+    assert "SSH" in (iframe.get_attribute("class") or "")
+
+    ssh_button.click()
+    wait.until(lambda driver: not ssh_box.is_displayed())
+    assert "active" not in ssh_button.get_attribute("class")
+    assert "SSH" not in (iframe.get_attribute("class") or "")
+    assert "/7681/" in (iframe.get_attribute("src") or "")
     random_user_browser.close()
 
 def test_actionbar_popout_mode(random_user_browser, random_user_name, interfaces_dojo):
@@ -323,10 +373,10 @@ def test_actionbar_popout_mode(random_user_browser, random_user_name, interfaces
     assert controls.get_attribute("data-popout") == "true"
     assert not controls.find_elements(By.ID, "fullscreen")
     assert not body.find_elements(By.ID, "workspace-select")
-    assert body.find_element(By.CSS_SELECTOR, ".workspace-ssh").is_displayed()
+    assert not body.find_element(By.CSS_SELECTOR, ".workspace-ssh").is_displayed()
 
     buttons = controls.find_elements(By.CSS_SELECTOR, ".workspace-service")
-    assert [button.get_attribute("data-service") for button in buttons] == ["terminal: 7681"]
+    assert [button.get_attribute("data-service") for button in buttons] == ["ssh: ", "terminal: 7681"]
 
     wait = WebDriverWait(random_user_browser, 30)
     iframe = wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, f"#challenges-body-{idx} #workspace-iframe")))

--- a/test/test_welcome.py
+++ b/test/test_welcome.py
@@ -239,6 +239,80 @@ def test_interface_chal_narrow(random_user_browser, random_user_name, interfaces
     values = ["terminal: 7681"]
     match_interfaces(interfaces, values)
 
+    challenge_start(random_user_browser, idx)
+    random_user_browser.get(f"{DOJO_URL}/workspace")
+    controls = random_user_browser.find_element(By.CSS_SELECTOR, ".workspace-controls")
+    services = [button.get_attribute("data-service") for button in controls.find_elements(By.CSS_SELECTOR, ".workspace-service")]
+    assert services == ["terminal: 7681"]
+    random_user_browser.close()
+
+def test_actionbar_service_buttons(random_user_browser, random_user_name, interfaces_dojo):
+    random_user_browser.get(f"{DOJO_URL}/testing-interfaces/test")
+    idx = challenge_idx(random_user_browser, "test1")
+    challenge_start(random_user_browser, idx)
+    body = random_user_browser.find_element("id", f"challenges-body-{idx}")
+    module_handle = random_user_browser.current_window_handle
+    handles = set(random_user_browser.window_handles)
+    wait = WebDriverWait(random_user_browser, 30)
+
+    body.find_element(By.CSS_SELECTOR, '.workspace-service[data-service="terminal: 7681"]').click()
+    wait.until(lambda driver: len(driver.window_handles) == len(handles) + 1)
+    popout_handle = (set(random_user_browser.window_handles) - handles).pop()
+    random_user_browser.switch_to.window(popout_handle)
+    wait.until(lambda driver: driver.current_url.rstrip("/").endswith("/workspace/terminal"))
+
+    random_user_browser.switch_to.window(module_handle)
+    random_user_browser.find_element("id", f"challenges-body-{idx}") \
+        .find_element(By.CSS_SELECTOR, '.workspace-service[data-service="terminal: 7681"]').click()
+    time.sleep(2)
+    assert len(random_user_browser.window_handles) == len(handles) + 1
+
+    random_user_browser.get(f"{DOJO_URL}/workspace")
+    controls = random_user_browser.find_element(By.CSS_SELECTOR, ".workspace-controls")
+    terminal_button = controls.find_element(By.CSS_SELECTOR, '.workspace-service[data-service="terminal: 7681"]')
+    terminal_button.click()
+    wait.until(lambda driver: "/7681/" in (driver.find_element(By.ID, "workspace-iframe").get_attribute("src") or ""))
+    assert "active" in terminal_button.get_attribute("class")
+    assert not random_user_browser.find_element(By.CSS_SELECTOR, ".workspace-ssh").is_displayed()
+
+    controls.find_element(By.CSS_SELECTOR, '.workspace-service[data-service="ssh: "]').click()
+    wait.until(lambda driver: driver.find_element(By.CSS_SELECTOR, ".workspace-ssh").is_displayed())
+    assert "SSH" in random_user_browser.find_element(By.ID, "workspace-iframe").get_attribute("class")
+
+    random_user_browser.switch_to.window(popout_handle)
+    random_user_browser.close()
+    random_user_browser.switch_to.window(module_handle)
+    random_user_browser.close()
+
+def test_actionbar_port_popout(random_user_browser, random_user_name, interfaces_dojo):
+    random_user_browser.get(f"{DOJO_URL}/testing-interfaces/test")
+    idx = challenge_idx(random_user_browser, "test4")
+    challenge_start(random_user_browser, idx)
+    body = random_user_browser.find_element("id", f"challenges-body-{idx}")
+    handles = set(random_user_browser.window_handles)
+    wait = WebDriverWait(random_user_browser, 30)
+
+    body.find_element(By.CSS_SELECTOR, '.workspace-service[data-service="web: 80"]').click()
+    wait.until(lambda driver: len(driver.window_handles) == len(handles) + 1)
+    popout_handle = (set(random_user_browser.window_handles) - handles).pop()
+    random_user_browser.switch_to.window(popout_handle)
+    wait.until(lambda driver: driver.current_url.rstrip("/").endswith("/workspace/80"))
+    random_user_browser.close()
+
+def test_actionbar_ssh_only_challenge(random_user_browser, random_user_name, interfaces_dojo):
+    random_user_browser.get(f"{DOJO_URL}/testing-interfaces/test")
+    idx = challenge_idx(random_user_browser, "test5")
+    challenge_start(random_user_browser, idx)
+    body = random_user_browser.find_element("id", f"challenges-body-{idx}")
+    assert not body.find_elements(By.CSS_SELECTOR, ".workspace-service")
+    assert body.find_element(By.CSS_SELECTOR, ".workspace-ssh").is_displayed()
+
+    wait = WebDriverWait(random_user_browser, 30)
+    iframe = wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, f"#challenges-body-{idx} #workspace-iframe")))
+    wait.until(lambda driver: "SSH" in (iframe.get_attribute("class") or ""))
+    assert iframe.size["height"] == 0
+    random_user_browser.close()
+
 def test_actionbar_popout_mode(random_user_browser, random_user_name, interfaces_dojo):
     random_user_browser.get(f"{DOJO_URL}/testing-interfaces/test")
     idx = challenge_idx(random_user_browser, "test1")

--- a/test/test_welcome.py
+++ b/test/test_welcome.py
@@ -4,7 +4,7 @@ import string
 import random
 
 import pytest
-from selenium.common.exceptions import NoSuchElementException
+from selenium.common.exceptions import NoSuchElementException, TimeoutException
 from selenium.webdriver import Firefox, FirefoxOptions
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
@@ -47,8 +47,19 @@ def vscode_terminal(browser):
 
     surface = wait_for_selector(".monaco-workbench", "div.getting-started-step", "button.getting-started-step")
     surface.click()
-    ActionChains(browser).key_down(Keys.CONTROL).key_down(Keys.SHIFT).send_keys("`").key_up(Keys.SHIFT).key_up(Keys.CONTROL).perform()
-    terminal = wait_for_selector("textarea.xterm-helper-textarea")
+    terminal = None
+    for _ in range(5):
+        # The Getting Started webview steals focus into a cross-origin iframe, swallowing keybindings.
+        browser.execute_script("if (document.activeElement) document.activeElement.blur();")
+        ActionChains(browser).key_down(Keys.CONTROL).key_down(Keys.SHIFT).send_keys("`").key_up(Keys.SHIFT).key_up(Keys.CONTROL).perform()
+        try:
+            terminal = WebDriverWait(browser, 5).until(
+                lambda driver: (driver.find_elements(By.CSS_SELECTOR, "textarea.xterm-helper-textarea") or [None])[0])
+            break
+        except TimeoutException:
+            continue
+    if terminal is None:
+        terminal = wait_for_selector("textarea.xterm-helper-textarea")
     time.sleep(2)
     browser.execute_script("arguments[0].focus();", terminal)
 
@@ -247,6 +258,8 @@ def test_interface_chal_narrow(random_user_browser, random_user_name, interfaces
     controls = random_user_browser.find_element(By.CSS_SELECTOR, ".workspace-controls")
     services = [button.get_attribute("data-service") for button in controls.find_elements(By.CSS_SELECTOR, ".workspace-service")]
     assert services == ["terminal: 7681"]
+    WebDriverWait(random_user_browser, 30).until(
+        lambda driver: "/7681/" in (driver.find_element(By.ID, "workspace-iframe").get_attribute("src") or ""))
     random_user_browser.close()
 
 def test_actionbar_service_buttons(random_user_browser, random_user_name, interfaces_dojo):

--- a/test/test_welcome.py
+++ b/test/test_welcome.py
@@ -30,7 +30,7 @@ def vscode_terminal(browser):
             for selector in selectors:
                 elements = driver.find_elements(By.CSS_SELECTOR, selector)
                 if elements:
-                    return elements[0]
+                    return elements[-1]
             return False
         try:
             return wait.until(locate)
@@ -47,17 +47,23 @@ def vscode_terminal(browser):
 
     surface = wait_for_selector(".monaco-workbench", "div.getting-started-step", "button.getting-started-step")
     surface.click()
-    terminal = None
-    for _ in range(5):
-        # The Getting Started webview steals focus into a cross-origin iframe, swallowing keybindings.
+    def send_terminal_shortcut():
         browser.execute_script("if (document.activeElement) document.activeElement.blur();")
         ActionChains(browser).key_down(Keys.CONTROL).key_down(Keys.SHIFT).send_keys("`").key_up(Keys.SHIFT).key_up(Keys.CONTROL).perform()
+
+    send_terminal_shortcut()
+    terminal = None
+    for _ in range(5):
         try:
-            terminal = WebDriverWait(browser, 5).until(
-                lambda driver: (driver.find_elements(By.CSS_SELECTOR, "textarea.xterm-helper-textarea") or [None])[0])
+            terminal = WebDriverWait(browser, 10).until(
+                lambda driver: (driver.find_elements(By.CSS_SELECTOR, "textarea.xterm-helper-textarea") or [None])[-1])
             break
         except TimeoutException:
-            continue
+            # The Getting Started webview steals focus into a cross-origin iframe, swallowing keybindings;
+            # only resend the shortcut if focus is still trapped there, lest we spawn a second terminal.
+            if not browser.execute_script("return document.activeElement !== null && document.activeElement.tagName === 'IFRAME';"):
+                break
+            send_terminal_shortcut()
     if terminal is None:
         terminal = wait_for_selector("textarea.xterm-helper-textarea")
     time.sleep(2)
@@ -210,6 +216,7 @@ def skip_test_welcome_practice(random_user_browser, random_user_name, welcome_do
         time.sleep(1)
 
     random_user_browser.find_element(By.CSS_SELECTOR, "#workspace-change-privilege input").click()
+    WebDriverWait(random_user_browser, 30).until(EC.alert_is_present())
     random_user_browser.switch_to.alert.accept()
     time.sleep(10)
     with desktop_terminal(random_user_browser, random_user_name) as vs:
@@ -282,6 +289,9 @@ def test_actionbar_service_buttons(random_user_browser, random_user_name, interf
         .find_element(By.CSS_SELECTOR, '.workspace-service[data-service="terminal: 7681"]').click()
     time.sleep(2)
     assert len(random_user_browser.window_handles) == len(handles) + 1
+    random_user_browser.switch_to.window(popout_handle)
+    assert random_user_browser.current_url.rstrip("/").endswith("/workspace/terminal")
+    random_user_browser.switch_to.window(module_handle)
 
     random_user_browser.get(f"{DOJO_URL}/workspace")
     controls = random_user_browser.find_element(By.CSS_SELECTOR, ".workspace-controls")
@@ -330,8 +340,10 @@ def test_actionbar_ssh_only_challenge(random_user_browser, random_user_name, int
     assert body.find_element(By.CSS_SELECTOR, ".workspace-ssh").is_displayed()
     assert "active" in buttons[0].get_attribute("class")
 
+    handles = len(random_user_browser.window_handles)
     buttons[0].click()
     time.sleep(1)
+    assert len(random_user_browser.window_handles) == handles
     assert body.find_element(By.CSS_SELECTOR, ".workspace-ssh").is_displayed()
     assert "active" in buttons[0].get_attribute("class")
     assert "SSH" in (iframe.get_attribute("class") or "")
@@ -407,17 +419,25 @@ def test_actionbar_sudo_checkbox(random_user_browser, random_user_name, interfac
     assert checkbox.is_selected()
 
     def workspace_output(cmd):
+        last_exception = None
         for _ in range(30):
             try:
                 output = workspace_run(cmd, user=random_user_name).stdout
-            except Exception:
+            except Exception as e:
+                last_exception = e
                 output = None
             if output:
                 return output
             time.sleep(1)
-        raise AssertionError(f"no output from workspace: {cmd}")
+        raise AssertionError(f"no output from workspace: {cmd} (last exception: {last_exception!r})") from last_exception
 
     assert workspace_output("sudo id -u || echo nosudo").strip() == "0"
+
+    checkbox.click()
+    wait.until(EC.alert_is_present())
+    random_user_browser.switch_to.alert.dismiss()
+    assert checkbox.is_selected()
+    assert control.get_attribute("data-privileged") == "true"
 
     checkbox.click()
     wait.until(EC.alert_is_present())
@@ -454,6 +474,72 @@ def test_actionbar_popout_mode(random_user_browser, random_user_name, interfaces
     assert controls.find_elements(By.ID, "fullscreen")
     services = [button.get_attribute("data-service") for button in controls.find_elements(By.CSS_SELECTOR, ".workspace-service")]
     assert services == ["ssh: ", "terminal: 7681"]
+    random_user_browser.close()
+
+def test_actionbar_popout_reload(random_user_browser, random_user_name, interfaces_dojo):
+    random_user_browser.get(f"{DOJO_URL}/testing-interfaces/test")
+    idx = challenge_idx(random_user_browser, "test1")
+    challenge_start(random_user_browser, idx)
+    body = random_user_browser.find_element("id", f"challenges-body-{idx}")
+    module_handle = random_user_browser.current_window_handle
+    handles = set(random_user_browser.window_handles)
+    wait = WebDriverWait(random_user_browser, 30)
+
+    body.find_element(By.CSS_SELECTOR, '.workspace-service[data-service="terminal: 7681"]').click()
+    wait.until(lambda driver: len(driver.window_handles) == len(handles) + 1)
+    popout_handle = (set(random_user_browser.window_handles) - handles).pop()
+    random_user_browser.switch_to.window(popout_handle)
+    wait.until(lambda driver: driver.current_url.rstrip("/").endswith("/workspace/terminal"))
+    popout_page = random_user_browser.find_element(By.TAG_NAME, "body")
+
+    random_user_browser.switch_to.window(module_handle)
+    restart_button = body.find_element(By.CSS_SELECTOR, "#challenge-restart")
+    restart_button.click()
+    wait.until(lambda driver: restart_button.get_attribute("disabled") is None)
+
+    random_user_browser.switch_to.window(popout_handle)
+    wait.until(EC.staleness_of(popout_page))
+    assert random_user_browser.current_url.rstrip("/").endswith("/workspace/terminal")
+    random_user_browser.close()
+    random_user_browser.switch_to.window(module_handle)
+    random_user_browser.close()
+
+def test_actionbar_first_ported_inline(random_user_browser, random_user_name, interfaces_dojo):
+    random_user_browser.get(f"{DOJO_URL}/testing-interfaces/test")
+    idx = challenge_idx(random_user_browser, "test2")
+    challenge_start(random_user_browser, idx)
+    wait = WebDriverWait(random_user_browser, 30)
+    iframe = wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, f"#challenges-body-{idx} #workspace-iframe")))
+    wait.until(lambda driver: "/8080/" in (iframe.get_attribute("src") or ""))
+    random_user_browser.close()
+
+def test_actionbar_popup_blocked(random_user_browser, random_user_name, interfaces_dojo):
+    random_user_browser.get(f"{DOJO_URL}/testing-interfaces/test")
+    idx = challenge_idx(random_user_browser, "test1")
+    challenge_start(random_user_browser, idx)
+    body = random_user_browser.find_element("id", f"challenges-body-{idx}")
+    handles = len(random_user_browser.window_handles)
+    random_user_browser.execute_script("window.open = function() { return null; };")
+
+    body.find_element(By.CSS_SELECTOR, '.workspace-service[data-service="terminal: 7681"]').click()
+    banner = body.find_element(By.ID, "workspace-notification-banner")
+    WebDriverWait(random_user_browser, 30).until(
+        lambda driver: "Pop-up blocked" in (banner.get_attribute("innerHTML") or ""))
+    assert banner.is_displayed()
+    assert len(random_user_browser.window_handles) == handles
+    random_user_browser.close()
+
+def test_actionbar_service_icons(random_user_browser, random_user_name, interfaces_dojo):
+    random_user_browser.get(f"{DOJO_URL}/testing-interfaces/test")
+
+    def interface_icon(name, service):
+        idx = challenge_idx(random_user_browser, name)
+        interfaces = get_interfaces(random_user_browser, idx)
+        return next(i for i in interfaces if i.get_attribute("data-service") == service)
+
+    assert interface_icon("test1", "terminal: 7681").find_elements(By.CSS_SELECTOR, ".fa-terminal")
+    assert interface_icon("test4", "web: 80").find_elements(By.CSS_SELECTOR, ".fa-network-wired")
+    assert interface_icon("test6", "lecture: 80").find_elements(By.CSS_SELECTOR, ".fa-video")
     random_user_browser.close()
 
 

--- a/test/test_welcome.py
+++ b/test/test_welcome.py
@@ -198,7 +198,8 @@ def skip_test_welcome_practice(random_user_browser, random_user_name, welcome_do
         vs.send_keys("sudo cp /challenge/secret /home/hacker/secret\n")
         time.sleep(1)
 
-    random_user_browser.find_element("id", "workspace-change-privilege").click()
+    random_user_browser.find_element(By.CSS_SELECTOR, "#workspace-change-privilege input").click()
+    random_user_browser.switch_to.alert.accept()
     time.sleep(10)
     with desktop_terminal(random_user_browser, random_user_name) as vs:
         vs.send_keys("/challenge/solve < secret | tee /tmp/out\n")
@@ -363,6 +364,56 @@ def test_actionbar_ssh_toggle(random_user_browser, random_user_name, interfaces_
     assert "active" not in ssh_button.get_attribute("class")
     assert "SSH" not in (iframe.get_attribute("class") or "")
     assert "/7681/" in (iframe.get_attribute("src") or "")
+    random_user_browser.close()
+
+def test_actionbar_sudo_checkbox(random_user_browser, random_user_name, interfaces_dojo):
+    random_user_browser.get(f"{DOJO_URL}/testing-interfaces/test")
+    idx = challenge_idx(random_user_browser, "test1")
+    challenge_start(random_user_browser, idx)
+    body = random_user_browser.find_element("id", f"challenges-body-{idx}")
+    wait = WebDriverWait(random_user_browser, 30)
+
+    control = body.find_element(By.CSS_SELECTOR, "#workspace-change-privilege")
+    checkbox = control.find_element(By.CSS_SELECTOR, "input")
+    assert not checkbox.is_selected()
+    assert control.get_attribute("data-privileged") == "false"
+
+    checkbox.click()
+    wait.until(EC.alert_is_present())
+    alert = random_user_browser.switch_to.alert
+    assert "sudo" in alert.text
+    alert.dismiss()
+    assert not checkbox.is_selected()
+    assert control.get_attribute("data-privileged") == "false"
+
+    checkbox.click()
+    wait.until(EC.alert_is_present())
+    random_user_browser.switch_to.alert.accept()
+    wait.until(lambda driver: control.get_attribute("data-privileged") == "true")
+    wait.until(lambda driver: checkbox.is_enabled())
+    assert checkbox.is_selected()
+
+    def workspace_output(cmd):
+        for _ in range(30):
+            try:
+                output = workspace_run(cmd, user=random_user_name).stdout
+            except Exception:
+                output = None
+            if output:
+                return output
+            time.sleep(1)
+        raise AssertionError(f"no output from workspace: {cmd}")
+
+    assert workspace_output("sudo id -u || echo nosudo").strip() == "0"
+
+    checkbox.click()
+    wait.until(EC.alert_is_present())
+    random_user_browser.switch_to.alert.accept()
+    wait.until(lambda driver: control.get_attribute("data-privileged") == "false")
+    wait.until(lambda driver: checkbox.is_enabled())
+    assert not checkbox.is_selected()
+
+    assert "nosudo" in workspace_output("sudo id -u || echo nosudo")
     random_user_browser.close()
 
 def test_actionbar_popout_mode(random_user_browser, random_user_name, interfaces_dojo):

--- a/test/test_welcome.py
+++ b/test/test_welcome.py
@@ -7,7 +7,7 @@ import pytest
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver import Firefox, FirefoxOptions
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait, Select
+from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.action_chains import ActionChains
@@ -208,20 +208,19 @@ def skip_test_welcome_practice(random_user_browser, random_user_name, welcome_do
 def get_interfaces(browser, idx):
     challenge_expand(browser, idx)
     body = browser.find_element("id", f"challenges-body-{idx}")
-    options = Select(body.find_element("id", "workspace-select"))
-    return options.options
+    return body.find_elements(By.CSS_SELECTOR, ".workspace-service")
 
 def match_interfaces(interfaces, expected):
     assert len(interfaces) == len(expected)
     for interface, value in zip(interfaces, expected) :
-        assert interface.get_attribute("value") == value
+        assert interface.get_attribute("data-service") == value
 
 def test_interface_inherit(random_user_browser, random_user_name, interfaces_dojo):
     random_user_browser.get(f"{DOJO_URL}/testing-interfaces/test")
     idx = challenge_idx(random_user_browser, "test1")
     interfaces = get_interfaces(random_user_browser, idx)
 
-    values = ["ssh: ", "terminal: 7681"]
+    values = ["terminal: 7681"]
     match_interfaces(interfaces, values)
 
 def test_interface_chal_override(random_user_browser, random_user_name, interfaces_dojo):
@@ -239,6 +238,33 @@ def test_interface_chal_narrow(random_user_browser, random_user_name, interfaces
 
     values = ["terminal: 7681"]
     match_interfaces(interfaces, values)
+
+def test_actionbar_popout_mode(random_user_browser, random_user_name, interfaces_dojo):
+    random_user_browser.get(f"{DOJO_URL}/testing-interfaces/test")
+    idx = challenge_idx(random_user_browser, "test1")
+    challenge_start(random_user_browser, idx)
+
+    body = random_user_browser.find_element("id", f"challenges-body-{idx}")
+    controls = body.find_element(By.CSS_SELECTOR, ".workspace-controls")
+    assert controls.get_attribute("data-popout") == "true"
+    assert not controls.find_elements(By.ID, "fullscreen")
+    assert not body.find_elements(By.ID, "workspace-select")
+    assert body.find_element(By.CSS_SELECTOR, ".workspace-ssh").is_displayed()
+
+    buttons = controls.find_elements(By.CSS_SELECTOR, ".workspace-service")
+    assert [button.get_attribute("data-service") for button in buttons] == ["terminal: 7681"]
+
+    wait = WebDriverWait(random_user_browser, 30)
+    iframe = wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, f"#challenges-body-{idx} #workspace-iframe")))
+    wait.until(lambda driver: "/7681/" in (iframe.get_attribute("src") or ""))
+
+    random_user_browser.get(f"{DOJO_URL}/workspace")
+    controls = random_user_browser.find_element(By.CSS_SELECTOR, ".workspace-controls")
+    assert controls.get_attribute("data-popout") == "false"
+    assert controls.find_elements(By.ID, "fullscreen")
+    services = [button.get_attribute("data-service") for button in controls.find_elements(By.CSS_SELECTOR, ".workspace-service")]
+    assert services == ["ssh: ", "terminal: 7681"]
+    random_user_browser.close()
 
 
 def test_registration_commitment(browser_fixture):

--- a/test/test_welcome.py
+++ b/test/test_welcome.py
@@ -48,9 +48,11 @@ def vscode_terminal(browser):
     surface = wait_for_selector(".monaco-workbench", "div.getting-started-step", "button.getting-started-step")
     surface.click()
     ActionChains(browser).key_down(Keys.CONTROL).key_down(Keys.SHIFT).send_keys("`").key_up(Keys.SHIFT).key_up(Keys.CONTROL).perform()
-    wait_for_selector("textarea.xterm-helper-textarea")
+    terminal = wait_for_selector("textarea.xterm-helper-textarea")
+    time.sleep(2)
+    browser.execute_script("arguments[0].focus();", terminal)
 
-    yield browser.switch_to.active_element
+    yield terminal
 
     browser.close()
     browser.switch_to.window(module_window)


### PR DESCRIPTION
## Problem

Starting a challenge embeds the whole workspace (VS Code, desktop, terminal) in a small letterboxed iframe in the middle of the module page. Terminals are tolerable in that box; IDEs and desktops are not. Switching services swaps the same tiny iframe, the actionbar's service dropdown hides what is available, and "fullscreen" is a `position: fixed` hack layered over the navbar.

## Change

The actionbar's service dropdown is replaced with labeled service buttons. The shared component now has two modes:

**Module page (pop-out mode):**
- The inline iframe always loads the challenge's *first* port-having interface — the terminal for standard challenges, the lecture player for port-80 lecture challenges — and no longer switches inline.
- Every port-backed interface (including Terminal) gets a button that opens `/workspace/<service>` (or `/workspace/<port>` for custom interfaces) in a named tab. Well-known services and lecture interfaces get dedicated icons; other custom interfaces fall back to a generic one. Re-clicking focuses the existing tab without reloading it, so live terminal/VS Code/VNC sessions survive; blocked pop-ups surface a banner.
- SSH gets a button too, marked with a `?` hint instead of the pop-out arrow: it swaps the inline workspace for the SSH connection instructions in place, and clicking it again restores the workspace (the iframe just collapses, so the session stays alive). SSH-only challenges default to the instructions view with the button active.
- The privilege-mode lock icon is replaced with a `sudo` checkbox. Toggling it asks for confirmation ("Restart the challenge with/without sudo access? The running container will be replaced."), restarts in the chosen mode on confirm, and reverts the checkbox on cancel. The checkbox state stays in sync with restarts from the module start buttons and cross-tab broadcasts.
- The inline fullscreen hack (fixed positioning, scroll locking, window-aspect-ratio juggling) is deleted.
- Failed starts/restarts now surface the API error in the banner and revert the actionbar instead of silently pretending success: the `/docker` POST response is actually parsed (the old code returned `response.json` uncalled, so the failure branch was dead), privilege state commits only on success, and the restart button and sudo checkbox disable together while a start is in flight. Pop-out windows are keyed by the same token as their URL, so two same-named interfaces on different ports get distinct tabs, and the interface-name schema regex is anchored (it was substring-matched, letting crafted names escape `/workspace/` in pop-out URLs). Service buttons expose `aria-pressed`, and the sudo checkbox has a visible focus ring.

**`/workspace` page:**
- The same buttons switch the iframe in place, with a visible active state. The SSH button now shows an SSH info box (it used to blank the page). The fullscreen (navbar-hide) button remains.
- On a challenge switch broadcast from another tab, the page reloads so the server re-renders the correct challenge, interfaces, and privilege state.

**Bare `/workspace/<service>` and `/workspace/<port>` pages (the pop-out targets):**
- Now subscribe to the challenge sync channel and reload on restarts/privilege toggles, so popped-out tabs stop going permanently stale (their container-id-signed URLs die on restart).
- Gained the same clipboard delegation the inline iframe had.
- The dead `'New challenge started'` listener (its sender was removed long ago) is dropped from navbar.js.

## Screenshots

Inline terminal with pop-out buttons on the module page:

![module page](https://raw.githubusercontent.com/pwncollege/dojo/workspace-popout-assets/module-inline-terminal.png)

The SSH button swaps the inline workspace for connection instructions:

![ssh instructions](https://raw.githubusercontent.com/pwncollege/dojo/workspace-popout-assets/module-ssh-instructions.png)

The `sudo` checkbox, unchecked and then checked after a confirmed privileged restart:

![sudo checkbox unchecked](https://raw.githubusercontent.com/pwncollege/dojo/workspace-popout-assets/module-sudo-checkbox.png)

![sudo checkbox checked](https://raw.githubusercontent.com/pwncollege/dojo/workspace-popout-assets/module-sudo-checked.png)

A challenge with a custom `Lecture: 80` interface leads with the lecture player inline, and the Lecture button pops it out to `/workspace/80`:

![lecture interface](https://raw.githubusercontent.com/pwncollege/dojo/workspace-popout-assets/module-lecture-inline.png)

`/workspace` with in-place switching (Terminal active):

![workspace page](https://raw.githubusercontent.com/pwncollege/dojo/workspace-popout-assets/workspace-fullpage.png)

Popped-out VS Code tab (`/workspace/code`):

![code pop-out](https://raw.githubusercontent.com/pwncollege/dojo/workspace-popout-assets/workspace-code-popout.png)

## Tests

The three interface tests were updated to the new markup, and this adds functional coverage: pop-out click opens the named tab and re-click reuses it (asserting the tab stays on its URL), custom-port interfaces pop out to `/workspace/<port>`, `/workspace` in-place switching (active state, SSH box, iframe collapse), the module-page SSH toggle (instructions shown/hidden in place, no new tab, iframe collapse and restore), SSH-only challenges defaulting to the instructions view (and never reaching `window.open`), the sudo checkbox (cancel reverts in both directions with no restart; confirm restarts and the new container's sudo access is verified both ways), pop-out tabs reloading on a challenge restart via the sync channel, the first ported interface winning the inline slot on multi-interface challenges, the popup-blocked banner, and per-service button icons. The browser fixture now quits on teardown. Full suite: 181 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CbHUrxbSQDU1c24hZeEpt

