### PR TITLE
Site: Exclude optional challenges from profile progress

### DIFF
--- a/dojo_plugin/pages/users.py
+++ b/dojo_plugin/pages/users.py
@@ -78,6 +78,7 @@ def view_hacker(user, bypass_hidden=False):
 
     dojos = (Dojos
              .viewable(user=get_current_user())
+             .options(db.undefer(Dojos.required_challenges_count))
              .filter(Dojos.data["type"].astext != "hidden", Dojos.data["type"].astext != "course")
              .all())
     user_solves = {}

--- a/dojo_plugin/worker/handlers/scores.py
+++ b/dojo_plugin/worker/handlers/scores.py
@@ -25,6 +25,7 @@ def _scores_query(granularity, dojo_filter):
     dsc_query = db.session.query(*fields).where(
         Dojos.dojo_id == DojoChallenges.dojo_id,
         DojoChallenges.challenge_id == Solves.challenge_id,
+        DojoChallenges.required,
         dojo_filter
     ).group_by(*grouping).order_by(Dojos.dojo_id, solve_count.desc(), last_solve_date)
 

--- a/dojo_plugin/worker/handlers/solve.py
+++ b/dojo_plugin/worker/handlers/solve.py
@@ -57,11 +57,11 @@ def handle_challenge_solve(payload, event_timestamp):
         else:
             logger.info(f"User {user_id} is not a member of dojo {dojo_ref_id}, skipping scoreboard/stats updates")
 
-        if is_public_or_official:
+        if is_public_or_official and dojo_challenge.required:
             logger.info(f"Updating scores for dojo {dojo_ref_id}")
             _update_scores(dojo_id, module_index, user_id, event_timestamp)
         else:
-            logger.info(f"Dojo {dojo_ref_id} is not public or official, skipping scores update")
+            logger.info(f"Dojo {dojo_ref_id} is not public or official, or challenge {challenge_name} is optional; skipping scores update")
 
     logger.info(f"Updating activity for user {user_id}")
     _update_user_activity(user_id, solve_date, event_timestamp)

--- a/dojo_theme/templates/hacker.html
+++ b/dojo_theme/templates/hacker.html
@@ -89,7 +89,7 @@
         <h2>{{ dojo.name }}</h2>
         <h4>
           <i class="fas fa-flag pt-3 pr-3" title="Solves"></i>
-          <td>{{ solves }} / {{ dojo.challenges | length }}</td>
+          <td>{{ solves }} / {{ dojo.required_challenges_count }}</td>
           <i class="fas fa-trophy pt-3 pr-3 pl-5 " title="Rank"></i>
           <td>{{ rank or "-" }} / {{ max_rank or "-" }}</td>
         </h4>
@@ -107,7 +107,7 @@
               <h4 class="accordion-item-name">{{ module.name }}</h4>
               <span class="challenge-header-right">
                 <i class="fas fa-flag pr-1" title="Solves"></i>
-                <td>{{ solves }} / {{ module.challenges | length }}</td>
+                <td>{{ solves }} / {{ module.challenges | selectattr("required") | list | length }}</td>
                 <i class="fas fa-trophy pr-1 pl-3 " title="Rank"></i>
                 <td>{{ rank or "-" }} / {{ max_rank or "-" }}</td>
               </span>


### PR DESCRIPTION
Optional challenges were excluded from dojo and module progress but still counted by the cached profile ranking queries and profile denominators, causing completed users to appear as 10/12 while users with historical optional solves appeared as 12/12. This change limits both cold and incremental profile scores to required challenges and renders profile totals from required challenge counts so profiles match the rest of the site.