### PR TITLE
Feed: use canonical dojo links

### DIFF
--- a/dojo_theme/static/js/dojo/feed.js
+++ b/dojo_theme/static/js/dojo/feed.js
@@ -163,7 +163,7 @@
         const fragment = document.createDocumentFragment();
         
         if (data.dojo_name || data.dojo_id) {
-            const dojoLink = createLink(`/dojos/${data.dojo_id}`, data.dojo_name || data.dojo_id);
+            const dojoLink = createLink(`/${data.dojo_id}`, data.dojo_name || data.dojo_id);
             fragment.appendChild(dojoLink);
             fragment.appendChild(document.createTextNode(' / '));
         }
@@ -258,7 +258,7 @@
                 const small = document.createElement('small');
                 small.className = 'text-muted';
                 small.appendChild(document.createTextNode('Completed '));
-                small.appendChild(createLink(`/dojos/${event.data.dojo_id}`, event.data.dojo_name || event.data.dojo_id));
+                small.appendChild(createLink(`/${event.data.dojo_id}`, event.data.dojo_name || event.data.dojo_id));
                 
                 detailElem.appendChild(br);
                 detailElem.appendChild(small);
@@ -288,7 +288,7 @@
                 const small = document.createElement('small');
                 small.className = 'text-muted';
                 small.appendChild(document.createTextNode('Completed '));
-                small.appendChild(createLink(`/dojos/${event.data.dojo_id}`, event.data.dojo_name || event.data.dojo_id));
+                small.appendChild(createLink(`/${event.data.dojo_id}`, event.data.dojo_name || event.data.dojo_id));
                 
                 detailElem.appendChild(br);
                 detailElem.appendChild(small);
@@ -303,7 +303,7 @@
             const card = createEventFromTemplate(EVENT_TEMPLATES.dojo_update, event);
             
             const dojoLink = card.querySelector('.event-dojo-link');
-            dojoLink.href = `/dojos/${event.data.dojo_id}`;
+            dojoLink.href = `/${event.data.dojo_id}`;
             dojoLink.textContent = event.data.dojo_name || event.data.dojo_id;
             
             const detailElem = card.querySelector('.event-update-detail');

--- a/dojo_theme/templates/feed.html
+++ b/dojo_theme/templates/feed.html
@@ -24,9 +24,9 @@
 
 {% macro render_dojo_module_challenge(data) %}
     {% if data.dojo_name %}
-        <a href="/dojos/{{ data.dojo_id }}">{{ data.dojo_name }}</a> /
+        <a href="/{{ data.dojo_id }}">{{ data.dojo_name }}</a> /
     {% elif data.dojo_id %}
-        <a href="/dojos/{{ data.dojo_id }}">{{ data.dojo_id }}</a> /
+        <a href="/{{ data.dojo_id }}">{{ data.dojo_id }}</a> /
     {% endif %}
     {% if data.module_name %}
         {% if data.dojo_id %}
@@ -44,9 +44,9 @@
 
 {% macro render_dojo_link(data) %}
     {% if data.dojo_name %}
-        <a href="/dojos/{{ data.dojo_id }}">{{ data.dojo_name }}</a>
+        <a href="/{{ data.dojo_id }}">{{ data.dojo_name }}</a>
     {% elif data.dojo_id %}
-        <a href="/dojos/{{ data.dojo_id }}">{{ data.dojo_id }}</a>
+        <a href="/{{ data.dojo_id }}">{{ data.dojo_id }}</a>
     {% endif %}
 {% endmacro %}
 

--- a/test/test_feed.py
+++ b/test/test_feed.py
@@ -48,6 +48,7 @@ def test_feed_shows_all_events(welcome_dojo, simple_award_dojo, random_user_name
                 found_start_event = True
                 assert "Start Here" in event_text, \
                     f"Dojo name 'Start Here' not found in event: {event_text}"
+                assert event.find_elements(By.CSS_SELECTOR, f'a[href="/{welcome_dojo.split("~", 1)[0]}"]')
                 assert "Using the Dojo" in event_text, \
                     f"Module name 'Using the Dojo' not found in event: {event_text}"
                 assert "The Flag File" in event_text, \
@@ -77,6 +78,7 @@ def test_feed_shows_all_events(welcome_dojo, simple_award_dojo, random_user_name
                     found_solve_event = True
                     assert "Start Here" in event_text, \
                         f"Dojo name 'Start Here' not found in solve event: {event_text}"
+                    assert event.find_elements(By.CSS_SELECTOR, f'a[href="/{welcome_dojo.split("~", 1)[0]}"]')
                     assert "Using the Dojo" in event_text, \
                         f"Module name 'Using the Dojo' not found in solve event: {event_text}"
                     assert "The Flag File" in event_text, \


### PR DESCRIPTION
Fixes #970

## Summary

- replace the eight incorrect `/dojos/<id>` feed links with `/<id>`
- cover both server-rendered and live-streamed feed events

## Testing

- assert the initial feed event links to the canonical dojo URL
- assert a streamed solve event does the same