### PR TITLE
Workspace: expose start failure diagnostics to dojo admins

### DIFF
--- a/dojo_plugin/api/v1/docker.py
+++ b/dojo_plugin/api/v1/docker.py
@@ -48,6 +48,13 @@ docker_namespace = Namespace(
 HOST_HOMES = pathlib.Path(HOST_DATA_PATH) / "workspace" / "homes"
 HOST_HOMES_MOUNTS = HOST_HOMES / "mounts"
 HOST_HOMES_OVERLAYS = HOST_HOMES / "overlays"
+WORKSPACE_OUTPUT_LIMIT = 16 * 1024
+
+
+class WorkspaceInitializationError(RuntimeError):
+    def __init__(self, message, output):
+        super().__init__(message)
+        self.output = output
 
 
 def remove_container(user):
@@ -210,14 +217,22 @@ def start_container(docker_client, user, as_user, user_mounts, dojo_challenge, p
 
     container.start()
     logger.info(f"container started after {time.time()-start_time:.1f} seconds")
+    workspace_output = bytearray()
     for message in log_generator_output(
         "workspace initialization ", container.logs(stream=True, follow=True), start_time=start_time
     ):
+        workspace_output.extend(message)
+        if len(workspace_output) > WORKSPACE_OUTPUT_LIMIT:
+            del workspace_output[:-WORKSPACE_OUTPUT_LIMIT]
+
         if b"DOJO_INIT_INITIALIZED" in message or message == b"Initialized.\n":
             logger.info(f"workspace initialized after {time.time()-start_time:.1f} seconds")
             break
     else:
-        raise RuntimeError(f"Workspace failed to initialize after {time.time()-start_time:.1f} seconds.")
+        raise WorkspaceInitializationError(
+            f"Workspace failed to initialize after {time.time()-start_time:.1f} seconds.",
+            workspace_output.decode(errors="replace"),
+        )
 
     cache.set(f"user_{user.id}-running-image", resolved_dojo_challenge.image, timeout=0)
     return container
@@ -331,17 +346,32 @@ def start_challenge(user, dojo_challenge, practice, *, as_user=None, home=True):
         flag = serialize_user_flag(as_user.id, dojo_challenge.challenge_id)
     insert_flag(container, flag)
 
+    workspace_output = bytearray()
     for message in log_generator_output(
         "workspace readying ", container.logs(stream=True, follow=True), start_time=start_time
     ):
+        workspace_output.extend(message)
+        if len(workspace_output) > WORKSPACE_OUTPUT_LIMIT:
+            del workspace_output[:-WORKSPACE_OUTPUT_LIMIT]
+
         if b"DOJO_INIT_READY" in message or message == b"Ready.\n":
             logger.info(f"workspace ready after {time.time()-start_time:.1f} seconds")
             break
         if b"DOJO_INIT_FAILED:" in message:
-            cause = message.split(b"DOJO_INIT_FAILED:")[1].split(b"\n")[0]
-            raise RuntimeError(f"DOJO_INIT_FAILED: {cause}")
+            cause = (
+                message.split(b"DOJO_INIT_FAILED:", 1)[1]
+                .split(b"\n", 1)[0]
+                .decode(errors="replace")
+            )
+            raise WorkspaceInitializationError(
+                f"DOJO_INIT_FAILED: {cause}",
+                workspace_output.decode(errors="replace"),
+            )
     else:
-        raise RuntimeError(f"Workspace failed to become ready.")
+        raise WorkspaceInitializationError(
+            "Workspace failed to become ready.",
+            workspace_output.decode(errors="replace"),
+        )
 
 def docker_locked(func):
     def wrapper(*args, **kwargs):
@@ -498,6 +528,7 @@ class RunDocker(Resource):
                 as_user = student.user
 
         max_attempts = 3
+        attempt_errors = []
         for attempt in range(1, max_attempts+1):
             try:
                 logger.info(f"Starting challenge for user {user.id} (attempt {attempt}/{max_attempts})...")
@@ -521,12 +552,27 @@ class RunDocker(Resource):
                 break
             except Exception as e:
                 logger.warning(f"Attempt {attempt} failed for user {user.id} with error: {e}")
+                attempt_error = {
+                    "attempt": attempt,
+                    "type": type(e).__name__,
+                    "message": str(e),
+                }
+                if isinstance(e, WorkspaceInitializationError):
+                    attempt_error["output"] = e.output
+                attempt_errors.append(attempt_error)
                 if attempt < max_attempts:
                     logger.info(f"Retrying... ({attempt}/{max_attempts})")
                     time.sleep(2)
         else:
             logger.error(f"ERROR: Docker failed for {user.id} after {max_attempts} attempts.")
-            return {"success": False, "error": "Docker failed"}
+            response = {"success": False, "error": "Docker failed"}
+            resolved_dojo_challenge = dojo_challenge.resolve()
+            if resolved_dojo_challenge and resolved_dojo_challenge.dojo.is_admin(user):
+                response["debug"] = {
+                    "trace_id": get_trace_id(),
+                    "attempts": attempt_errors,
+                }
+            return response
 
         return {"success": True}
 

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -360,6 +360,9 @@ function actionStartChallenge(event, privileged) {
             return response.json();
         }).then(function (result) {
             if (result.success == false) {
+                if (result.debug) {
+                    console.error("Challenge start failed:", result.debug);
+                }
                 startFailed(result.error);
                 return;
             }

--- a/dojo_theme/static/js/dojo/challenges.js
+++ b/dojo_theme/static/js/dojo/challenges.js
@@ -249,6 +249,9 @@ function startChallenge(event) {
             item.find(".challenge-name").addClass("challenge-active");
         }
         else {
+            if (result.debug) {
+                console.error("Challenge start failed:", result.debug);
+            }
             result_message.html("Error:<br><code></code><br>");
             result_message.find("code").text(result.error);
             result_notification.addClass('alert alert-warning alert-dismissable text-center');

--- a/dojo_theme/templates/workspace_launch.html
+++ b/dojo_theme/templates/workspace_launch.html
@@ -69,6 +69,9 @@ window.addEventListener("load", async function () {
 
         const result = await response.json();
         if (!result.success) {
+            if (result.debug) {
+                console.error("Challenge start failed:", result.debug);
+            }
             throw new Error(result.error || "Failed to start challenge");
         }
 

--- a/test/test_challenges.py
+++ b/test/test_challenges.py
@@ -6,7 +6,7 @@ from urllib.parse import quote, urlencode
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
-from utils import DOJO_URL, dojo_run, workspace_run, start_challenge, solve_challenge, db_sql, get_user_id
+from utils import DOJO_URL, create_dojo_yml, dojo_run, workspace_run, start_challenge, solve_challenge, db_sql, get_user_id
 
 def check_mount(path, *, user, fstype=None, check_nosuid=True):
     try:
@@ -29,6 +29,55 @@ def check_mount(path, *, user, fstype=None, check_nosuid=True):
 
 def test_start_challenge(admin_session, example_dojo):
     start_challenge(example_dojo, "hello", "apple", session=admin_session)
+
+
+def test_start_challenge_failure_debug(admin_session, guest_dojo_admin, random_user_session):
+    dojo_admin_name, dojo_admin_session = guest_dojo_admin
+    dojo = create_dojo_yml(f"""
+id: docker-failure-{dojo_admin_name}
+type: public
+image: pwncollege/challenge-simple
+modules:
+  - id: test
+    challenges:
+      - id: test
+files:
+  - type: text
+    path: test/test/.init
+    content: |
+      #!/bin/sh
+      printf '%20000s\\n' x
+      echo init-stdout
+      echo init-stderr >&2
+      exit 1
+""", session=admin_session)
+
+    assert dojo_admin_session.get(f"{DOJO_URL}/dojo/{dojo}/join/").status_code == 200
+    response = admin_session.post(
+        f"{DOJO_URL}/pwncollege_api/v1/dojos/{dojo}/admins/promote",
+        json={"user_id": get_user_id(dojo_admin_name)},
+    )
+    assert response.status_code == 200
+
+    start_data = {"dojo": dojo, "module": "test", "challenge": "test", "practice": False}
+    response = dojo_admin_session.post(f"{DOJO_URL}/pwncollege_api/v1/docker", json=start_data)
+    assert response.status_code == 200
+    result = response.json()
+    assert result["success"] is False
+    assert result["error"] == "Docker failed"
+    assert result["debug"]["trace_id"]
+    assert [attempt["attempt"] for attempt in result["debug"]["attempts"]] == [1, 2, 3]
+    for attempt in result["debug"]["attempts"]:
+        assert attempt["type"] == "WorkspaceInitializationError"
+        assert attempt["message"] == "DOJO_INIT_FAILED: Challenge initialization error."
+        assert "init-stdout" in attempt["output"]
+        assert "init-stderr" in attempt["output"]
+        assert len(attempt["output"].encode()) <= 16 * 1024
+
+    response = random_user_session.post(f"{DOJO_URL}/pwncollege_api/v1/docker", json=start_data)
+    assert response.status_code == 200
+    result = response.json()
+    assert result == {"success": False, "error": "Docker failed"}
 
 
 def test_start_challenge_error_renders_as_user_as_text(browser_fixture, example_dojo):


### PR DESCRIPTION
## Summary

- retain a bounded 16 KiB tail of workspace initialization and readiness output for each failed start attempt
- include the trace ID, exception type/message, and captured output only when the requester administers the resolved source dojo
- log authorized diagnostics in each challenge-launch frontend while preserving the generic Docker failed response for other users

## Testing

- docker integration: test/test_challenges.py::test_start_challenge_failure_debug (passed)
- python -m compileall -q dojo_plugin/api/v1/docker.py test/test_challenges.py
- node --check dojo_theme/static/js/dojo/actionbar.js
- node --check dojo_theme/static/js/dojo/challenges.js
- git diff --check