### PR TITLE
Build: apply CTFd patches deterministically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,15 @@ EOF
 WORKDIR /opt/pwn.college
 COPY . .
 
-RUN find /opt/pwn.college/ctfd/patches -exec patch -d /opt/CTFd -p1 -N -i {} \;
+RUN <<EOF
+set -eu
+find /opt/pwn.college/ctfd/patches -type f -name '*.patch' -print > /tmp/ctfd-patches
+LC_ALL=C sort -o /tmp/ctfd-patches /tmp/ctfd-patches
+while IFS= read -r patch_file; do
+    patch --batch --forward -d /opt/CTFd -p1 -i "$patch_file"
+done < /tmp/ctfd-patches
+rm /tmp/ctfd-patches
+EOF
 
 RUN <<EOF
 find /opt/pwn.college/etc/systemd/system -type f -exec ln -s {} /etc/systemd/system/ \;


### PR DESCRIPTION
## Summary

- select only patch files from the bundled CTFd patch directory
- apply them in deterministic lexical order
- make patch rejection fail the image build immediately

## Scope

This is independent image-build hardening. It is intentionally separate from CI PR #1114 and is not a prerequisite for #1111 or #1112; the existing runner applies both feature patches successfully.

## Validation

- applied the #1111 patch set, #1112 patch set, and combined patch set to pristine CTFd 3.6.0 with both runners
- confirmed identical successful patched trees
- confirmed the old runner masks a forced patch failure while this runner exits nonzero
- Dockerfile whitespace checks
- full single-node and multi-node suites in GitHub Actions