### PR TITLE
Add auto-start workspace URLs

### DIFF
--- a/dojo_plugin/api/v1/docker.py
+++ b/dojo_plugin/api/v1/docker.py
@@ -268,7 +268,7 @@ def insert_flag(container, flag):
         ws.close()
 
 
-def start_challenge(user, dojo_challenge, practice, *, as_user=None):
+def start_challenge(user, dojo_challenge, practice, *, as_user=None, home=True):
     docker_client = user_docker_client(user, image_name=dojo_challenge.image)
     node_id = user_node(user)
     if node_id is None:
@@ -279,7 +279,7 @@ def start_challenge(user, dojo_challenge, practice, *, as_user=None):
     remove_container(user)
 
     user_mounts = []
-    if as_user is None:
+    if home and as_user is None:
         user_mounts.append(
             docker.types.Mount(
                 "/home/hacker",
@@ -289,7 +289,7 @@ def start_challenge(user, dojo_challenge, practice, *, as_user=None):
                 driver_config=docker.types.DriverConfig("homefs", options=dict(trace_id=get_trace_id())),
             )
         )
-    else:
+    elif home:
         user_mounts.extend([
             docker.types.Mount(
                 "/home/hacker",
@@ -431,6 +431,10 @@ class RunDocker(Resource):
         module_id = data.get("module")
         challenge_id = data.get("challenge")
         practice = data.get("practice")
+        home = data.get("home", True)
+
+        if not isinstance(home, bool):
+            return {"success": False, "error": "Invalid home option"}
 
         user = get_current_user()
         as_user = None
@@ -496,7 +500,7 @@ class RunDocker(Resource):
         for attempt in range(1, max_attempts+1):
             try:
                 logger.info(f"Starting challenge for user {user.id} (attempt {attempt}/{max_attempts})...")
-                start_challenge(user, dojo_challenge, practice, as_user=as_user)
+                start_challenge(user, dojo_challenge, practice, as_user=as_user, home=home)
 
                 if dojo.official or dojo.data.get("type") == "public":
                     challenge_data = {

--- a/dojo_plugin/pages/workspace.py
+++ b/dojo_plugin/pages/workspace.py
@@ -26,6 +26,36 @@ port_names = {
 @workspace.route("/workspace", methods=["GET"])
 @authed_only
 def view_workspace():
+    launch_ids = {
+        key: request.args.get(key)
+        for key in ("dojo", "module", "challenge")
+    }
+    if any(value is not None for value in launch_ids.values()):
+        if not all(launch_ids.values()):
+            return render_template(
+                "error.html",
+                error="dojo, module, and challenge are all required to start a workspace",
+            ), 400
+
+        launch_options = {}
+        for key, default in (("practice", False), ("home", True)):
+            value = request.args.get(key)
+            if value is None:
+                launch_options[key] = default
+            elif value.lower() == "true":
+                launch_options[key] = True
+            elif value.lower() == "false":
+                launch_options[key] = False
+            else:
+                return render_template(
+                    "error.html",
+                    error=f"{key} must be true or false",
+                ), 400
+
+        return render_template(
+            "workspace_launch.html",
+            launch={**launch_ids, **launch_options},
+        )
 
     current_challenge = get_current_dojo_challenge()
     if not current_challenge:

--- a/dojo_theme/templates/workspace_launch.html
+++ b/dojo_theme/templates/workspace_launch.html
@@ -1,0 +1,85 @@
+{% extends "base.html" %}
+
+
+{% block stylesheets %}
+{{ super() }}
+
+<style>
+    .workspace-launch {
+        min-height: 70vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+    }
+
+    .workspace-launch-spinner {
+        width: 3rem;
+        height: 3rem;
+        margin: 0 auto 1.5rem;
+        border: 0.35rem solid var(--brand-light-gray);
+        border-top-color: var(--brand-blue);
+        border-radius: 50%;
+        animation: workspace-launch-spin 0.8s linear infinite;
+    }
+
+    @keyframes workspace-launch-spin {
+        to { transform: rotate(360deg); }
+    }
+</style>
+{% endblock %}
+
+
+{% block content %}
+<div class="workspace-launch">
+  <div>
+    <div id="workspace-launch-spinner" class="workspace-launch-spinner" role="status">
+      <span class="sr-only">Starting challenge</span>
+    </div>
+    <h2 id="workspace-launch-status">Starting challenge...</h2>
+    <div id="workspace-launch-error" class="alert alert-danger mt-4" style="display: none;"></div>
+  </div>
+</div>
+{% endblock %}
+
+
+{% block scripts %}
+<script>
+window.addEventListener("load", async function () {
+    const spinner = document.getElementById("workspace-launch-spinner");
+    const status = document.getElementById("workspace-launch-status");
+    const error = document.getElementById("workspace-launch-error");
+
+    try {
+        const response = await CTFd.fetch("/pwncollege_api/v1/docker", {
+            method: "POST",
+            credentials: "same-origin",
+            headers: {
+                "Accept": "application/json",
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify({{ launch | tojson }})
+        });
+
+        if (response.status === 403) {
+            window.location = CTFd.config.urlRoot + "/login?next=" +
+                encodeURIComponent(window.location.pathname + window.location.search);
+            return;
+        }
+
+        const result = await response.json();
+        if (!result.success) {
+            throw new Error(result.error || "Failed to start challenge");
+        }
+
+        status.textContent = "Opening workspace...";
+        window.location.replace({{ url_for("pwncollege_workspace.view_workspace") | tojson }});
+    } catch (exception) {
+        spinner.style.display = "none";
+        status.textContent = "Failed to start challenge";
+        error.textContent = exception.message || "An unexpected error occurred";
+        error.style.display = "block";
+    }
+});
+</script>
+{% endblock %}

--- a/test/test_challenges.py
+++ b/test/test_challenges.py
@@ -2,7 +2,7 @@ import subprocess
 import pytest
 import json
 import re
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
@@ -134,6 +134,32 @@ def test_workspace_challenge():
 
 def test_workspace_home_mount():
     check_mount("/home/hacker", user="admin")
+
+
+def test_workspace_auto_start_without_home_mount(
+    random_user_name, random_user_session, random_user_browser, example_dojo
+):
+    query = urlencode({
+        "dojo": example_dojo,
+        "module": "hello",
+        "challenge": "apple",
+        "home": "false",
+    })
+    random_user_browser.get(f"{DOJO_URL}/workspace?{query}")
+
+    assert random_user_browser.find_element(By.ID, "workspace-launch-status").text.startswith("Starting challenge")
+    WebDriverWait(random_user_browser, 60).until(
+        lambda browser: browser.current_url.rstrip("/").endswith("/workspace")
+    )
+    assert random_user_browser.find_element(By.ID, "workspace-iframe")
+
+    workspace_run("test -d /home/hacker", user=random_user_name)
+    with pytest.raises(subprocess.CalledProcessError):
+        workspace_run("findmnt --mountpoint /home/hacker", user=random_user_name)
+
+    workspace_run("touch /home/hacker/ephemeral", user=random_user_name)
+    start_challenge(example_dojo, "hello", "apple", session=random_user_session, home=False)
+    workspace_run("test ! -e /home/hacker/ephemeral", user=random_user_name)
 
 
 def test_workspace_no_sudo():

--- a/test/utils.py
+++ b/test/utils.py
@@ -180,10 +180,12 @@ def workspace_run(cmd, *, user, root=False, **kwargs):
     return dojo_run(*args, stdin=subprocess.DEVNULL, check=True, container=outer_container, **kwargs)
 
 
-def start_challenge(dojo, module, challenge, practice=False, *, session, as_user=None, wait=0):
+def start_challenge(dojo, module, challenge, practice=False, *, session, as_user=None, home=None, wait=0):
     start_challenge_json = dict(dojo=dojo, module=module, challenge=challenge, practice=practice)
     if as_user:
         start_challenge_json["as_user"] = as_user
+    if home is not None:
+        start_challenge_json["home"] = home
     response = session.post(f"{DOJO_URL}/pwncollege_api/v1/docker", json=start_challenge_json)
     assert response.status_code == 200, f"Expected status code 200, but got {response.status_code}"
     assert response.json()["success"], f"Failed to start challenge: {response.json()['error']}"


### PR DESCRIPTION
## Summary

- add `/workspace?dojo=…&module=…&challenge=…` as an authenticated auto-start URL
- show a loading/error view while a same-origin POST starts the requested challenge, then replace the URL with plain `/workspace` and load the existing workspace iframe view
- support validated `practice=true|false` and `home=true|false` launch options
- make `home=false` skip the persistent home volume; `dojo-init` creates an ordinary ephemeral `/home/hacker` inside the container

## Why

This provides a simple URL for automation and external links that can launch a specific dojo/module/challenge directly into the workspace. The launcher remains a GET-able page, while challenge startup still goes through the existing authenticated POST endpoint.

## Validation

- `test_start_challenge`
- `test_workspace_home_mount`
- `test_workspace_home_persistent`
- `test_workspace_auto_start_without_home_mount`

All four focused tests pass locally. The new browser test covers the loading page, automatic start, redirect to `/workspace`, iframe rendering, absence of a `/home/hacker` mount, and ephemeral-home behavior across restart.