### PR TITLE
Workspace: Use committed flake lock

### DIFF
--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -14,12 +14,10 @@ COPY --chmod=755 <<'EOF' /docker-entrypoint.sh
 TIMESTAMP=$(date +%Y%m%d%H%M%S)
 NIX_PROFILES_DIR=/nix/var/nix/profiles
 NIX_PROFILE=${NIX_PROFILES_DIR}/dojo-workspace-${TIMESTAMP}
-NIX_FLAKE_LOCK_FILE=/nix/var/nix/dojo-workspace-flake.lock
 
 nix build ".#${DOJO_WORKSPACE:-default}" \
     --out-link "$NIX_PROFILE" \
-    --reference-lock-file "$NIX_FLAKE_LOCK_FILE" \
-    --output-lock-file "$NIX_FLAKE_LOCK_FILE" \
+    --no-update-lock-file \
     --print-build-logs
 
 SUID_FILE="$NIX_PROFILE/suid"


### PR DESCRIPTION
## Summary

- make workspace-builder consume the checked-in workspace/flake.lock
- fail instead of silently updating an out-of-date lock
- remove the obsolete per-node persistent lock override

## Testing

- nix flake check --no-update-lock-file path:./workspace
- built the workspace-builder image and confirmed its lock metadata resolves nixpkgs b18a4b905f8d028dc4476412e6d6891728695379 and angr PR b08d5a99f7e34d585ea347e74dbd99a184f119b0
- confirmed no persistent dojo-workspace-flake.lock is used