### PR TITLE
Site: content-hash cache busting for theme assets

### DIFF
--- a/dojo_plugin/__init__.py
+++ b/dojo_plugin/__init__.py
@@ -1,4 +1,6 @@
 import datetime
+import functools
+import hashlib
 import logging
 import sys
 import os
@@ -10,7 +12,9 @@ from urllib.parse import urlparse, urlunparse
 from flask import Response, request, redirect, current_app
 from itsdangerous.exc import BadSignature
 from marshmallow_sqlalchemy import field_for
+from werkzeug.utils import safe_join
 from CTFd.models import db, Challenges, Users, Solves
+from CTFd.utils.config import ctf_theme
 from CTFd.utils.user import get_current_user
 from CTFd.plugins import register_admin_plugin_menu_bar
 from CTFd.plugins.challenges import CHALLENGE_CLASSES, BaseChallenge
@@ -148,6 +152,36 @@ def handle_authorization(default_handler):
     default_handler()
 
 
+@functools.lru_cache(maxsize=1024)
+def theme_asset_digest(asset_path, mtime_ns, ctime_ns, size):
+    with open(asset_path, "rb") as asset:
+        return hashlib.sha256(asset.read()).hexdigest()[:8]
+
+
+def inject_theme_asset_version(endpoint, values):
+    path = values.get("path", "")
+    if (
+        endpoint != "views.themes"
+        or values.get("theme") != ctf_theme()
+        or "v" in values
+        or not path.endswith((".css", ".js"))
+    ):
+        return
+    asset_path = safe_join(current_app.root_path, "themes", values["theme"], "static", path)
+    if not asset_path:
+        return
+    try:
+        stat_result = os.stat(asset_path)
+        values["v"] = theme_asset_digest(
+            asset_path,
+            stat_result.st_mtime_ns,
+            stat_result.st_ctime_ns,
+            stat_result.st_size,
+        )
+    except OSError:
+        return
+
+
 def load(app):
     db.create_all()
 
@@ -179,6 +213,8 @@ def load(app):
 
     if not app.debug:
         app.before_request(redirect_dojo)
+
+    app.url_defaults(inject_theme_asset_version)
 
     app.register_blueprint(dojos)
     app.register_blueprint(dojo)

--- a/test/test_theme_assets.py
+++ b/test/test_theme_assets.py
@@ -1,0 +1,44 @@
+import hashlib
+import html
+import re
+from pathlib import Path
+from urllib.parse import parse_qs, urljoin, urlparse
+
+import requests
+
+from utils import DOJO_URL
+
+
+ASSET_PATH = Path(__file__).parents[1] / "dojo_theme/static/css/custom.css"
+
+
+def custom_css_url():
+    response = requests.get(DOJO_URL)
+    response.raise_for_status()
+    match = re.search(r'href="([^"]*/themes/dojo_theme/static/css/custom\.(?:dev|min)\.css\?[^"]+)"', response.text)
+    assert match
+    return html.unescape(match.group(1))
+
+
+def asset_version(url):
+    return parse_qs(urlparse(url).query)["v"][0]
+
+
+def test_theme_asset_version_changes_without_restart():
+    original = ASSET_PATH.read_bytes()
+    initial_url = custom_css_url()
+    initial_response = requests.get(urljoin(DOJO_URL, initial_url))
+    assert initial_response.status_code == 200
+    assert asset_version(initial_url) == hashlib.sha256(initial_response.content).hexdigest()[:8]
+    assert "max-age=3600" in initial_response.headers.get("Cache-Control", "")
+
+    try:
+        ASSET_PATH.write_bytes(original + b"\n")
+        changed_url = custom_css_url()
+        assert asset_version(changed_url) != asset_version(initial_url)
+        changed_response = requests.get(urljoin(DOJO_URL, changed_url))
+        assert asset_version(changed_url) == hashlib.sha256(changed_response.content).hexdigest()[:8]
+    finally:
+        ASSET_PATH.write_bytes(original)
+
+    assert asset_version(custom_css_url()) == asset_version(initial_url)


### PR DESCRIPTION
## Summary

- append a content-derived `v` only to CSS and JavaScript URLs for the configured, hot-mounted theme
- cache digests by path and nanosecond file metadata
- tolerate asset replacement races without breaking page rendering
- leave admin, fallback, and beta-theme assets unchanged

## Testing

- mutate and restore `custom.css` without restarting CTFd
- verify `v` changes, matches the served bytes, and returns to its original value
- verify the existing one-hour cache header remains intact