### PR TITLE
Add explicit overwrite for challenge transfers

### DIFF
--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -155,6 +155,7 @@ DOJO_SPEC = Schema({
                     Optional("dojo"): UNIQUE_ID_REGEX,
                     Optional("module"): ID_REGEX,
                     "challenge": ID_REGEX,
+                    Optional("overwrite", default=False): bool,
                 },
                 Optional("survey"): {
                     Optional("probability"): float,
@@ -384,16 +385,22 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
     def challenge(module_id, challenge_id, transfer=None):
         if (module_id, challenge_id) in existing_challenges:
             return existing_challenges[(module_id, challenge_id)]
-        if chal := Challenges.query.filter_by(category=dojo.hex_dojo_id, name=f"{module_id}:{challenge_id}").first():
-            return chal
+        destination_challenge = Challenges.query.filter_by(category=dojo.hex_dojo_id, name=f"{module_id}:{challenge_id}").first()
+        if destination_challenge and not (transfer and transfer["overwrite"]):
+            return destination_challenge
         if transfer:
             old_dojo_id = transfer.get("dojo", dojo.reference_id)
             old_module_id = transfer.get("module", module_id)
             old_challenge_id = transfer["challenge"]
             old_dojo = Dojos.from_id(old_dojo_id).first()
             assert old_dojo and (old_dojo.dojo_id == dojo.dojo_id or dojo.official or (is_admin() and not Dojos.from_id(dojo.id).first()))
-            old_challenge = Challenges.query.filter_by(category=old_dojo.hex_dojo_id, name=f"{old_module_id}:{old_challenge_id}").first()
-            assert old_challenge, f"unable to find source dojo/module/challenge in database for {old_dojo_id}:{old_module_id}:{old_challenge_id}"
+            old_dojo_challenge = DojoChallenges.from_id(old_dojo.reference_id, old_module_id, old_challenge_id).first()
+            assert (
+                old_dojo_challenge
+                and old_dojo_challenge.challenge.category == old_dojo.hex_dojo_id
+                and old_dojo_challenge.challenge.name == f"{old_module_id}:{old_challenge_id}"
+            ), f"unable to find source dojo/module/challenge in database for {old_dojo_id}:{old_module_id}:{old_challenge_id}"
+            old_challenge = old_dojo_challenge.challenge
             old_challenge.category = dojo.hex_dojo_id
             old_challenge.name = f"{module_id}:{challenge_id}"
             return old_challenge

--- a/test/test_dojos.py
+++ b/test/test_dojos.py
@@ -277,7 +277,7 @@ def test_community_dojo_internal_transfer(admin_session, guest_dojo_admin):
     username, session = guest_dojo_admin
     suffix = "".join(random.choices(string.ascii_lowercase, k=8))
     dojo_id = f"internal-transfer-{suffix}"
-    spec = {"id": dojo_id, "image": "pwncollege/challenge-simple", "modules": [{"id": "m", "challenges": [{"id": "old"}]}]}
+    spec = {"id": dojo_id, "image": "pwncollege/challenge-simple", "modules": [{"id": "m", "challenges": [{"id": "old"}, {"id": "new"}]}]}
     dojo = create_dojo_yml(yaml.safe_dump(spec), session=admin_session)
     assert session.get(f"{DOJO_URL}/dojo/{dojo}/join/").status_code == 200
     response = admin_session.post(
@@ -286,10 +286,36 @@ def test_community_dojo_internal_transfer(admin_session, guest_dojo_admin):
     )
     assert response.status_code == 200
     challenge_id = get_dojo_challenge_id(dojo_id, "m", "old")
+    stale_challenge_id = get_dojo_challenge_id(dojo_id, "m", "new")
+
+    spec["modules"] = [{
+        "id": "m",
+        "resources": [{"type": "challenge", "id": "old", "name": "Old"}],
+    }]
+    response = session.post(f"{DOJO_URL}/pwncollege_api/v1/dojos/{dojo}/update", json=spec)
+    assert response.status_code == 200
+    assert get_dojo_challenge_id(dojo_id, "m", "old") == challenge_id
+    assert int(db_sql(f"SELECT count(*) FROM challenges WHERE id = {stale_challenge_id}")) == 1
 
     spec["modules"] = [{
         "id": "m",
         "resources": [{"type": "challenge", "id": "new", "name": "New", "transfer": {"challenge": "old"}}],
+    }]
+    response = session.post(f"{DOJO_URL}/pwncollege_api/v1/dojos/{dojo}/update", json=spec)
+    assert response.status_code == 200
+    assert get_dojo_challenge_id(dojo_id, "m", "new") == stale_challenge_id
+
+    spec["modules"] = [{
+        "id": "m",
+        "resources": [{"type": "challenge", "id": "old", "name": "Old"}],
+    }]
+    response = session.post(f"{DOJO_URL}/pwncollege_api/v1/dojos/{dojo}/update", json=spec)
+    assert response.status_code == 200
+    assert get_dojo_challenge_id(dojo_id, "m", "old") == challenge_id
+
+    spec["modules"] = [{
+        "id": "m",
+        "resources": [{"type": "challenge", "id": "new", "name": "New", "transfer": {"challenge": "old", "overwrite": True}}],
     }]
     response = session.post(f"{DOJO_URL}/pwncollege_api/v1/dojos/{dojo}/update", json=spec)
     assert response.status_code == 200


### PR DESCRIPTION
## Problem

Removing a module can leave its physical challenge rows behind. When the same module and challenge IDs are later used as transfer destinations, the loader reuses those stale rows and leaves the source challenge IDs and solves in place.

Always bypassing an existing destination would change established transfer behavior and could replace the wrong challenge unexpectedly.

## Summary

- add an optional `overwrite` flag to challenge transfers
- keep destination reuse as the default behavior
- resolve overwritten sources through their exact dojo associations
- preserve ownership checks for imported and shared challenges

## Testing

- add a regression that creates and removes a destination challenge to leave a stale row
- verify the default transfer reuses the stale destination
- verify `overwrite: true` preserves the source challenge ID
- verify the overwritten transfer remains stable on replay
- verify Python syntax and whitespace checks