### PR TITLE
Crews: add Mastery scoreboard mode

### DIFF
--- a/dojo_plugin/api/v1/scoreboard.py
+++ b/dojo_plugin/api/v1/scoreboard.py
@@ -15,6 +15,8 @@ logger = logging.getLogger(__name__)
 
 scoreboard_namespace = Namespace("scoreboard")
 
+CREW_MODE_RANK_FIELDS = {"unique": "unique_rank", "mastery": "mastery_rank"}
+
 
 def email_symbol_asset(email):
     if email.endswith("@asu.edu"):
@@ -116,11 +118,12 @@ def get_crew_scoreboard_page(model, duration=None, page=1, per_page=20, mode="cu
     emojis = get_viewable_emojis(user)
     crews = get_crews_for(model, duration)
 
-    if mode == "unique" and all(crew.get("unique_rank") is not None for crew in crews):
-        crews = sorted(crews, key=lambda crew: crew["unique_rank"])
+    rank_field = CREW_MODE_RANK_FIELDS.get(mode)
+    if rank_field and all(crew.get(rank_field) is not None for crew in crews):
+        crews = sorted(crews, key=lambda crew: crew[rank_field])
 
     def crew_rank(crew):
-        return crew["unique_rank"] if mode == "unique" and crew.get("unique_rank") is not None else crew["rank"]
+        return crew[rank_field] if rank_field and crew.get(rank_field) is not None else crew["rank"]
 
     def crew_entry(crew):
         return {
@@ -129,6 +132,7 @@ def get_crew_scoreboard_page(model, duration=None, page=1, per_page=20, mode="cu
             "key": crew["key"],
             "score": crew["score"],
             "unique": crew.get("unique"),
+            "mastery": crew.get("mastery"),
             "members": [
                 entry for entry in (standing_entry(member, belt_data, emojis) for member in crew["members"])
                 if entry is not None
@@ -162,7 +166,7 @@ def get_crew_scoreboard_page(model, duration=None, page=1, per_page=20, mode="cu
 
 def crew_mode_arg():
     mode = request.args.get("mode", "cumulative")
-    return mode if mode in ("cumulative", "unique") else "cumulative"
+    return mode if mode in ("cumulative", "unique", "mastery") else "cumulative"
 
 
 @scoreboard_namespace.route("/<dojo>/_/<int:duration>/<int:page>")

--- a/dojo_plugin/utils/crews.py
+++ b/dojo_plugin/utils/crews.py
@@ -49,9 +49,12 @@ def aggregate_crews(standings, member_challenges=None):
     for i, crew in enumerate(ranked):
         crew["rank"] = i + 1
         if member_challenges is not None:
-            crew["unique"] = len(set().union(*(member["challenges"] for member in crew["members"])) if crew["members"] else set())
+            challenge_sets = [set(member["challenges"]) for member in crew["members"]]
+            crew["unique"] = len(set().union(*challenge_sets)) if challenge_sets else 0
+            crew["mastery"] = len(set.intersection(*challenge_sets)) if challenge_sets else 0
         else:
             crew["unique"] = None
+            crew["mastery"] = None
 
     if member_challenges is not None:
         by_unique = sorted(
@@ -60,9 +63,17 @@ def aggregate_crews(standings, member_challenges=None):
         )
         for i, crew in enumerate(by_unique):
             crew["unique_rank"] = i + 1
+        # Bigger crews rank higher on mastery ties: a full-crew solve is harder with more members.
+        by_mastery = sorted(
+            ranked,
+            key=lambda crew: (-crew["mastery"], -len(crew["members"]), crew["best_rank"], crew["key"]),
+        )
+        for i, crew in enumerate(by_mastery):
+            crew["mastery_rank"] = i + 1
     else:
         for crew in ranked:
             crew["unique_rank"] = None
+            crew["mastery_rank"] = None
 
     return ranked
 

--- a/dojo_theme/static/js/dojo/scoreboard.js
+++ b/dojo_theme/static/js/dojo/scoreboard.js
@@ -1,7 +1,9 @@
+const CREW_MODE_HASHES = { cumulative: "#crews", unique: "#crews-unique", mastery: "#crews-mastery" };
+
 const scoreboardState = {
     generation: 0,
-    view: location.hash === "#crews" || location.hash === "#crews-unique" ? "crews" : "hackers",
-    crewMode: location.hash === "#crews-unique" ? "unique" : "cumulative",
+    view: Object.values(CREW_MODE_HASHES).includes(location.hash) ? "crews" : "hackers",
+    crewMode: Object.keys(CREW_MODE_HASHES).find(mode => CREW_MODE_HASHES[mode] === location.hash) || "cumulative",
     duration: 30,
 };
 
@@ -131,10 +133,12 @@ function buildCrewRow(crew, myCrewKey) {
     const top = crew.members[0];
     row.find(".scoreboard-belt").attr("src", top.belt).attr("title", `Top member: ${top.name}`);
     const unique = crew.unique === null || crew.unique === undefined ? "—" : crew.unique.toLocaleString();
+    const mastery = crew.mastery === null || crew.mastery === undefined ? "—" : crew.mastery.toLocaleString();
     const scoreCell = row.find(".crew-score");
     if (scoreboardState.crewMode === "unique") scoreCell.text(unique);
+    else if (scoreboardState.crewMode === "mastery") scoreCell.text(mastery);
     else scoreCell.text(crew.score.toLocaleString());
-    scoreCell.attr("title", `Cumulative: ${crew.score.toLocaleString()} · Unique challenges: ${unique}`);
+    scoreCell.attr("title", `Cumulative: ${crew.score.toLocaleString()} · Unique challenges: ${unique} · Mastered: ${mastery}`);
     if (myCrewKey && crew.key === myCrewKey) row.addClass("scoreboard-row-me");
 
     let memberRows = null;
@@ -191,16 +195,19 @@ function setScoreboardControls(view, duration) {
     const controls = { 7: "#scoreboard-control-week", 30: "#scoreboard-control-month", 0: "#scoreboard-control-all" };
     if (controls[duration]) $(controls[duration]).addClass("scoreboard-page-selected");
     const crews = view === "crews";
-    const unique = scoreboardState.crewMode === "unique";
+    const crewMode = scoreboardState.crewMode;
+    const scoreLabels = { unique: "Unique", mastery: "Mastery" };
     $("#scoreboard-heading").text(`${labels[duration] || ""}${crews ? " Crew" : ""} Scoreboard:`);
     $("#scoreboard-th-name").text(crews ? "Crew" : "Hacker");
     $("#scoreboard-th-badges").text(crews ? "Members" : "Badges");
-    $("#scoreboard-th-score").text(crews && unique ? "Unique" : "Score");
+    $("#scoreboard-th-score").text((crews && scoreLabels[crewMode]) || "Score");
     $("#scoreboard-view-hackers").toggleClass("scoreboard-view-selected", !crews).attr("aria-selected", String(!crews));
     $("#scoreboard-view-crews").toggleClass("scoreboard-view-selected", crews).attr("aria-selected", String(crews));
     $("#scoreboard-crew-mode-toggle").prop("hidden", !crews);
-    $("#scoreboard-crew-mode-cumulative").toggleClass("scoreboard-view-selected", !unique).attr("aria-selected", String(!unique));
-    $("#scoreboard-crew-mode-unique").toggleClass("scoreboard-view-selected", unique).attr("aria-selected", String(unique));
+    Object.keys(CREW_MODE_HASHES).forEach(mode => {
+        const selected = crewMode === mode;
+        $(`#scoreboard-crew-mode-${mode}`).toggleClass("scoreboard-view-selected", selected).attr("aria-selected", String(selected));
+    });
     $(".scoreboard").toggleClass("scoreboard-crew-mode", crews);
 }
 
@@ -321,7 +328,7 @@ function loadScoreboard(duration, page) {
 
 function scoreboardHash() {
     if (scoreboardState.view !== "crews") return location.pathname + location.search;
-    return scoreboardState.crewMode === "unique" ? "#crews-unique" : "#crews";
+    return CREW_MODE_HASHES[scoreboardState.crewMode] || "#crews";
 }
 
 function setScoreboardView(view) {

--- a/dojo_theme/templates/macros/scoreboard.html
+++ b/dojo_theme/templates/macros/scoreboard.html
@@ -9,6 +9,7 @@
     <div id="scoreboard-crew-mode-toggle" class="scoreboard-view-toggle brand-mono" role="tablist" aria-label="Crew scoring" hidden>
       <a id="scoreboard-crew-mode-cumulative" role="tab" aria-selected="true" href="javascript:setCrewMode('cumulative')">Cumulative</a>
       <a id="scoreboard-crew-mode-unique" role="tab" aria-selected="false" href="javascript:setCrewMode('unique')">Unique</a>
+      <a id="scoreboard-crew-mode-mastery" role="tab" aria-selected="false" href="javascript:setCrewMode('mastery')">Mastery</a>
     </div>
     <div class="scoreboard-view-toggle brand-mono" role="tablist" aria-label="Scoreboard view">
       <a id="scoreboard-view-hackers" role="tab" aria-selected="true" href="javascript:setScoreboardView('hackers')">Hackers</a>

--- a/test/test_crew_scoreboard.py
+++ b/test/test_crew_scoreboard.py
@@ -128,6 +128,13 @@ def test_crew_scoreboard_happy_path(browser_fixture, crew_dojo):
          if row.find_element("css selector", ".crew-tag-text").text == tag), None))
     assert unique_crew_row.find_element("css selector", ".crew-score").text == "2"
     assert browser.execute_script("return location.hash") == "#crews-unique"
+    browser.execute_script("setCrewMode('mastery')")
+    wait_until(lambda: browser.execute_script("return $('#scoreboard-th-score').text() === 'Mastery' && $('#scoreboard .crew-row').length > 0"))
+    mastery_crew_row = wait_until(lambda: next(
+        (row for row in browser.find_elements("css selector", ".crew-row")
+         if row.find_element("css selector", ".crew-tag-text").text == tag), None))
+    assert mastery_crew_row.find_element("css selector", ".crew-score").text == "1"
+    assert browser.execute_script("return location.hash") == "#crews-mastery"
     browser.execute_script("setCrewMode('cumulative')")
     wait_until(lambda: browser.execute_script("return $('#scoreboard-th-score').text() === 'Score' && $('#scoreboard .crew-row').length > 0"))
 
@@ -144,6 +151,13 @@ def test_crew_scoreboard_happy_path(browser_fixture, crew_dojo):
     wait_until(lambda: browser.execute_script("return $('#scoreboard .crew-row').length > 0"))
     assert browser.execute_script("return $('#scoreboard-th-score').text()") == "Unique"
     assert browser.execute_script("return $('#scoreboard-crew-mode-unique').hasClass('scoreboard-view-selected')")
+    assert browser.execute_script("return $('#scoreboard-view-crews').hasClass('scoreboard-view-selected')")
+
+    browser.get(f"{DOJO_URL}/login")
+    browser.get(f"{DOJO_URL}/dojo/{crew_dojo}#crews-mastery")
+    wait_until(lambda: browser.execute_script("return $('#scoreboard .crew-row').length > 0"))
+    assert browser.execute_script("return $('#scoreboard-th-score').text()") == "Mastery"
+    assert browser.execute_script("return $('#scoreboard-crew-mode-mastery').hasClass('scoreboard-view-selected')")
     assert browser.execute_script("return $('#scoreboard-view-crews').hasClass('scoreboard-view-selected')")
 
 
@@ -221,6 +235,7 @@ standings = [
 crews = aggregate_crews(standings)
 assert [(c["tag"], c["score"], len(c["members"]), c["rank"]) for c in crews] == [("X", 9, 2, 1), ("Y", 3, 1, 2), ("__proto__", 2, 1, 3)]
 assert all(c["unique"] is None and c["unique_rank"] is None for c in crews)
+assert all(c["mastery"] is None and c["mastery_rank"] is None for c in crews)
 
 challenge_map = {1: {10, 11, 12, 13, 14}, 2: {10, 11, 12, 13}, 3: {10, 11, 12}, 4: {20, 21}}
 crews = aggregate_crews(standings, challenge_map)
@@ -230,6 +245,8 @@ proto = next(c for c in crews if c["key"] == "__proto__")
 assert (x["score"], x["unique"], x["rank"]) == (9, 5, 1)
 assert (y["score"], y["unique"], y["rank"]) == (3, 3, 2)
 assert x["unique_rank"] == 1 and y["unique_rank"] == 2 and proto["unique_rank"] == 3
+assert (x["mastery"], y["mastery"], proto["mastery"]) == (4, 3, 2)
+assert x["mastery_rank"] == 1 and y["mastery_rank"] == 2 and proto["mastery_rank"] == 3
 assert x["members"][0]["challenges"] == [10, 11, 12, 13, 14]
 
 overlap = aggregate_crews([
@@ -242,6 +259,28 @@ wide = next(c for c in overlap if c["key"] == "wide")
 assert (dup["score"], dup["unique"], dup["rank"]) == (6, 3, 1)
 assert (wide["score"], wide["unique"], wide["rank"]) == (4, 4, 2)
 assert wide["unique_rank"] == 1 and dup["unique_rank"] == 2
+assert (dup["mastery"], wide["mastery"]) == (3, 4)
+assert wide["mastery_rank"] == 1 and dup["mastery_rank"] == 2
+
+disjoint = aggregate_crews([
+    {"user_id": 1, "name": "a [Split]", "solves": 1, "rank": 1},
+    {"user_id": 2, "name": "b [Split]", "solves": 1, "rank": 2},
+    {"user_id": 3, "name": "c [Solo]", "solves": 2, "rank": 3},
+], {1: {1}, 2: {2}, 3: {1, 2}})
+split = next(c for c in disjoint if c["key"] == "split")
+solo = next(c for c in disjoint if c["key"] == "solo")
+assert (split["mastery"], solo["mastery"]) == (0, 2)
+assert solo["mastery_rank"] == 1 and split["mastery_rank"] == 2
+
+mastery_tie = aggregate_crews([
+    {"user_id": 1, "name": "a [Duo]", "solves": 2, "rank": 1},
+    {"user_id": 2, "name": "b [Duo]", "solves": 2, "rank": 2},
+    {"user_id": 3, "name": "c [One]", "solves": 2, "rank": 3},
+], {1: {1, 2}, 2: {1, 2}, 3: {1, 2}})
+duo = next(c for c in mastery_tie if c["key"] == "duo")
+one = next(c for c in mastery_tie if c["key"] == "one")
+assert duo["mastery"] == 2 and one["mastery"] == 2
+assert duo["mastery_rank"] == 1 and one["mastery_rank"] == 2
 
 tie = aggregate_crews([
     {"user_id": 1, "name": "a [Big]", "solves": 3, "rank": 1},
@@ -306,6 +345,16 @@ def test_crew_scoreboard_api(crew_dojo):
     unique_ranks = [c["rank"] for c in unique_board["standings"]]
     assert unique_ranks == sorted(unique_ranks)
 
+    mastery_board = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/_/crews/0/1?mode=mastery").json()
+    assert mastery_board["mode"] == "mastery"
+    mastery_crew = next(c for c in mastery_board["standings"] if c["key"] == tag.lower())
+    assert mastery_crew["mastery"] == 0
+    mastery_ranks = [c["rank"] for c in mastery_board["standings"]]
+    assert mastery_ranks == sorted(mastery_ranks)
+
+    bogus_board = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/_/crews/0/1?mode=bogus").json()
+    assert bogus_board["mode"] == "cumulative"
+
     solve(crew_dojo, name_b, session_b, "apple")
     remove_workspace_container(name_b)
     wait_for_background_worker(timeout=30)
@@ -313,11 +362,13 @@ def test_crew_scoreboard_api(crew_dojo):
     overlap_crew = next(c for c in overlap_board["standings"] if c["key"] == tag.lower())
     assert overlap_crew["score"] == 3
     assert overlap_crew["unique"] == 2
+    assert overlap_crew["mastery"] == 1
 
     module_board = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/hello/crews/0/1").json()
     module_crew = next(c for c in module_board["standings"] if c["key"] == tag.lower())
     assert module_crew["score"] == 3
     assert module_crew["unique"] == 2
+    assert module_crew["mastery"] == 1
 
     solo_tag = "".join(random.choices(string.ascii_uppercase, k=8))
     name_s, _, session_s = register_user(tag=solo_tag)
@@ -334,8 +385,10 @@ def test_crew_scoreboard_api(crew_dojo):
 
     cumulative_order = crew_order("cumulative")
     unique_order = crew_order("unique")
+    mastery_order = crew_order("mastery")
     assert cumulative_order.index(tag.lower()) < cumulative_order.index(solo_tag.lower())
     assert unique_order.index(solo_tag.lower()) < unique_order.index(tag.lower())
+    assert mastery_order.index(solo_tag.lower()) < mastery_order.index(tag.lower())
 
     flask_exec(f"""
 from CTFd.plugins.dojo_plugin.models import Dojos
@@ -348,9 +401,11 @@ print("RECALC-DONE", dojo.dojo_id)
     recalc_crew = next(c for c in recalc_board["standings"] if c["key"] == tag.lower())
     assert recalc_crew["score"] == 3
     assert recalc_crew["unique"] == 2
+    assert recalc_crew["mastery"] == 1
     recalc_solo = next(c for c in recalc_board["standings"] if c["key"] == solo_tag.lower())
     assert recalc_solo["score"] == 2
     assert recalc_solo["unique"] == 2
+    assert recalc_solo["mastery"] == 2
 
     dojo_id = flask_exec(f"""
 from CTFd.plugins.dojo_plugin.models import Dojos
@@ -362,10 +417,15 @@ print("DOJO-ID", Dojos.from_id({crew_dojo!r}).first().dojo_id)
     fallback_crew = next(c for c in fallback_board["standings"] if c["key"] == tag.lower())
     assert fallback_crew["score"] == 3
     assert fallback_crew["unique"] is None
+    assert fallback_crew["mastery"] is None
     dojo_run("docker", "exec", "cache", "redis-cli", "DEL", f"stats:crews:dojo:{dojo_id}:0")
     fallback_unique = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/_/crews/0/1?mode=unique")
     assert fallback_unique.status_code == 200
     assert fallback_unique.json()["mode"] == "unique"
+    dojo_run("docker", "exec", "cache", "redis-cli", "DEL", f"stats:crews:dojo:{dojo_id}:0")
+    fallback_mastery = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/_/crews/0/1?mode=mastery")
+    assert fallback_mastery.status_code == 200
+    assert fallback_mastery.json()["mode"] == "mastery"
 
     hacker_board = session_a.get(f"{DOJO_URL}/pwncollege_api/v1/scoreboard/{crew_dojo}/_/0/1").json()
     tagged = next(entry for entry in hacker_board["standings"] if entry["name"] == name_a)


### PR DESCRIPTION
## Summary

Adds a third crew scoreboard mode, **Mastery**, alongside the existing Cumulative and Unique modes. Mastery counts the challenges that *every* member of the crew has solved (the intersection of member solve sets), rewarding crews that bring all their members through the material rather than dividing and conquering.

- `aggregate_crews` now computes `mastery` and `mastery_rank` next to `unique`/`unique_rank`. On mastery ties, bigger crews rank higher, since a full-crew solve is harder with more members.
- The crews scoreboard API accepts `?mode=mastery` and returns `mastery` per crew; invalid modes still fall back to cumulative.
- The scoreboard UI gains a Mastery toggle tab, a `#crews-mastery` deep link, a "Mastery" score column header, and the score tooltip now shows all three numbers.
- When the crews cache is cold and crews are re-aggregated without per-member solve data, `mastery` is `null` and the UI shows "—", matching the existing Unique fallback.

## Testing

- `test/test_crew_scoreboard.py` extended: unit coverage for mastery intersection, disjoint-solves (mastery 0), and the bigger-crew tie-break; API assertions for `mode=mastery` ordering, invalid-mode fallback, cache-recalc, and cold-cache fallback; browser assertions for the Mastery toggle and `#crews-mastery` deep link.
- Full suite run locally via `./deploy.sh -t`: 193 passed, 4 skipped (pre-existing), 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)