### PR TITLE
Secure dojo file initialization and updates

### DIFF
--- a/dojo_plugin/api/v1/dojos.py
+++ b/dojo_plugin/api/v1/dojos.py
@@ -145,7 +145,7 @@ class UpdateDojo(Resource):
             return {"success": False, "error": "Missing dojo spec."}, 400
 
         try:
-            dojo_from_spec(data, dojo=dojo)
+            dojo_from_spec(data, dojo=dojo, platform_admin=is_admin())
             db.session.commit()
         except Exception as e:
             db.session.rollback()

--- a/dojo_plugin/pages/dojo.py
+++ b/dojo_plugin/pages/dojo.py
@@ -6,6 +6,7 @@ import traceback
 import datetime
 import sys
 import re
+import secrets
 
 from flask import Blueprint, render_template, abort, send_file, redirect, url_for, Response, stream_with_context, request, g
 from sqlalchemy.exc import IntegrityError
@@ -195,15 +196,14 @@ def join_dojo(dojo, password=None):
     return redirect(url_for("pwncollege_dojo.listing", dojo=dojo.reference_id))
 
 
-@dojo.route("/dojo/<dojo>/update/", methods=["GET", "POST"])
-@dojo.route("/dojo/<dojo>/update/<update_code>", methods=["GET", "POST"])
+@dojo.route("/dojo/<dojo>/update/<update_code>", methods=["POST"])
 @bypass_csrf_protection
-def update_dojo(dojo, update_code=None):
+def update_dojo(dojo, update_code):
     dojo = Dojos.from_id(dojo).first()
     if not dojo:
         return {"success": False, "error": "Not Found"}, 404
 
-    if dojo.update_code != update_code:
+    if not secrets.compare_digest(dojo.update_code, update_code):
         return {"success": False, "error": "Forbidden"}, 403
 
     try:

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -36,7 +36,7 @@ UNIQUE_ID_REGEX = Regex(r"^[a-z0-9-~]{1,128}$")
 NAME_REGEX = Regex(r"^[\S ]{1,128}$")
 IMAGE_REGEX = Regex(r"^[\S]{1,256}$")
 FILE_PATH_REGEX = Regex(r"^[A-Za-z0-9_][A-Za-z0-9-_./]*$")
-FILE_URL_REGEX = Regex(r"^https://www.dropbox.com/[a-zA-Z0-9]*/[a-zA-Z0-9]*/[a-zA-Z0-9]*/[a-zA-Z0-9.-_]*?rlkey=[a-zA-Z0-9]*&dl=1")
+FILE_URL_REGEX = Regex(r"^https://www\.dropbox\.com/[a-zA-Z0-9]+/[a-zA-Z0-9]+/[a-zA-Z0-9]+/[a-zA-Z0-9._-]+\?rlkey=[a-zA-Z0-9]+&dl=1$")
 INTERFACES_LIST = [Or({"name": Regex(r"^[a-zA-Z][a-zA-Z0-9 _-]{0,31}$"),"port": int},{"name": "SSH"})]
 DATE = Use(datetime.datetime.fromisoformat)
 
@@ -304,13 +304,17 @@ def load_surveys(data, dojo_dir):
 
     return data
 
-def dojo_initialize_files(data, dojo_dir):
-    for dojo_file in data.get("files", []):
-        assert is_admin(), "yml-specified files support requires admin privileges"
-        rel_path = dojo_dir / dojo_file["path"]
+def dojo_initialize_files(data, dojo_dir, *, platform_admin=False):
+    dojo_files = data.get("files", [])
+    if dojo_files and not platform_admin:
+        raise AssertionError("yml-specified files support requires admin privileges")
 
-        abs_path = dojo_dir / rel_path
-        assert not abs_path.is_symlink(), f"{rel_path} is a symbolic link!"
+    dojo_dir = dojo_dir.resolve()
+    for dojo_file in dojo_files:
+        rel_path = pathlib.Path(dojo_file["path"])
+        abs_path = (dojo_dir / rel_path).resolve()
+        if abs_path == dojo_dir or not abs_path.is_relative_to(dojo_dir):
+            raise AssertionError(f"{markupsafe.escape(rel_path)} references path outside of the dojo")
         if abs_path.exists():
             continue
         abs_path.parent.mkdir(parents=True, exist_ok=True)
@@ -319,11 +323,11 @@ def dojo_initialize_files(data, dojo_dir):
             urllib.request.urlretrieve(dojo_file["url"], str(abs_path))
             assert abs_path.stat().st_size >= 50*1024*1024, f"{rel_path} is small enough to fit into git ({abs_path.stat().st_size} bytes) --- put it in the repository!"
         if dojo_file["type"] == "text":
-            with open(abs_path, "w") as o:
-                o.write(dojo_file["content"])
+            with open(abs_path, "w") as output:
+                output.write(dojo_file["content"])
 
 
-def dojo_from_dir(dojo_dir, *, dojo=None):
+def dojo_from_dir(dojo_dir, *, dojo=None, platform_admin=False):
     dojo_yml_path = dojo_dir / "dojo.yml"
     assert dojo_yml_path.exists(), "Missing file: `dojo.yml`"
 
@@ -333,15 +337,17 @@ def dojo_from_dir(dojo_dir, *, dojo=None):
     data_raw = yaml.safe_load(dojo_yml_path.read_text())
     data = load_dojo_subyamls(data_raw, dojo_dir)
     data = load_surveys(data, dojo_dir)
-    dojo_initialize_files(data, dojo_dir)
-    return dojo_from_spec(data, dojo_dir=dojo_dir, dojo=dojo)
+    return dojo_from_spec(data, dojo_dir=dojo_dir, dojo=dojo, platform_admin=platform_admin)
 
 
-def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
+def dojo_from_spec(data, *, dojo_dir=None, dojo=None, platform_admin=False):
     try:
         dojo_data = DOJO_SPEC.validate(data)
     except SchemaError as e:
-        raise AssertionError(markupsafe.escape(e))  # TODO: this probably shouldn't be re-raised as an AssertionError
+        raise AssertionError(markupsafe.escape(e))
+
+    if dojo_dir:
+        dojo_initialize_files(dojo_data, dojo_dir, platform_admin=platform_admin)
 
     def assert_importable(o):
         assert o.importable, f"Import disallowed for {o}."
@@ -391,7 +397,7 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None):
             old_module_id = transfer.get("module", module_id)
             old_challenge_id = transfer["challenge"]
             old_dojo = Dojos.from_id(old_dojo_id).first()
-            assert old_dojo and (old_dojo.dojo_id == dojo.dojo_id or dojo.official or (is_admin() and not Dojos.from_id(dojo.id).first()))
+            assert old_dojo and (old_dojo.dojo_id == dojo.dojo_id or dojo.official or (platform_admin and not Dojos.from_id(dojo.id).first()))
             old_challenge = Challenges.query.filter_by(category=old_dojo.hex_dojo_id, name=f"{old_module_id}:{old_challenge_id}").first()
             assert old_challenge, f"unable to find source dojo/module/challenge in database for {old_dojo_id}:{old_module_id}:{old_challenge_id}"
             old_challenge.category = dojo.hex_dojo_id
@@ -636,6 +642,7 @@ def dojo_git_command(dojo, *args, repo_path=None):
 
 def dojo_create(user, repository, public_key, private_key, spec):
     try:
+        platform_admin = is_admin()
         if repository:
             repository_re = r"[\w\-]+/[\w\-]+"
             repository = repository.replace("https://github.com/", "")
@@ -647,7 +654,7 @@ def dojo_create(user, repository, public_key, private_key, spec):
             dojo_dir = dojo_clone(repository, private_key)
 
         elif spec:
-            assert is_admin(), "Must be an admin user to create dojos from spec rather than repositories"
+            assert platform_admin, "Must be an admin user to create dojos from spec rather than repositories"
             dojo_dir = dojo_yml_dir(spec)
             repository, public_key, private_key = None, None, None
 
@@ -656,7 +663,7 @@ def dojo_create(user, repository, public_key, private_key, spec):
 
         dojo_path = pathlib.Path(dojo_dir.name)
 
-        dojo = dojo_from_dir(dojo_path)
+        dojo = dojo_from_dir(dojo_path, platform_admin=platform_admin)
         dojo.repository = repository
         dojo.public_key = public_key
         dojo.private_key = private_key
@@ -686,7 +693,7 @@ def dojo_create(user, repository, public_key, private_key, spec):
     return dojo
 
 
-def dojo_update(dojo):
+def dojo_update(dojo, *, platform_admin=False):
     if dojo.path.exists():
         old_commit = dojo_git_command(dojo, "rev-parse", "HEAD").stdout.decode().strip()
 
@@ -709,7 +716,7 @@ def dojo_update(dojo):
     else:
         tmpdir = dojo_clone(dojo.repository, dojo.private_key)
         os.rename(tmpdir.name, str(dojo.path))
-    return dojo_from_dir(dojo.path, dojo=dojo)
+    return dojo_from_dir(dojo.path, dojo=dojo, platform_admin=platform_admin)
 
 
 def dojo_accessible(id):

--- a/dojo_theme/templates/dojo_admin.html
+++ b/dojo_theme/templates/dojo_admin.html
@@ -22,10 +22,12 @@
       </div>
     <div class="col-lg-auto m-3">
       <figure>
-      <a class="text-decoration-none" href="{{ url_for('pwncollege_dojo.update_dojo', dojo=dojo.reference_id, update_code=dojo.update_code) }}" target="_blank">
-        <i class="fas fa-upload fa-3x"></i>
-        <figcaption><b>Update</b></figcaption>
-      </a>
+      <form action="{{ url_for('pwncollege_dojo.update_dojo', dojo=dojo.reference_id, update_code=dojo.update_code) }}" method="post" target="_blank">
+        <button class="brand-blue text-decoration-none border-0 bg-transparent p-0" type="submit">
+          <i class="fas fa-upload fa-3x"></i>
+          <figcaption><b>Update</b></figcaption>
+        </button>
+      </form>
       </figure>
     </div>
     {% if is_admin() %}
@@ -56,6 +58,16 @@
       </figure>
     </div>
     {% endif %}
+  </div>
+  <label class="mb-1 ml-3 font-weight-bold" for="dojo-update-url-result">Update URL</label>
+  <small class="form-text text-muted mb-2 ml-3">Send an unauthenticated POST request to this URL to update the dojo.</small>
+  <div class="input-group mx-3 mb-3">
+    <input type="text" id="dojo-update-url-result" class="form-control text-monospace" value="{{ url_for('pwncollege_dojo.update_dojo', dojo=dojo.reference_id, update_code=dojo.update_code, _external=True) }}" readonly>
+    <div class="input-group-append copy-button">
+      <button class="btn btn-outline-secondary" type="button">
+        <i class="fas fa-clipboard"></i>
+      </button>
+    </div>
   </div>
   {% if dojo.public_key %}
   <label class="mb-1 ml-3 font-weight-bold" for="dojo-deploy-key-result">Deploy Key</label>

--- a/test/test_dojos.py
+++ b/test/test_dojos.py
@@ -1,3 +1,5 @@
+import html
+import re
 import subprocess
 import requests
 import random
@@ -5,7 +7,7 @@ import string
 import time
 import yaml
 
-from utils import TEST_DOJOS_LOCATION, DOJO_URL, create_dojo_yml, start_challenge, solve_challenge, workspace_run, login, db_sql, get_user_id, wait_for_background_worker
+from utils import TEST_DOJOS_LOCATION, DOJO_URL, create_dojo_yml, start_challenge, solve_challenge, workspace_run, login, db_sql, get_user_id, wait_for_background_worker, dojo_run
 
 
 def get_dojo_modules(dojo):
@@ -41,6 +43,40 @@ survey:
     error = response.json()["error"]
     assert payload not in error
     assert "&lt;img src=x onerror=alert(1)&gt;" in error
+
+
+def test_dojo_files_reject_path_traversal(admin_session):
+    suffix = "".join(random.choices(string.ascii_lowercase, k=8))
+    dojo_id = f"file-path-{suffix}"
+    target = f"/tmp/{dojo_id}"
+    assert dojo_run("docker", "exec", "ctfd", "test", "!", "-e", target, check=False).returncode == 0
+    response = admin_session.post(
+        f"{DOJO_URL}/pwncollege_api/v1/dojos/create",
+        json={"spec": yaml.safe_dump({
+            "id": dojo_id,
+            "files": [{
+                "type": "text",
+                "path": f"a/../../../../../../tmp/{dojo_id}",
+                "content": "unexpected",
+            }],
+        })},
+    )
+    target_missing = dojo_run("docker", "exec", "ctfd", "test", "!", "-e", target, check=False).returncode == 0
+    dojo_run("docker", "exec", "ctfd", "rm", "-f", target, check=False)
+
+    assert response.status_code == 400
+    assert target_missing
+
+
+def test_dojo_update_code_requires_post_not_authentication(example_dojo, admin_session):
+    admin_page = admin_session.get(f"{DOJO_URL}/dojo/{example_dojo}/admin/")
+    action_match = re.search(r'<form action="([^"]+/update/[^"]+)" method="post"', admin_page.text)
+    assert action_match
+    update_url = requests.compat.urljoin(DOJO_URL, html.unescape(action_match.group(1)))
+
+    assert admin_session.get(update_url).status_code in {404, 405}
+
+    assert requests.post(update_url).status_code == 200
 
 
 def test_create_dojo(example_dojo, admin_session):


### PR DESCRIPTION
## Summary

- validate expanded dojo specifications before processing the `files:` field
- resolve every file destination and require it to remain inside the dojo directory
- validate download URLs before fetching them
- replace ambient request-session admin checks with an explicit `platform_admin` capability passed only by trusted creation and authenticated API flows
- make update-code URLs POST-only while keeping unauthenticated automation supported
- show the update URL as a copyable field on the dojo admin page

## Root cause

`dojo_from_dir` initialized files before `DOJO_SPEC.validate` ran. The path construction could resolve traversal paths outside the dojo, and the nonexistent leading component caused the existing symlink and existence checks to miss the eventual destination.

The token update endpoint also accepted GET requests. Because downstream file authorization consulted the current request's admin session, an attacker-controlled dojo page could cause an administrator's browser to trigger a privileged update automatically.

## Impact

File side effects now occur only after schema validation, and resolved destinations must remain contained by the dojo directory. Update-code requests retain code-as-auth automation without inheriting privileges from a logged-in browser session. Existing automation must send POST instead of GET.

## Validation

- `7 passed`: traversal rejection, unauthenticated POST update, authenticated dojo update with files, LFS/download files, import overrides, internal transfers, and denied cross-dojo transfers
- Python compilation for the modified modules and tests
- `git diff --check`
