### PR TITLE
Key module scoreboards by module ID

### DIFF
--- a/dojo_plugin/api/v1/scoreboard.py
+++ b/dojo_plugin/api/v1/scoreboard.py
@@ -30,7 +30,7 @@ def model_cache_key(model, kind, duration):
     if isinstance(model, Dojos):
         return f"stats:{kind}:dojo:{model.dojo_id}:{duration}"
     if isinstance(model, DojoModules):
-        return f"stats:{kind}:module:{model.dojo_id}:{model.module_index}:{duration}"
+        return f"stats:{kind}:module:{model.dojo_id}:id:{model.id}:{duration}"
     return None
 
 

--- a/dojo_plugin/worker/handlers/scoreboard.py
+++ b/dojo_plugin/worker/handlers/scoreboard.py
@@ -185,7 +185,7 @@ def handle_scoreboard_update(payload, event_timestamp=None):
         if not model:
             logger.info(f"Module not found for id {model_id} (may have been deleted)")
             return
-        cache_prefix = f"stats:scoreboard:module:{model.dojo_id}:{model.module_index}"
+        cache_prefix = f"stats:scoreboard:module:{model.dojo_id}:id:{model.id}"
     else:
         logger.warning(f"Unknown model_type: {model_type}")
         return
@@ -231,7 +231,7 @@ def initialize_all_scoreboards():
             for duration in COMMON_DURATIONS:
                 try:
                     scoreboard = calculate_scoreboard(module, duration)
-                    cache_key = f"stats:scoreboard:module:{module.dojo_id}:{module.module_index}:{duration}"
+                    cache_key = f"stats:scoreboard:module:{module.dojo_id}:id:{module.id}:{duration}"
                     set_scoreboard_cache(cache_key, scoreboard, calculate_member_challenges(module, duration, scoreboard))
                     logger.info(f"Initialized scoreboard for module {dojo.reference_id}/{module.id} (dojo_id={module.dojo_id}, module_index={module.module_index}), duration={duration}")
                 except Exception as e:

--- a/dojo_plugin/worker/handlers/solve.py
+++ b/dojo_plugin/worker/handlers/solve.py
@@ -81,7 +81,7 @@ def _update_dojo_scoreboard(dojo, user_id, challenge_id, event_timestamp):
 
 
 def _update_module_scoreboard(module, user_id, challenge_id, event_timestamp):
-    cache_prefix = f"stats:scoreboard:module:{module.dojo_id}:{module.module_index}"
+    cache_prefix = f"stats:scoreboard:module:{module.dojo_id}:id:{module.id}"
     for duration in COMMON_DURATIONS:
         try:
             cache_key = f"{cache_prefix}:{duration}"

--- a/test/test_scoreboard.py
+++ b/test/test_scoreboard.py
@@ -2,6 +2,7 @@ import random
 import string
 
 import pytest
+import yaml
 
 from utils import DOJO_URL, login, create_dojo_yml, workspace_run, start_challenge, solve_challenge, wait_for_background_worker, get_user_id, remove_workspace_container
 
@@ -111,6 +112,50 @@ modules:
     assert result["pages"] == []
 
 
+def test_replaced_module_has_fresh_scoreboard(admin_session, example_dojo, random_user):
+    user_name, session = random_user
+    suffix = "".join(random.choices(string.ascii_lowercase, k=8))
+    dojo_id = f"module-scoreboard-{suffix}"
+    spec = {
+        "id": dojo_id,
+        "type": "public",
+        "modules": [{
+            "id": "old",
+            "resources": [{
+                "type": "challenge",
+                "id": "old",
+                "name": "Old",
+                "import": {"dojo": example_dojo, "module": "hello", "challenge": "apple"},
+            }],
+        }],
+    }
+    dojo = create_dojo_yml(yaml.safe_dump(spec), session=admin_session)
+    assert session.get(f"{DOJO_URL}/dojo/{dojo}/join/").status_code == 200
+    start_challenge(dojo, "old", "old", session=session)
+    solve_challenge(dojo, "old", "old", session=session, user=user_name)
+    wait_for_background_worker(timeout=2)
+    assert any(entry["name"] == user_name for entry in get_all_standings(session, dojo, "old"))
+
+    spec["modules"] = [{
+        "id": "new",
+        "resources": [{
+            "type": "challenge",
+            "id": "new",
+            "name": "New",
+            "import": {"dojo": example_dojo, "module": "hello", "challenge": "banana"},
+        }],
+    }]
+    response = admin_session.post(f"{DOJO_URL}/pwncollege_api/v1/dojos/{dojo}/update", json=spec)
+    assert response.status_code == 200
+    assert get_all_standings(session, dojo, "new") == []
+
+    start_challenge(dojo, "new", "new", session=session)
+    solve_challenge(dojo, "new", "new", session=session, user=user_name)
+    wait_for_background_worker(timeout=2)
+    standings = get_all_standings(session, dojo, "new")
+    assert next(entry for entry in standings if entry["name"] == user_name)["solves"] == 1
+
+
 def test_folder_awards(admin_session, event_dojo, random_user, example_dojo):
     grant_award = f"{DOJO_URL}/pwncollege_api/v1/dojos/{event_dojo}/award/grant"
     random_user_name, random_user_session = random_user
@@ -131,4 +176,3 @@ def test_folder_awards(admin_session, event_dojo, random_user, example_dojo):
         if emoji["emoji"] == "🥈" and emoji["count"] == 2:
             return
     assert False, f"Failed to find second place award with count 2. Emojis: {scoreboard["me"]["badges"]}"
-


### PR DESCRIPTION
Fixes #1097

## Summary

- key module scoreboard and crew caches by the stable module ID instead of its mutable list index
- add an explicit `id` discriminator so numeric module IDs cannot collide with legacy index keys
- change only the four module scoreboard readers and writers involved in the reported bug

## Testing

- populate a module scoreboard, replace that module at the same index, and verify the replacement starts empty
- solve the replacement once and verify its score is exactly one