### PR TITLE
Workspace: Update Nixpkgs to 26.05

### DIFF
--- a/workspace/additional/additional.nix
+++ b/workspace/additional/additional.nix
@@ -4,65 +4,166 @@ let
   bata24-gef = import ./bata24-gef.nix { inherit pkgs; };
   burpsuite = import ./burpsuite.nix { inherit pkgs; };
   ghidra = import ./ghidra.nix { inherit pkgs; };
+  ida-free = import ./ida-free.nix { inherit pkgs; };
   wireshark = import ./wireshark.nix { inherit pkgs; };
 
-  pythonPackages = ps: with ps; [
-    angr
-    asteval
-    flask
-    ipython
-    jupyter
-    pillow
-    psutil
-    pwntools
-    pycryptodome
-    pyroute2
-    r2pipe
-    requests
-    ropper
-    scapy
-    selenium
-  ];
+  pythonPackages =
+    ps:
+    (with ps; [
+      angr
+      asteval
+      flask
+      ipython
+      jupyter
+      pillow
+      psutil
+      pwntools
+      pycryptodome
+      pyroute2
+      r2pipe
+      requests
+      ropper
+      scapy
+      selenium
+    ])
+    ++ ps.angr.optional-dependencies.angrdb
+    ++ ps.angr.optional-dependencies.unicorn;
 
   pythonEnv = pkgs.python3.withPackages pythonPackages;
 
   tools = with pkgs; {
-    build = [ (lib.hiPrio gcc) (lib.lowPrio clang) clang-tools cmake gnumake nasm qemu rustup ];
+    build = [
+      (lib.hiPrio gcc)
+      (lib.lowPrio clang)
+      clang-tools
+      cmake
+      gnumake
+      nasm
+      qemu
+      rustup
+    ];
 
-    cli-tools = [ atuin bat delta hexyl hyperfine navi sd zoxide ];
+    cli-tools = [
+      atuin
+      bat
+      delta
+      hexyl
+      hyperfine
+      navi
+      sd
+      zoxide
+    ];
 
-    compress = [ gnutar gzip unzip zip ];
+    compress = [
+      gnutar
+      gzip
+      unzip
+      zip
+    ];
 
-    debug = [ bata24-gef gdb gef ltrace pwndbg strace ];
+    debug = [
+      bata24-gef
+      gdb
+      gef
+      ltrace
+      pwndbg
+      strace
+    ];
 
-    documentation = [ man-pages man-pages-posix ];
+    documentation = [
+      man-pages
+      man-pages-posix
+    ];
 
-    editor = [ emacs gedit nano neovim vim zed-editor.remote_server ];
+    editor = [
+      emacs
+      gedit
+      nano
+      neovim
+      vim
+      zed-editor.remote_server
+    ];
 
-    exploit = [ aflplusplus rappel ropgadget sage ];
+    exploit = [
+      aflplusplus
+      rappel
+      ropgadget
+      sage
+    ];
 
-    fetch = [ fastfetch neofetch ];
+    fetch = [ fastfetch ];
 
-    finder = [ broot dust eza fd fzf ripgrep ripgrep-all ];
+    finder = [
+      broot
+      dust
+      eza
+      fd
+      fzf
+      ripgrep
+      ripgrep-all
+    ];
 
-    lsp = [ ruff ty ];
+    lsp = [
+      ruff
+      ty
+    ];
 
-    network = [ burpsuite netcat-openbsd nmap tcpdump termshark tshark wireshark ];
+    network = [
+      burpsuite
+      netcat-openbsd
+      nmap
+      tcpdump
+      termshark
+      tshark
+      wireshark
+    ];
 
-    reverse = [ angr-management binaryninja-free cutter file ghidra ida-free radare2 ];
+    reverse = [
+      angr-management
+      binaryninja-free
+      cutter
+      file
+      ghidra
+      ida-free
+      radare2
+    ];
 
-    shells = [ fish nushell oh-my-zsh starship zsh ];
+    shells = [
+      fish
+      nushell
+      oh-my-zsh
+      starship
+      zsh
+    ];
 
-    system = [ bottom firejail htop landrun ncdu nftables openssh rsync ];
+    system = [
+      bottom
+      firejail
+      htop
+      landrun
+      ncdu
+      nftables
+      openssh
+      rsync
+    ];
 
-    terminal = [ ghostty.terminfo kitty.terminfo screen tmux zellij ];
+    terminal = [
+      kitty.terminfo
+      screen
+      tmux
+      zellij
+    ];
 
-    web = [ firefox geckodriver ];
+    web = [
+      firefox
+      geckodriver
+    ];
   };
 
 in
 {
-  packages = with pkgs;
+  packages =
+    with pkgs;
     [ (lib.hiPrio pythonEnv) ]
     ++ tools.build
     ++ tools.cli-tools

--- a/workspace/additional/ghidra.nix
+++ b/workspace/additional/ghidra.nix
@@ -5,33 +5,9 @@ let
 
   description = "Software reverse engineering (SRE) suite of tools developed by NSA's Research Directorate in support of the Cybersecurity mission";
 
-  ghidraPythonDist = "${pkgs.ghidra}/lib/ghidra/Ghidra/Debug/Debugger-rmi-trace/pypkg/dist";
-
-  ghidraProtobuf = pkgs.python3Packages.buildPythonPackage {
-    pname = "protobuf";
-    version = "3.20.3";
-    format = "wheel";
-    src = "${ghidraPythonDist}/protobuf-3.20.3-py2.py3-none-any.whl";
-    doCheck = false;
-    pythonImportsCheck = [ "google.protobuf" ];
-  };
-
-  ghidraPsutil = pkgs.python3Packages.buildPythonPackage {
-    pname = "psutil";
-    version = "5.9.8";
-    pyproject = true;
-    src = "${ghidraPythonDist}/psutil-5.9.8.tar.gz";
-    build-system = with pkgs.python3Packages; [
-      setuptools
-      wheel
-    ];
-    doCheck = false;
-    pythonImportsCheck = [ "psutil" ];
-  };
-
-  pythonEnv = pkgs.python3.withPackages (_: [
-    ghidraProtobuf
-    ghidraPsutil
+  pythonEnv = pkgs.python3.withPackages (ps: [
+    ps.protobuf
+    ps.psutil
   ]);
 
   gdb = pkgs.symlinkJoin {
@@ -44,26 +20,44 @@ let
     '';
   };
 
-in pkgs.stdenv.mkDerivation {
-  inherit pname version meta description;
+in
+pkgs.stdenv.mkDerivation {
+  inherit
+    pname
+    version
+    meta
+    description
+    ;
 
   src = pkgs.ghidra;
 
   buildInputs = [ pkgs.makeWrapper ];
 
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+    export PYTHONPATH="${pkgs.ghidra}/lib/ghidra/Ghidra/Debug/Debugger-agent-gdb/pypkg/src:${pkgs.ghidra}/lib/ghidra/Ghidra/Debug/Debugger-rmi-trace/pypkg/src"
+    ${gdb}/bin/gdb -q -nx -batch \
+      -ex 'python import google.protobuf, psutil, ghidragdb.commands' \
+      -ex 'help ghidra trace connect' | \
+      ${pkgs.gnugrep}/bin/grep -F 'Connect GDB to Ghidra for tracing.'
+    runHook postCheck
+  '';
+
   installPhase = ''
-      runHook preInstall
+    runHook preInstall
 
-      mkdir -p "$out/bin"
+    mkdir -p "$out/bin"
 
-      # Ghidra will spam-log stack traces into the home directory when not run in a desktop environment.
-      makeWrapper "$src/bin/ghidra" \
-        "$out/bin/ghidra" \
-        --prefix PATH : "${pkgs.lib.makeBinPath [ gdb ]}" \
-        --run 'if [ -z "$DISPLAY" ]; then echo "Error: DISPLAY is not set. Please run under desktop environment." >&2; exit 1; fi'
+    # Ghidra will spam-log stack traces into the home directory when not run in a desktop environment.
+    makeWrapper "$src/bin/ghidra" \
+      "$out/bin/ghidra" \
+      --prefix PATH : "${pkgs.lib.makeBinPath [ gdb ]}" \
+      --run 'if [ -z "$DISPLAY" ]; then echo "Error: DISPLAY is not set. Please run under desktop environment." >&2; exit 1; fi'
 
-      cp -r "$src/share" "$out/share"
+    cp -r "$src/share" "$out/share"
 
-      runHook postInstall
+    runHook postInstall
   '';
 }

--- a/workspace/additional/ida-free.nix
+++ b/workspace/additional/ida-free.nix
@@ -1,0 +1,105 @@
+{ pkgs }:
+
+pkgs.stdenv.mkDerivation rec {
+  pname = "ida-free";
+  version = "8.4.240320";
+
+  src = pkgs.fetchurl {
+    url = "https://web.archive.org/web/20240330140328/https://out7.hex-rays.com/files/idafree84_linux.run";
+    hash = "sha256-StjJDl3DIset+6bt1bAS9Pf2jMOkE0WFr0dKOJ0C5vE=";
+  };
+
+  icon = pkgs.fetchurl {
+    url = "https://web.archive.org/web/20221105181231if_/https://hex-rays.com/products/ida/news/8_1/images/icon_free.png";
+    hash = "sha256-widkv2VGh+eOauUK/6Sz/e2auCNFAsc8n9z0fdrSnW0=";
+  };
+
+  desktopItem = pkgs.makeDesktopItem {
+    name = "ida-free";
+    exec = "ida64";
+    icon = icon;
+    comment = meta.description;
+    desktopName = "IDA Free";
+    genericName = "Interactive Disassembler";
+    categories = [ "Development" ];
+    startupWMClass = "IDA";
+  };
+
+  desktopItems = [ desktopItem ];
+
+  nativeBuildInputs = with pkgs; [
+    makeWrapper
+    copyDesktopItems
+    autoPatchelfHook
+    libsForQt5.wrapQtAppsHook
+  ];
+
+  dontUnpack = true;
+
+  runtimeDependencies = with pkgs; [
+    cairo
+    dbus
+    fontconfig
+    freetype
+    glib
+    gtk3
+    libdrm
+    libGL
+    libkrb5
+    libsecret
+    libsForQt5.qtbase
+    libunwind
+    libxkbcommon
+    openssl
+    stdenv.cc.cc
+    libice
+    libsm
+    libx11
+    libxau
+    libxcb
+    libxext
+    libxi
+    libxrender
+    libxcb-image
+    libxcb-keysyms
+    libxcb-render-util
+    libxcb-wm
+    zlib
+  ];
+  buildInputs = runtimeDependencies;
+
+  dontWrapQtApps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib $out/opt
+    IDADIR=$out/opt
+
+    $(cat $NIX_CC/nix-support/dynamic-linker) $src \
+      --mode unattended --prefix $IDADIR --installpassword ""
+
+    cp $IDADIR/libida64.so $out/lib
+    addAutoPatchelfSearchPath $IDADIR
+
+    for bb in ida64 assistant; do
+      wrapProgram $IDADIR/$bb \
+        --prefix QT_PLUGIN_PATH : $IDADIR/plugins/platforms
+      ln -s $IDADIR/$bb $out/bin/$bb
+    done
+
+    patchelf --add-needed libcrypto.so $IDADIR/libida64.so
+
+    runHook postInstall
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Freeware version of the world's smartest and most feature-full disassembler";
+    homepage = "https://hex-rays.com/ida-free/";
+    changelog = "https://hex-rays.com/products/ida/news/";
+    license = licenses.unfree;
+    mainProgram = "ida64";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/workspace/core/ghostty-terminfo.nix
+++ b/workspace/core/ghostty-terminfo.nix
@@ -1,0 +1,7 @@
+{ pkgs }:
+
+# Ghostty uses xterm-ghostty, while ncurses 6.6 installs this entry only as ghostty.
+pkgs.runCommand "ghostty-terminfo" { } ''
+  mkdir -p $out/share/terminfo/x
+  ln -s ${pkgs.ncurses}/share/terminfo/g/ghostty $out/share/terminfo/x/xterm-ghostty
+''

--- a/workspace/flake.lock
+++ b/workspace/flake.lock
@@ -1,0 +1,143 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787101114,
+        "narHash": "sha256-gwrPcFf/rDjHPaVflbDZ040ZDmBTRj/7+s8ZmE2SaIM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b18a4b905f8d028dc4476412e6d6891728695379",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-pr-angr": {
+      "locked": {
+        "lastModified": 1787334783,
+        "narHash": "sha256-PfVuM2FWG2QmxRMjGLPkj5ezSu/A9npO+U168WjxKPY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b08d5a99f7e34d585ea347e74dbd99a184f119b0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "pull/554851/head",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pwndbg": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      },
+      "locked": {
+        "lastModified": 1786941291,
+        "narHash": "sha256-lZf2YOHHD2JY/sZ+nApLXJcJ9TTgXDCTpOVAa3IMHSM=",
+        "owner": "pwndbg",
+        "repo": "pwndbg",
+        "rev": "9e53d898e37683ded38e853b4ae573e39323ebff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pwndbg",
+        "repo": "pwndbg",
+        "type": "github"
+      }
+    },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "pwndbg",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pwndbg",
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "pwndbg",
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1763662255,
+        "narHash": "sha256-4bocaOyLa3AfiS8KrWjZQYu+IAta05u3gYZzZ6zXbT0=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "042904167604c681a090c07eb6967b4dd4dae88c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "pwndbg",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769936401,
+        "narHash": "sha256-kwCOegKLZJM9v/e/7cqwg1p/YjjTAukKPqmxKnAZRgA=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "b0d513eeeebed6d45b4f2e874f9afba2021f7812",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-pr-angr": "nixpkgs-pr-angr",
+        "pwndbg": "pwndbg"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "pwndbg",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pwndbg",
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769957392,
+        "narHash": "sha256-6PkqwwYf5K2CHi2V+faI/9pqjfz/HxUkI/MVid6hlOY=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "d18bc50ae1c3d4be9c41c2d94ea765524400af75",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/workspace/flake.nix
+++ b/workspace/flake.nix
@@ -2,18 +2,19 @@
   description = "DOJO Workspace Flake";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
-    nixpkgs-24-11.url = "github:NixOS/nixpkgs/nixos-24.11";
-    nixpkgs-pr-angr-management.url = "github:NixOS/nixpkgs/pull/360310/head";
-    pwndbg.url = "github:pwndbg/pwndbg";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+    nixpkgs-pr-angr.url = "github:NixOS/nixpkgs/pull/554851/head";
+    pwndbg = {
+      url = "github:pwndbg/pwndbg";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
     {
       self,
       nixpkgs,
-      nixpkgs-24-11,
-      nixpkgs-pr-angr-management,
+      nixpkgs-pr-angr,
       pwndbg,
     }:
     {
@@ -23,39 +24,19 @@
             system = "x86_64-linux";
             config = {
               allowUnfree = true;
-              allowBroken = true; # angr is currently marked "broken" in nixpkgs, but works fine (without unicorn)
             };
 
-            angr-management-overlay = self: super: {
-              angr-management = (import nixpkgs-pr-angr-management { inherit system config; }).angr-management;
-            };
-
-            ida-free-overlay = self: super: {
-              ida-free = (import nixpkgs-24-11 { inherit system config; }).ida-free;
-            };
-
-            pwndbg-overlay = self: super: {
-              pwndbg = pwndbg.packages.${system}.pwndbg;
-            };
-
-            sage-overlay = final: prev: {
-              sage = prev.sage.override {
-                extraPythonPackages = ps: with ps; [
-                  pycryptodome
-                  pwntools
-                ];
-              requireSageTests = false;
-              };
+            workspace-overlays = import ./overlays {
+              inherit
+                nixpkgs-pr-angr
+                pwndbg
+                system
+                ;
             };
 
             pkgs = import nixpkgs {
               inherit system config;
-              overlays = [
-                angr-management-overlay
-                ida-free-overlay
-                sage-overlay
-                pwndbg-overlay
-              ];
+              overlays = workspace-overlays;
             };
 
             ldd = pkgs.writeShellScriptBin "ldd" ''
@@ -78,6 +59,7 @@
             ssh-entrypoint = import ./core/ssh-entrypoint.nix { inherit pkgs; };
             sudo = import ./core/sudo.nix { inherit pkgs; };
             dojo-cli = import ./core/dojo-cli.nix { inherit pkgs; };
+            ghostty-terminfo = import ./core/ghostty-terminfo.nix { inherit pkgs; };
 
             service = import ./services/service.nix { inherit pkgs; };
             code-service = import ./services/code.nix { inherit pkgs; };
@@ -93,6 +75,7 @@
               curl
               findutils
               gawk
+              ghostty-terminfo
               glibc
               glibc.static
               glibcLocales
@@ -155,7 +138,5 @@
             full = buildDojoEnv "full" fullPackages;
           };
       };
-
-      defaultPackage.x86_64-linux = self.packages.x86_64-linux;
     };
 }

--- a/workspace/overlays/angr.nix
+++ b/workspace/overlays/angr.nix
@@ -1,0 +1,52 @@
+{ nixpkgs-pr-angr }:
+
+# Evaluate only the PR's angr-family package recipes in the active nixpkgs
+# package set, instead of importing the PR as a second general package set.
+final: prev:
+let
+  angr-capstone = final.callPackage "${nixpkgs-pr-angr}/pkgs/by-name/ca/capstone/package.nix" { };
+in
+{
+  angr-management =
+    (final.callPackage "${nixpkgs-pr-angr}/pkgs/by-name/an/angr-management/package.nix" { })
+    .overridePythonAttrs
+      (old: {
+        dependencies = old.dependencies ++ final.python312Packages.angr.optional-dependencies.unicorn;
+      });
+  pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
+    (
+      python-final: python-prev:
+      let
+        fromAngrPr =
+          name: args:
+          python-final.callPackage "${nixpkgs-pr-angr}/pkgs/development/python-modules/${name}" args;
+      in
+      {
+        angr = fromAngrPr "angr" { };
+        angr-data = fromAngrPr "angr-data" { };
+        archinfo = fromAngrPr "archinfo" { };
+        binsync = fromAngrPr "binsync" { };
+        capstone = fromAngrPr "capstone" {
+          capstone = angr-capstone;
+        };
+        claripy = fromAngrPr "claripy" { };
+        cle = fromAngrPr "cle" {
+          uefi-firmware = python-final.uefi-firmware-parser;
+        };
+        declib = fromAngrPr "declib" { };
+        pypcode = fromAngrPr "pypcode" { };
+        pydemumble = fromAngrPr "pydemumble" { };
+        pyside6-qtads = fromAngrPr "pyside6-qtads" { };
+        pyqodeng = fromAngrPr "pyqodeng" { };
+        pyvex = fromAngrPr "pyvex" { };
+        pyxdia = fromAngrPr "pyxdia" { };
+      }
+      // final.lib.optionalAttrs (python-prev.python.pythonVersion == "3.12") {
+        lmdb = python-prev.lmdb.overridePythonAttrs (old: {
+          # This page-fault-count assertion is kernel/cache dependent.
+          disabledTests = (old.disabledTests or [ ]) ++ [ "test_preload" ];
+        });
+      }
+    )
+  ];
+}

--- a/workspace/overlays/default.nix
+++ b/workspace/overlays/default.nix
@@ -1,0 +1,11 @@
+{
+  nixpkgs-pr-angr,
+  pwndbg,
+  system,
+}:
+
+[
+  (import ./angr.nix { inherit nixpkgs-pr-angr; })
+  (import ./sage.nix)
+  (import ./pwndbg.nix { inherit pwndbg system; })
+]

--- a/workspace/overlays/pwndbg.nix
+++ b/workspace/overlays/pwndbg.nix
@@ -1,0 +1,8 @@
+{
+  pwndbg,
+  system,
+}:
+
+_final: _prev: {
+  pwndbg = pwndbg.packages.${system}.pwndbg;
+}

--- a/workspace/overlays/sage.nix
+++ b/workspace/overlays/sage.nix
@@ -1,0 +1,10 @@
+_final: prev: {
+  sage = prev.sage.override {
+    extraPythonPackages =
+      ps: with ps; [
+        pycryptodome
+        pwntools
+      ];
+    requireSageTests = false;
+  };
+}

--- a/workspace/services/code.nix
+++ b/workspace/services/code.nix
@@ -14,10 +14,16 @@ let
         sys.argv.remove("--follow")
     os.execv(sys.argv[0], sys.argv)
   '';
-  code-server = pkgs.stdenv.mkDerivation {
-    name = "code-server";
+  code-server-unwrapped = pkgs.stdenv.mkDerivation {
+    inherit (pkgs.code-server) pname version;
     src = pkgs.code-server;
-    buildInputs = with pkgs; [ nodejs makeWrapper ];
+    buildInputs = with pkgs; [
+      nodejs
+      makeWrapper
+    ];
+    passthru = {
+      inherit (pkgs.code-server) executableName longName;
+    };
     installPhase = ''
       runHook preInstall
       rgBin=libexec/code-server/lib/vscode/node_modules/@vscode/ripgrep/bin
@@ -30,6 +36,14 @@ let
       runHook postInstall
     '';
   };
+  codeExtensions = with pkgs.vscode-extensions; [
+    ms-python.python
+    ms-vscode.cpptools
+  ];
+  code-server = pkgs.vscode-with-extensions.override {
+    vscode = code-server-unwrapped;
+    vscodeExtensions = codeExtensions;
+  };
 
   serviceScript = pkgs.writeScript "dojo-code" ''
     #!${pkgs.bash}/bin/bash
@@ -37,9 +51,9 @@ let
     until [ -f /run/dojo/var/ready ]; do sleep 0.1; done
 
     if [ -d /run/challenge/share/code/extensions ]; then
-      EXTENSIONS_DIR="/run/challenge/share/code/extensions"
+      extensionArgs=(--extensions-dir=/run/challenge/share/code/extensions)
     else
-      EXTENSIONS_DIR="@out@/share/code/extensions"
+      extensionArgs=()
     fi
 
     ${service}/bin/dojo-service start code-service/code-server \
@@ -48,21 +62,20 @@ let
         --bind-addr=0.0.0.0:8080 \
         --trusted-origins='*' \
         --disable-telemetry \
-        --extensions-dir=$EXTENSIONS_DIR \
+        "''${extensionArgs[@]}" \
         --config=/dev/null
 
     until ${pkgs.curl}/bin/curl -fs localhost:8080 >/dev/null; do sleep 0.1; done
   '';
 
-in pkgs.stdenv.mkDerivation {
+in
+pkgs.stdenv.mkDerivation {
   name = "code-service";
   buildInputs = with pkgs; [
     code-server
     bash
     python3
-    wget
     curl
-    cacert
   ];
   dontUnpack = true;
 
@@ -70,22 +83,9 @@ in pkgs.stdenv.mkDerivation {
     runHook preInstall
 
     mkdir -p $out/bin
-    substitute ${serviceScript} $out/bin/dojo-code \
-      --subst-var-by out $out
-    chmod +x $out/bin/dojo-code
+    cp ${serviceScript} $out/bin/dojo-code
     ln -s ${code-server}/bin/code-server $out/bin/code-server
     ln -s ${code-server}/bin/code-server $out/bin/code
-
-    mkdir -p $out/share/code/extensions
-    ${pkgs.wget}/bin/wget -P $NIX_BUILD_TOP 'https://github.com/microsoft/vscode-cpptools/releases/download/v1.20.5/cpptools-linux.vsix'
-    export HOME=$NIX_BUILD_TOP
-    ${code-server}/bin/code-server \
-      --auth=none \
-      --disable-telemetry \
-      --extensions-dir=$out/share/code/extensions \
-      --install-extension ms-python.python \
-      --install-extension $NIX_BUILD_TOP/cpptools-linux.vsix
-    chmod +x $out/share/code/extensions/ms-vscode.cpptools-*/{bin/cpptools*,bin/libc.so,debugAdapters/bin/OpenDebugAD7,LLVM/bin/clang-*}
 
     runHook postInstall
   '';

--- a/workspace/services/desktop.nix
+++ b/workspace/services/desktop.nix
@@ -2,6 +2,9 @@
 
 let
   service = import ./service.nix { inherit pkgs; };
+  fontsConf = pkgs.makeFontsConf {
+    fontDirectories = [ pkgs.dejavu_fonts ];
+  };
 
   # Revert https://github.com/novnc/noVNC/pull/1672
   reconnectPatch = pkgs.writeText "reconnect_patch.diff" ''
@@ -25,6 +28,7 @@ let
     export DISPLAY=:0
     export XDG_DATA_DIRS="/run/dojo/share:''${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
     export XDG_CONFIG_DIRS="/run/dojo/etc/xdg:''${XDG_CONFIG_DIRS:-/etc/xdg}"
+    export FONTCONFIG_FILE="${fontsConf}"
 
     auth_token="$(cat /run/dojo/var/auth_token)"
     password_interact="$(printf 'desktop-interact' | ${pkgs.openssl}/bin/openssl dgst -sha256 -hmac "$auth_token" | awk '{print $2}' | head -c 8)"
@@ -53,12 +57,12 @@ let
 
     # By default, xfce4-session invokes dbus-launch without `--config-file`, and it fails to find /etc/dbus-1/session.conf; so we manually specify the config file here.
     ${service}/bin/dojo-service start desktop-service/xfce4-session \
-      ${pkgs.dbus}/bin/dbus-launch --sh-syntax --exit-with-session --config-file=${pkgs.dbus}/share/dbus-1/session.conf ${pkgs.xfce.xfce4-session}/bin/xfce4-session
+      ${pkgs.dbus}/bin/dbus-launch --sh-syntax --exit-with-session --config-file=${pkgs.dbus}/share/dbus-1/session.conf ${pkgs.xfce4-session}/bin/xfce4-session
   '';
 
   xfce = pkgs.symlinkJoin {
     name = "xfce";
-    paths = with pkgs.xfce; [
+    paths = with pkgs; [
       xfce4-session
       xfce4-settings
       xfce4-terminal
@@ -67,16 +71,17 @@ let
       xfwm4
       xfdesktop
       xfconf
-      exo
+      xfce4-exo
       thunar
-    ] ++ (with pkgs; [
       dbus
+      dconf
       dejavu_fonts
       blackbird
-    ]);
+    ];
   };
 
-in pkgs.stdenv.mkDerivation {
+in
+pkgs.stdenv.mkDerivation {
   name = "desktop-service";
   src = ./desktop;
 
@@ -90,10 +95,10 @@ in pkgs.stdenv.mkDerivation {
     tigervnc
     novnc
     xfce
-    elementary-xfce-icon-theme  # If we include this in `xfce`, we get a "Permission denied" error related to `nix-support/propagated-build-inputs`.
+    elementary-xfce-icon-theme # If we include this in `xfce`, we get a "Permission denied" error related to `nix-support/propagated-build-inputs`.
   ];
 
-  dontMoveSystemdUserUnits = true;  # We run into an issue where we `mv` "the same file".
+  dontMoveSystemdUserUnits = true; # We run into an issue where we `mv` "the same file".
 
   unpackPhase = ''
     runHook preUnpack
@@ -105,7 +110,7 @@ in pkgs.stdenv.mkDerivation {
     runHook preInstall
     mkdir -p $out/bin
     cp ${serviceScript} $out/bin/dojo-desktop
-    ln -s ${pkgs.xfce.xfce4-terminal}/bin/xfce4-terminal $out/bin/x-terminal-emulator
+    ln -s ${pkgs.xfce4-terminal}/bin/xfce4-terminal $out/bin/x-terminal-emulator
     rsync -a --ignore-existing $src/. ${xfce}/. ${pkgs.elementary-xfce-icon-theme}/. $out
     runHook postInstall
   '';


### PR DESCRIPTION
## Summary

- update the workspace package set from NixOS 25.11 to 26.05 and add a lock file
- remove the 24.11 and old angr-management package-set inputs; pwndbg now follows the main nixpkgs input
- import only the angr-family recipes from NixOS/nixpkgs#554851 through isolated overlays
- retain IDA Free 8.4 locally, preserve the wrapped Ghidra debugger environment, and update XFCE compatibility
- package code-server extensions natively with vscode-with-extensions
- provide the xterm-ghostty alias from the ncurses 6.6 Ghostty entry

## Validation

- nix flake check path:./workspace
- built both workspace core and full outputs
- verified the core closure contains no angr-family packages
- ran the upstream angr 9.3.3 smoke test: ELF loading, VEX, CFGFast, symbolic execution, real Unicorn execution, pypcode, Rust extension, protobuf, and AngrDB
- launched angr-management 9.3.3 under Xvfb, loaded and analyzed an ELF, navigated disassembly, and decompiled its choose function
- verified BinSync 5.15.4 and declib through the angr-management wrapper
- verified the wrapped Ghidra GDB imports protobuf, psutil, and ghidragdb.commands and exposes ghidra trace connect
- verified code-server contains the Python and C++ extensions and serves HTTP successfully
- verified Sage loads PyCryptodome and pwntools, pwndbg starts, and the workspace-local xterm-ghostty entry resolves

## Notes

The angr overlay is pinned to NixOS/nixpkgs#554851 at b08d5a99f7e34d585ea347e74dbd99a184f119b0. That upstream PR is still open, so this PR is a draft.

A full build against an empty temporary Nix store took 16m54s on a 16-core/32-thread EPYC host using cache.nixos.org. The runtime closure is 18.5 GiB; the uncached Python 3.12 PySide6 build for angr-management was the critical path. An immediate warm rebuild took 1.46s.