### PR TITLE
Workspace: add full controls to service routes

### DIFF
--- a/dojo_plugin/pages/workspace.py
+++ b/dojo_plugin/pages/workspace.py
@@ -26,6 +26,22 @@ port_names = {
 @workspace.route("/workspace", methods=["GET"])
 @authed_only
 def view_workspace():
+    return render_workspace()
+
+
+@workspace.route("/workspace/<int:port>", strict_slashes=False)
+@authed_only
+def view_workspace_port(port):
+    return render_workspace(port=port)
+
+
+@workspace.route("/workspace/<string:service>", strict_slashes=False)
+@authed_only
+def view_workspace_service(service):
+    return render_workspace(service=service)
+
+
+def render_workspace(*, service=None, port=None):
     launch_ids = {
         key: request.args.get(key)
         for key in ("dojo", "module", "challenge")
@@ -55,6 +71,7 @@ def view_workspace():
         return render_template(
             "workspace_launch.html",
             launch={**launch_ids, **launch_options},
+            workspace_url=request.path,
         )
 
     current_challenge = get_current_dojo_challenge()
@@ -62,22 +79,30 @@ def view_workspace():
         return render_template("error.html", error="No active challenge session; start a challenge!")
 
     practice = get_current_container().labels.get("dojo.mode") == "privileged"
+    initial_service = None
+    if service is not None or port is not None:
+        for interface in current_challenge.interfaces:
+            interface_name = interface["name"].lower()
+            interface_port = interface.get("port")
+            if service is not None and interface_name != service.lower():
+                continue
+            if port is not None and interface_port != port:
+                continue
+            initial_service = f"{interface_name}: {interface_port or ''}"
+            break
+
+        if initial_service is None:
+            return render_template(
+                "error.html",
+                error="Workspace service is not available for the active challenge",
+            ), 404
 
     return render_template(
         "workspace.html",
         practice=practice,
         challenge=current_challenge,
+        initial_service=initial_service,
     )
-
-@workspace.route("/workspace/<int:port>", strict_slashes=False)
-@authed_only
-def view_workspace_port(port):
-    return render_template("workspace_port.html", iframe_name="workspace", port=port)
-
-@workspace.route("/workspace/<string:service>", strict_slashes=False)
-@authed_only
-def view_workspace_service(service):
-    return render_template("workspace_service.html", iframe_name="workspace", service=service)
 
 def forward_workspace(service, signature, message, service_path="", include_host=True, **kwargs):
     if service.count("~") == 0:

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -134,8 +134,8 @@ function loadIframe(service, content) {
     }
 }
 
-function popoutUrl(service) {
-    if (isSpecialService(service)) {
+function workspaceUrl(service) {
+    if (isSpecialService(service) || servicePort(service) === "") {
         return "/workspace/" + encodeURIComponent(serviceName(service));
     }
     return "/workspace/" + encodeURIComponent(servicePort(service));
@@ -148,23 +148,44 @@ function selectService(service, log=true) {
         return;
     }
     if (log) {logService(service);}
-    const root = $(content).closest(".challenge-workspace").find(".workspace-controls");
+    const workspace = $(content).closest(".challenge-workspace");
+    const root = workspace.find(".workspace-controls");
+    $(content).show();
+    workspace.find(".workspace-description").hide();
+    root.find(".workspace-description-control").removeClass("active").attr("aria-pressed", "false");
     root.find(".workspace-service").each(function () {
         const active = $(this).attr("data-service") === service;
         $(this).toggleClass("active", active);
         $(this).attr("aria-pressed", active ? "true" : "false");
     });
+    if (!isPopout(root)) {
+        const url = new URL(window.location.href);
+        url.pathname = workspaceUrl(service);
+        window.history.replaceState(null, "", url);
+    }
     if (serviceName(service) == "ssh" && servicePort(service) == "") {
         content.src = "";
         $(content).addClass("SSH");
-        $(".workspace-ssh").show();
+        workspace.find(".workspace-ssh").show();
         return;
     }
     else {
         $(content).removeClass("SSH");
-        $(".workspace-ssh").hide();
+        workspace.find(".workspace-ssh").hide();
     }
     loadIframe(service, content);
+}
+
+function descriptionClickCallback(event) {
+    event.preventDefault();
+    const button = $(event.currentTarget);
+    const root = context(event);
+    const workspace = root.closest(".challenge-workspace");
+    workspace.find("#workspace-iframe").hide();
+    workspace.find(".workspace-ssh").hide();
+    workspace.find(".workspace-description").show();
+    root.find(".workspace-service").removeClass("active").attr("aria-pressed", "false");
+    button.addClass("active").attr("aria-pressed", "true");
 }
 
 function portlessButton(root) {
@@ -211,17 +232,17 @@ function serviceClickCallback(event) {
         }
         return;
     }
-    const popout = window.open("", "workspace-" + popoutUrl(service).split("/").pop());
+    const popout = window.open("", "workspace-" + workspaceUrl(service).split("/").pop());
     if (!popout) {
         animateBanner(event, "Pop-up blocked — please allow pop-ups for this site.", "warn");
         return;
     }
     let needsNavigation = true;
     try {
-        needsNavigation = popout.location.pathname !== popoutUrl(service);
+        needsNavigation = popout.location.pathname !== workspaceUrl(service);
     } catch (error) {}
     if (needsNavigation) {
-        popout.location = popoutUrl(service);
+        popout.location = workspaceUrl(service);
     }
     popout.focus();
 }
@@ -415,7 +436,10 @@ function loadWorkspace(log=true) {
         }
         return;
     }
-    var recent = getRecentService(root);
+    var recent = root.closest(".challenge-workspace").attr("data-initial-service");
+    if (!recent) {
+        recent = getRecentService(root);
+    }
     if (recent == null) {
         recent = root.find(".workspace-service").first().attr("data-service");
     }
@@ -443,6 +467,7 @@ $(() => {
     loadWorkspace();
     $(".workspace-controls").each(function () {
         $(this).find(".workspace-service").click(serviceClickCallback);
+        $(this).find(".workspace-description-control").click(descriptionClickCallback);
 
         $(this).find("#flag-input").on("input", function(event) {
             event.preventDefault();

--- a/dojo_theme/templates/components/actionbar.html
+++ b/dojo_theme/templates/components/actionbar.html
@@ -36,13 +36,15 @@
     justify-content: center;
   }
 
-  button.workspace-control.workspace-service {
+  button.workspace-control.workspace-service,
+  button.workspace-control.workspace-description-control {
     width: auto;
     padding-left: 0.75em;
     padding-right: 0.75em;
   }
 
-  .workspace-service .workspace-service-name {
+  .workspace-service .workspace-service-name,
+  .workspace-description-control .workspace-description-name {
     margin-left: 0.4em;
   }
 
@@ -53,13 +55,15 @@
     opacity: 0.6;
   }
 
-  .workspace-service.active {
+  .workspace-service.active,
+  .workspace-description-control.active {
     color: #fff;
     background-color: var(--foreground) !important;
     box-shadow: inset 0 0 0 1px var(--highlight) !important;
   }
 
-  .workspace-service.active:focus {
+  .workspace-service.active:focus,
+  .workspace-description-control.active:focus {
     box-shadow: inset 0 0 0 1px var(--highlight), 0 0 0 0.2rem rgba(108, 117, 125, 0.5) !important;
   }
 
@@ -217,6 +221,13 @@
     {% if popout and not service.port %}<i class="fas fa-question-circle hint-icon"></i>{% endif %}
   </button>
   {% endfor %}
+  {% if not popout %}
+  <button id="workspace-description" class="workspace-control workspace-description-control btn btn-md btn-outline-secondary"
+      aria-pressed="false" title="Show challenge description">
+    <i class="fas fa-book-open"></i>
+    <span class="workspace-description-name">Description</span>
+  </button>
+  {% endif %}
   <div title="Enter flag" class="workspace-control workspace-input">
     <i class="fas fa-flag workspace-highlight input-icon"></i>
     <input id="flag-input" type="text" placeholder="Flag">

--- a/dojo_theme/templates/workspace.html
+++ b/dojo_theme/templates/workspace.html
@@ -45,16 +45,31 @@
         flex: none;
         margin: 1em;
     }
+
+    .workspace-description {
+        flex: 1;
+        min-height: 0;
+        overflow: auto;
+        padding: 2rem;
+    }
+
+    .challenge-workspace > .workspace-controls {
+        flex: none;
+        margin-top: auto;
+    }
 </style>
 {% endblock %}
 
 
 {% block content %}
-<div class="challenge-workspace">
-  <iframe src="" id="workspace-iframe" allow="clipboard-read *; clipboard-write *"></iframe>
+<div class="challenge-workspace" data-initial-service="{{ initial_service or '' }}">
+  <iframe src="" id="workspace-iframe" name="workspace" allow="clipboard-read *; clipboard-write *"></iframe>
   <div class="workspace-ssh" style="display: none;">
     <h3>Connect with SSH</h3>
     Link your <a href="/settings#ssh-key" target="_blank">SSH key</a>, then connect with: <code>ssh hacker@dojo.pwn.college</code>
+  </div>
+  <div class="workspace-description" style="display: none;">
+    {{ challenge.description | markdown }}
   </div>
   {% include "components/actionbar.html" %}
 </div>

--- a/dojo_theme/templates/workspace_launch.html
+++ b/dojo_theme/templates/workspace_launch.html
@@ -76,7 +76,7 @@ window.addEventListener("load", async function () {
         }
 
         status.textContent = "Opening workspace...";
-        window.location.replace({{ url_for("pwncollege_workspace.view_workspace") | tojson }});
+        window.location.replace({{ workspace_url | tojson }});
     } catch (exception) {
         spinner.style.display = "none";
         status.textContent = "Failed to start challenge";

--- a/test/dojos/custom_interfaces.yml
+++ b/test/dojos/custom_interfaces.yml
@@ -9,6 +9,7 @@ modules:
     challenges:
       - id: test1
         name: test1
+        description: Interface test challenge description.
       - id: test2
         name: test2
         interfaces:

--- a/test/test_challenges.py
+++ b/test/test_challenges.py
@@ -194,13 +194,22 @@ def test_workspace_auto_start_without_home_mount(
         "challenge": "apple",
         "home": "false",
     })
-    random_user_browser.get(f"{DOJO_URL}/workspace?{query}")
+    random_user_browser.get(f"{DOJO_URL}/workspace/terminal?{query}")
 
     assert random_user_browser.find_element(By.ID, "workspace-launch-status").text.startswith("Starting challenge")
     WebDriverWait(random_user_browser, 60).until(
-        lambda browser: browser.current_url.rstrip("/").endswith("/workspace")
+        lambda browser: browser.current_url.rstrip("/").endswith("/workspace/terminal")
     )
-    assert random_user_browser.find_element(By.ID, "workspace-iframe")
+    workspace_iframe = random_user_browser.find_element(By.ID, "workspace-iframe")
+    workspace_controls = random_user_browser.find_element(By.CSS_SELECTOR, ".workspace-controls")
+    terminal_button = workspace_controls.find_element(
+        By.CSS_SELECTOR, '.workspace-service[data-service="terminal: 7681"]'
+    )
+    assert workspace_controls.get_attribute("data-popout") == "false"
+    assert "active" in terminal_button.get_attribute("class")
+    WebDriverWait(random_user_browser, 30).until(
+        lambda browser: "/7681/" in (workspace_iframe.get_attribute("src") or "")
+    )
 
     workspace_run("test -d /home/hacker", user=random_user_name)
     with pytest.raises(subprocess.CalledProcessError):

--- a/test/test_welcome.py
+++ b/test/test_welcome.py
@@ -22,7 +22,16 @@ def vscode_terminal(browser):
     browser.get(f"{DOJO_URL}/workspace/code")
 
     wait = WebDriverWait(browser, 30)
-    workspace_iframe = wait.until(EC.presence_of_element_located((By.ID, "workspace_iframe")))
+    workspace_iframe = wait.until(
+        lambda driver: next(
+            (
+                iframe
+                for iframe in driver.find_elements(By.ID, "workspace-iframe")
+                if "/8080/" in (iframe.get_attribute("src") or "")
+            ),
+            False,
+        )
+    )
     browser.switch_to.frame(workspace_iframe)
 
     def wait_for_selector(*selectors):
@@ -106,17 +115,23 @@ def ttyd_terminal(browser):
     browser.get(f"{DOJO_URL}/workspace/terminal")
 
     wait = WebDriverWait(browser, 30)
-    workspace_iframe = wait.until(EC.presence_of_element_located((By.ID, "workspace_iframe")))
+    workspace_iframe = wait.until(
+        lambda driver: next(
+            (
+                iframe
+                for iframe in driver.find_elements(By.ID, "workspace-iframe")
+                if "/7681/" in (iframe.get_attribute("src") or "")
+            ),
+            False,
+        )
+    )
     browser.switch_to.frame(workspace_iframe)
 
-    # Wait for ttyd to be ready and find the terminal input
     time.sleep(10)
-    # ttyd uses body as the input element
-    body = browser.find_element("tag name", "body")
-    body.click()  # Focus the terminal
-    time.sleep(1)
+    terminal = browser.find_element(By.TAG_NAME, "body")
+    terminal.click()
 
-    yield body
+    yield terminal
 
     browser.close()
     browser.switch_to.window(module_window)
@@ -274,6 +289,7 @@ def test_actionbar_service_buttons(random_user_browser, random_user_name, interf
     idx = challenge_idx(random_user_browser, "test1")
     challenge_start(random_user_browser, idx)
     body = random_user_browser.find_element("id", f"challenges-body-{idx}")
+    assert not body.find_elements(By.CSS_SELECTOR, ".workspace-description-control")
     module_handle = random_user_browser.current_window_handle
     handles = set(random_user_browser.window_handles)
     wait = WebDriverWait(random_user_browser, 30)
@@ -283,6 +299,51 @@ def test_actionbar_service_buttons(random_user_browser, random_user_name, interf
     popout_handle = (set(random_user_browser.window_handles) - handles).pop()
     random_user_browser.switch_to.window(popout_handle)
     wait.until(lambda driver: driver.current_url.rstrip("/").endswith("/workspace/terminal"))
+    popout_controls = wait.until(
+        EC.presence_of_element_located((By.CSS_SELECTOR, ".workspace-controls"))
+    )
+    assert popout_controls.get_attribute("data-popout") == "false"
+    terminal_button = popout_controls.find_element(
+        By.CSS_SELECTOR, '.workspace-service[data-service="terminal: 7681"]'
+    )
+    wait.until(lambda driver: "active" in terminal_button.get_attribute("class"))
+
+    description_button = popout_controls.find_element(
+        By.CSS_SELECTOR, ".workspace-description-control"
+    )
+    flag_control = popout_controls.find_element(By.CSS_SELECTOR, ".workspace-input")
+    assert random_user_browser.execute_script(
+        "return arguments[0].nextElementSibling === arguments[1]",
+        description_button,
+        flag_control,
+    )
+    description_button.click()
+    description = wait.until(
+        EC.visibility_of_element_located((By.CSS_SELECTOR, ".workspace-description"))
+    )
+    assert "Interface test challenge description." in description.text
+    assert "active" in description_button.get_attribute("class")
+    assert set(random_user_browser.window_handles) == handles | {popout_handle}
+
+    terminal_button.click()
+    wait.until(lambda driver: not description.is_displayed())
+
+    ssh_button = popout_controls.find_element(
+        By.CSS_SELECTOR, '.workspace-service[data-service="ssh: "]'
+    )
+    ssh_button.click()
+    wait.until(lambda driver: driver.current_url.rstrip("/").endswith("/workspace/ssh"))
+    assert set(random_user_browser.window_handles) == handles | {popout_handle}
+    assert random_user_browser.find_element(By.CSS_SELECTOR, ".workspace-ssh").is_displayed()
+    controls_bottom = random_user_browser.execute_script(
+        "return arguments[0].getBoundingClientRect().bottom", popout_controls
+    )
+    viewport_height = random_user_browser.execute_script("return window.innerHeight")
+    assert viewport_height - controls_bottom < 10
+
+    terminal_button.click()
+    wait.until(lambda driver: driver.current_url.rstrip("/").endswith("/workspace/terminal"))
+    assert set(random_user_browser.window_handles) == handles | {popout_handle}
 
     random_user_browser.switch_to.window(module_handle)
     random_user_browser.find_element("id", f"challenges-body-{idx}") \
@@ -323,6 +384,14 @@ def test_actionbar_port_popout(random_user_browser, random_user_name, interfaces
     popout_handle = (set(random_user_browser.window_handles) - handles).pop()
     random_user_browser.switch_to.window(popout_handle)
     wait.until(lambda driver: driver.current_url.rstrip("/").endswith("/workspace/80"))
+    popout_controls = wait.until(
+        EC.presence_of_element_located((By.CSS_SELECTOR, ".workspace-controls"))
+    )
+    assert popout_controls.get_attribute("data-popout") == "false"
+    web_button = popout_controls.find_element(
+        By.CSS_SELECTOR, '.workspace-service[data-service="web: 80"]'
+    )
+    wait.until(lambda driver: "active" in web_button.get_attribute("class"))
     random_user_browser.close()
 
 def test_actionbar_ssh_only_challenge(random_user_browser, random_user_name, interfaces_dojo):


### PR DESCRIPTION
## Summary

- render workspace service and port URLs with the full action bar, selecting the requested interface initially
- keep service buttons as popouts on module pages while switching services inline within full workspace pages and synchronizing the URL
- keep the action bar pinned to the bottom for SSH and preserve service-specific auto-start URLs
- add a full-workspace Description button before the flag input for revisiting the active challenge description

## Testing

- `test_workspace_auto_start_without_home_mount`
- `test_actionbar_service_buttons`
- `test_actionbar_port_popout`
- `test_welcome_ttyd`
- Python compile checks, JavaScript syntax check, and `git diff --check`