### PR TITLE
Restore hidden profile self data

### DIFF
--- a/dojo_plugin/pages/users.py
+++ b/dojo_plugin/pages/users.py
@@ -13,6 +13,7 @@ from CTFd.cache import cache
 from ..models import Dojos, DojoModules, DojoChallenges
 from ..utils.scores import get_dojo_scores, get_module_scores
 from ..utils.awards import get_belts, get_viewable_emojis
+from ..worker.handlers.awards import calculate_belts, calculate_emojis
 
 
 users = Blueprint("pwncollege_users", __name__)
@@ -95,11 +96,18 @@ def view_hacker(user, bypass_hidden=False):
 
     dojo_scores, module_scores = build_user_scores(user, dojos)
 
+    if user.hidden and bypass_hidden:
+        belts = calculate_belts(user)
+        badges = get_viewable_emojis(user, calculate_emojis(user))
+    else:
+        belts = get_belts()
+        badges = get_viewable_emojis(get_current_user())
+
     return render_template(
         "hacker.html",
         dojos=dojos, user=user,
         dojo_scores=dojo_scores, module_scores=module_scores,
-        belts=get_belts(), badges=get_viewable_emojis(get_current_user()),
+        belts=belts, badges=badges,
         user_solves=user_solves
     )
 

--- a/dojo_plugin/utils/awards.py
+++ b/dojo_plugin/utils/awards.py
@@ -48,16 +48,16 @@ def get_belts():
         result["ranks"][color] = []
     return result
 
-def get_viewable_emojis(user):
-    cached = get_cached_stat(CACHE_KEY_EMOJIS)
-    if cached:
+def get_viewable_emojis(user, emoji_data=None):
+    emoji_data = emoji_data if emoji_data is not None else get_cached_stat(CACHE_KEY_EMOJIS)
+    if emoji_data:
         viewable_dojos = {
             dojo.hex_dojo_id: dojo
             for dojo in Dojos.viewable(user=user).where(Dojos.data["type"].astext != "example")
         }
 
         result = {}
-        for user_id_str, emoji_list in cached.get("emojis", {}).items():
+        for user_id_str, emoji_list in emoji_data.get("emojis", {}).items():
             filtered = []
             for emoji_entry in emoji_list:
                 category = emoji_entry["category"]

--- a/dojo_plugin/worker/handlers/awards.py
+++ b/dojo_plugin/worker/handlers/awards.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 CACHE_KEY_BELTS = "stats:belts"
 CACHE_KEY_EMOJIS = "stats:emojis"
 
-def calculate_belts():
+def calculate_belts(user=None):
     result = dict(dates={}, users={}, ranks={})
     for color in reversed(BELT_ORDER):
         result["dates"][color] = {}
@@ -20,7 +20,10 @@ def calculate_belts():
     belts = (
         Belts.query
         .join(Users)
-        .filter(Belts.name.in_(BELT_ORDER), ~Users.hidden)
+        .filter(
+            Belts.name.in_(BELT_ORDER),
+            Users.id == user.id if user is not None else ~Users.hidden,
+        )
         .with_entities(
             Belts.date,
             Belts.name.label("color"),
@@ -44,7 +47,7 @@ def calculate_belts():
 
     return result
 
-def calculate_emojis():
+def calculate_emojis(user=None):
     dojos_by_hex = {
         dojo.hex_dojo_id: {
             "reference_id": dojo.reference_id,
@@ -59,7 +62,7 @@ def calculate_emojis():
     emojis = (
         Emojis.query
         .join(Users)
-        .filter(~Users.hidden)
+        .filter(Users.id == user.id if user is not None else ~Users.hidden)
         .order_by(Emojis.date, Emojis.name.desc())
         .with_entities(
             Emojis.name,

--- a/dojo_theme/static/js/dojo/popup.js
+++ b/dojo_theme/static/js/dojo/popup.js
@@ -7,7 +7,7 @@ document.addEventListener("DOMContentLoaded", function () {
 });
 
 function checkUserAwards() {
-    const endpoint = `/api/v1/users/${init.userId}/awards`;
+    const endpoint = "/api/v1/users/me/awards";
     return CTFd.fetch(endpoint, {
         method: "GET",
         credentials: "same-origin",

--- a/test/test_hidden_profile.py
+++ b/test/test_hidden_profile.py
@@ -1,0 +1,43 @@
+from utils import (
+    DOJO_URL,
+    db_sql,
+    get_user_id,
+    solve_challenge,
+    start_challenge,
+    wait_for_background_worker,
+)
+
+
+def test_hidden_user_can_view_own_profile_data(random_user, example_dojo):
+    username, session = random_user
+    user_id = get_user_id(username)
+    assert session.get(f"{DOJO_URL}/dojo/{example_dojo}/join/").status_code == 200
+    start_challenge(example_dojo, "hello", "apple", session=session)
+    solve_challenge(example_dojo, "hello", "apple", session=session, user=username)
+    wait_for_background_worker()
+
+    db_sql(f"""
+        INSERT INTO awards (user_id, type, name, description, date, value, icon)
+        VALUES
+            ({user_id}, 'belt', 'orange', 'Orange Belt', NOW(), 0, NULL),
+            ({user_id}, 'emoji', 'CUSTOM', 'Hidden self badge', NOW(), 0, '🧪')
+    """)
+    response = session.patch(f"{DOJO_URL}/api/v1/users/me", json={"hidden": True})
+    assert response.status_code == 200
+
+    profile = session.get(f"{DOJO_URL}/hacker/")
+    assert profile.status_code == 200
+    assert "/belt/orange.svg" in profile.text
+    assert "Hidden self badge" in profile.text
+    assert "Time of First Successful Submission" in profile.text
+
+    activity = session.get(f"{DOJO_URL}/pwncollege_api/v1/activity/{user_id}")
+    assert activity.status_code == 200
+    assert activity.json()["data"]["total_solves"] >= 1
+
+    awards = session.get(f"{DOJO_URL}/api/v1/users/me/awards")
+    assert awards.status_code == 200
+    assert {award["name"] for award in awards.json()["data"]} >= {"orange", "CUSTOM"}
+    assert session.get(f"{DOJO_URL}/hacker/{user_id}").status_code == 404
+    assert session.get(f"{DOJO_URL}/hacker/{username}").status_code == 404
+    assert session.get(f"{DOJO_URL}/api/v1/users/{user_id}/awards").status_code == 404


### PR DESCRIPTION
Fixes #993

## Summary

- use CTFd's private `/api/v1/users/me/awards` endpoint for the award popup
- overlay only the current hidden user's belt and badge rows when rendering their own `/hacker/` page
- leave public award caches and hidden-user public endpoints unchanged

## Testing

- verify a hidden user sees their own progress, belt, badge, and activity
- verify private awards return 200 while the numeric public awards endpoint remains 404