### PR TITLE
Internationalization support

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,6 +124,8 @@ You can drop into a python shell to leverage this as well by running `dojo flask
 
 The docker socket of the docker-in-docker daemon is mapped into the CTFd container, allowing CTFd to start up user challenge containers.
 
+Dojo content can be translated into other languages; see [internationalization](i18n.md).
+
 ## Challenge containers
 
 When a user launches a challenge, CTFd starts a docker container that will run alongside the infrastructure containers, and:

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -15,6 +15,9 @@ The languages offered by the switcher are listed in `dojo_plugin/i18n.py`:
 LANGUAGES = {
     "en": "English",
     "ko": "한국어",
+    "zh-CN": "简体中文",
+    "zh-TW": "繁體中文",
+    "it": "Italiano",
 }
 ```
 
@@ -22,6 +25,14 @@ A dojo may carry translations for tags that are not in this list; they are simpl
 selectable until the platform adds them.
 Language tags are BCP-47-ish (`ko`, `ko-KR`, `zh-Hans-CN`), and a region-qualified tag
 falls back to its base language before falling back to the source text.
+
+Write translations under the tags in `LANGUAGES` — a dojo that files its Chinese under
+`zh-Hans` is not found by a visitor who selected `zh-CN`.
+`LANGUAGE_ALIASES`, alongside `LANGUAGES`, maps the tags browsers actually send onto the
+ones offered, so `zh`, `zh-Hans-CN`, and `zh-SG` all select `zh-CN`, and `zh-Hant`,
+`zh-HK`, and `zh-MO` all select `zh-TW`.
+It steers the choice of language; it does not affect how a translation is looked up once
+the language is chosen.
 
 ## How a language is chosen
 

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -96,10 +96,16 @@ resources:
   content: 고급 섹션
 ```
 
-A locator that matches no resource is an error, reported when the dojo is created or
-updated.
-This is deliberate: a translation that silently stops being applied is worse than one that
-tells you it has drifted from the content it translates.
+A locator that matches no resource — or more than one — is an error, reported when the
+dojo is created or updated.
+This is deliberate: a translation that silently stops being applied, or lands on the wrong
+resource, is worse than one that tells you it has drifted from the content it translates.
+Consolidated dojos often repeat a resource name (several modules each contributing a
+"Resources" block); use `index` for those.
+
+`source` matches a resource's `name`, so it cannot address a header — headers have only
+`content`, and in a consolidated dojo a header's content is frequently identical to a
+nearby markdown resource's name. Address headers by `index`.
 
 ### Inline `translations:`
 

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -155,6 +155,8 @@ description — and its translation — can only be changed in the dojo it is im
 
 Translations are stored in each model's existing JSONB `data` column under a
 `translations` key, so this feature adds no table and no column, and needs no migration.
+The key is written only for content that actually has a translation, so an untranslated
+dojo's rows are exactly what a build without i18n would write.
 `LocalizedMixin` in `dojo_plugin/models/__init__.py` resolves them:
 `dojo.localized_name`, `module.localized_description`, and `resource.localized_content`
 each return the translation for the request's language, or the source value.

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,135 @@
+# Internationalization
+
+Dojo content — the names and descriptions of dojos, modules, challenges, and module
+resources — can be shipped in more than one language.
+A visitor picks a language from the switcher in the navigation bar, and every piece of
+content that has a translation for it is rendered in that language.
+Anything without a translation falls back to the source text, so a partially translated
+dojo is always coherent.
+
+## Supported languages
+
+The languages offered by the switcher are listed in `dojo_plugin/i18n.py`:
+
+```python
+LANGUAGES = {
+    "en": "English",
+    "ko": "한국어",
+}
+```
+
+A dojo may carry translations for tags that are not in this list; they are simply not
+selectable until the platform adds them.
+Language tags are BCP-47-ish (`ko`, `ko-KR`, `zh-Hans-CN`), and a region-qualified tag
+falls back to its base language before falling back to the source text.
+
+## How a language is chosen
+
+For each request, in order:
+
+1. a `?lang=` query parameter
+2. the logged-in user's stored preference (`dojo_user_preferences`)
+3. the `dojo_language` cookie, set by the switcher
+4. the browser's `Accept-Language` header
+5. `en`
+
+## Adding translations to a dojo
+
+### The `i18n/` tree
+
+The recommended layout is a parallel tree that mirrors the dojo's own structure, one
+directory per language:
+
+```
+repo-root/
+  dojo.yml
+  DESCRIPTION.md
+  hello/
+    module.yml
+    DESCRIPTION.md
+    hello/
+      DESCRIPTION.md
+  i18n/
+    ko/
+      dojo.yml                  <- translated dojo name
+      DESCRIPTION.md            <- translated dojo description
+      hello/
+        module.yml              <- translated module name + resource names/content
+        DESCRIPTION.md          <- translated module description
+        hello/
+          challenge.yml         <- translated challenge name (optional)
+          DESCRIPTION.md        <- translated challenge description
+```
+
+Every file is optional. Only what exists gets translated.
+
+`i18n/<lang>/dojo.yml` and `i18n/<lang>/<module>/<challenge>/challenge.yml` accept `name`
+and `description`.
+`i18n/<lang>/<module>/module.yml` accepts `name`, `description`, and a `resources` list.
+
+### Translating resources
+
+A module's resources are an ordered, heterogeneous list, so each entry in the translated
+`resources` list carries exactly one locator saying which resource it applies to:
+
+| Locator | Matches | Use for |
+| --- | --- | --- |
+| `id` | the resource's challenge id | challenges |
+| `source` | the resource's source (English) `name` | lectures, markdown resources |
+| `index` | the resource's position in the list | headers, which have neither |
+
+The remaining keys (`name`, `content`, `description`) are the translated values:
+
+```yaml
+# i18n/ko/hello/module.yml
+name: 안녕, 해커
+resources:
+- id: hello
+  name: 명령어 입문
+- source: The Command Line
+  name: 커맨드 라인
+- source: Other Tutorials
+  name: 다른 튜토리얼
+  content: |
+    - [방대한 bash 튜토리얼](https://bash.cyberciti.biz/guide/Main_Page).
+- index: 4
+  content: 고급 섹션
+```
+
+A locator that matches no resource is an error, reported when the dojo is created or
+updated.
+This is deliberate: a translation that silently stops being applied is worse than one that
+tells you it has drifted from the content it translates.
+
+### Inline `translations:`
+
+Translations can also be written directly into the dojo's own yml files, at any level that
+has a `name`, `description`, or `content`:
+
+```yaml
+id: linux-luminarium
+name: Linux Luminarium
+translations:
+  ko:
+    name: 리눅스 루미나리움
+    description: |
+      리눅스 루미나리움에 오신 것을 환영합니다!
+```
+
+An inline `translations:` block wins over the `i18n/` tree, the same way a `description:`
+in `dojo.yml` wins over `DESCRIPTION.md`.
+This form is mostly useful for dojos created from a spec rather than a repository.
+
+## Implementation notes
+
+Translations are stored in each model's existing JSONB `data` column under a
+`translations` key, so adding a language needs no database migration.
+`LocalizedMixin` in `dojo_plugin/models/__init__.py` resolves them:
+`dojo.localized_name`, `module.localized_description`, and `resource.localized_content`
+each return the translation for the request's language, or the source value.
+Templates and the JSON API use these properties throughout; the underlying `name` and
+`description` columns always hold the source text, which is what admin views and dojo
+imports operate on.
+
+`Dojos.languages` records which languages the dojo repo ships, derived from the
+subdirectories of `i18n/`.

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -28,10 +28,13 @@ falls back to its base language before falling back to the source text.
 For each request, in order:
 
 1. a `?lang=` query parameter
-2. the logged-in user's stored preference (`dojo_user_preferences`)
-3. the `dojo_language` cookie, set by the switcher
-4. the browser's `Accept-Language` header
-5. `en`
+2. the `dojo_language` cookie, set by the switcher
+3. the browser's `Accept-Language` header
+4. `en`
+
+The choice is per-browser, not per-account: it lives in a cookie and nothing about it is
+written to the database, so signing in on another machine starts from `Accept-Language`
+again.
 
 ## Adding translations to a dojo
 
@@ -151,7 +154,7 @@ description — and its translation — can only be changed in the dojo it is im
 ## Implementation notes
 
 Translations are stored in each model's existing JSONB `data` column under a
-`translations` key, so adding a language needs no database migration.
+`translations` key, so this feature adds no table and no column, and needs no migration.
 `LocalizedMixin` in `dojo_plugin/models/__init__.py` resolves them:
 `dojo.localized_name`, `module.localized_description`, and `resource.localized_content`
 each return the translation for the request's language, or the source value.

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -120,6 +120,28 @@ An inline `translations:` block wins over the `i18n/` tree, the same way a `desc
 in `dojo.yml` wins over `DESCRIPTION.md`.
 This form is mostly useful for dojos created from a spec rather than a repository.
 
+## Imported dojos, modules, and challenges
+
+A dojo that imports content inherits that content's translations. The inheritance is
+per-language and per-field, so a consolidated dojo can rename a challenge in its own
+language without losing the translated description it inherits:
+
+```yaml
+- type: challenge
+  id: hello-hello
+  name: Intro to Commands
+  translations:
+    ko:
+      name: 명령어 입문        # wins over the source's translated name
+  import:                       # the source's translated description is still inherited
+    dojo: linux-luminarium
+    module: hello
+    challenge: hello
+```
+
+Note the consequence: an imported challenge has no `description` of its own, so its
+description — and its translation — can only be changed in the dojo it is imported from.
+
 ## Implementation notes
 
 Translations are stored in each model's existing JSONB `data` column under a

--- a/dojo_plugin/__init__.py
+++ b/dojo_plugin/__init__.py
@@ -23,6 +23,7 @@ from CTFd.plugins.flags import FLAG_CLASSES, BaseFlag, FlagException
 from .models import Dojos, DojoChallenges, Belts, Emojis
 from .config import DOJO_HOST, bootstrap
 from .utils import unserialize_user_flag, render_markdown
+from .i18n import init_language
 from .utils.dojo import get_current_dojo_challenge
 from .utils.awards import update_awards
 from .utils.feed import publish_challenge_solve
@@ -35,6 +36,7 @@ from .pages.sensai import sensai
 from .pages.users import users
 from .pages.settings import settings_override
 from .pages.discord import discord
+from .pages.language import language
 from .pages.course import course
 from .pages.belts import belts
 from .pages.research import research
@@ -227,6 +229,7 @@ def load(app):
     app.register_blueprint(workspace)
     app.register_blueprint(sensai)
     app.register_blueprint(discord)
+    app.register_blueprint(language)
     app.register_blueprint(users)
     app.register_blueprint(course)
     app.register_blueprint(belts)
@@ -236,6 +239,8 @@ def load(app):
     app.register_blueprint(api, url_prefix="/pwncollege_api/v1")
 
     app.jinja_env.filters["markdown"] = render_markdown
+
+    init_language(app)
 
     register_admin_plugin_menu_bar("Dojos", "/admin/dojos")
 

--- a/dojo_plugin/api/v1/dojos.py
+++ b/dojo_plugin/api/v1/dojos.py
@@ -47,8 +47,8 @@ class DojoList(Resource):
         dojos = [
             dict(id=dojo.reference_id,
                  hex_id=dojo.hex_dojo_id,
-                 name=dojo.name,
-                 description=dojo.description,
+                 name=dojo.localized_name,
+                 description=dojo.localized_description,
                  type=dojo.type,
                  official=dojo.official,
                  award=dojo.award,
@@ -179,13 +179,13 @@ class DojoModuleList(Resource):
         is_dojo_admin = dojo.is_admin()
         modules = [
             dict(id=module.id,
-                 name=module.name,
-                 description=module.description,
+                 name=module.localized_name,
+                 description=module.localized_description,
                  resources=[
                     dict(id=f"resource-{resource.resource_index}",
-                         name=resource.name,
+                         name=resource.localized_name,
                          type=resource.type,
-                         content=getattr(resource, 'content', None) if resource.type == "markdown" else None,
+                         content=resource.localized_content if resource.type == "markdown" else None,
                          video=getattr(resource, 'video', None) if resource.type == "lecture" else None,
                          playlist=getattr(resource, 'playlist', None) if resource.type == "lecture" else None,
                          slides=getattr(resource, 'slides', None) if resource.type == "lecture" else None,
@@ -195,9 +195,9 @@ class DojoModuleList(Resource):
                  ],
                  challenges=[
                     dict(id=challenge.id,
-                         name=challenge.name,
+                         name=challenge.localized_name,
                          required=challenge.required,
-                         description=challenge.description)
+                         description=challenge.localized_description)
                     for challenge in (module.visible_challenges() if not is_dojo_admin
                                       else module.challenges)
                  ],
@@ -205,14 +205,14 @@ class DojoModuleList(Resource):
                      dict(
                          item_type=item.item_type,
                          id=f"resource-{item.resource_index}" if item.item_type == 'resource' else getattr(item, 'id', None),
-                         name=item.name,
+                         name=item.localized_name,
                          type=getattr(item, 'type', None),
-                         content=getattr(item, 'content', None) if hasattr(item, 'type') and item.type in ["markdown", "header"] else None,
+                         content=item.localized_content if hasattr(item, 'type') and item.type in ["markdown", "header"] else None,
                          video=getattr(item, 'video', None) if hasattr(item, 'type') and item.type == "lecture" else None,
                          playlist=getattr(item, 'playlist', None) if hasattr(item, 'type') and item.type == "lecture" else None,
                          slides=getattr(item, 'slides', None) if hasattr(item, 'type') and item.type == "lecture" else None,
                          expandable=getattr(item, 'expandable', True) if hasattr(item, 'type') else None,
-                         description=getattr(item, 'description', None),
+                         description=item.localized_description,
                          required=getattr(item, 'required', None) if item.item_type == 'challenge' else None
                      ) for item in (module.unified_items if is_dojo_admin else module.visible_items)
                  ])
@@ -430,7 +430,7 @@ class DojoChallengeDescription(Resource):
 
         return {
             "success": True,
-            "description": render_markdown(dojo_challenge.description)
+            "description": render_markdown(dojo_challenge.localized_description)
         }
 
 

--- a/dojo_plugin/api/v1/search.py
+++ b/dojo_plugin/api/v1/search.py
@@ -10,17 +10,11 @@ from ...models import Dojos, DojoAdmins, DojoModules, DojoChallenges
 search_namespace = Namespace("search", description="Search across dojos, modules, and challenges")
 
 
-def translated_match(model, language, like_query):
-    if language == DEFAULT_LANGUAGE:
-        return None
-    return model.data["translations"][language].astext.ilike(like_query, escape="\\")
-
-
-def matches(model, language, like_query, *columns):
-    conditions = [column.ilike(like_query, escape="\\") for column in columns]
-    translated = translated_match(model, language, like_query)
-    if translated is not None:
-        conditions.append(translated)
+def matches(model, language, like_query, *fields):
+    conditions = [getattr(model, field).ilike(like_query, escape="\\") for field in fields]
+    if language != DEFAULT_LANGUAGE:
+        conditions += [model.data["translations"][language][field].astext.ilike(like_query, escape="\\")
+                       for field in fields]
     return or_(*conditions)
 
 
@@ -40,17 +34,15 @@ class Search(Resource):
         like_query = f"%{escaped}%"
 
         dojos = Dojos.viewable(user=user).filter(
-            matches(Dojos, language, like_query, Dojos.name, Dojos.description))
+            matches(Dojos, language, like_query, "name", "description"))
         modules = (DojoModules.query
                    .join(Dojos.viewable(user=user))
-                   .filter(matches(DojoModules, language, like_query,
-                                   DojoModules.name, DojoModules.description)))
+                   .filter(matches(DojoModules, language, like_query, "name", "description")))
         challenges = (DojoChallenges.query
                       .join(Dojos.viewable(user=user))
                       .join(DojoModules, and_(DojoModules.dojo_id == DojoChallenges.dojo_id,
                                               DojoModules.module_index == DojoChallenges.module_index))
-                      .filter(matches(DojoChallenges, language, like_query,
-                                      DojoChallenges.name, DojoChallenges.description)))
+                      .filter(matches(DojoChallenges, language, like_query, "name", "description")))
 
         if not is_admin():
             admin_dojo_ids = (db.session.query(DojoAdmins.dojo_id)

--- a/dojo_plugin/api/v1/search.py
+++ b/dojo_plugin/api/v1/search.py
@@ -4,9 +4,25 @@ from sqlalchemy.sql import and_, or_
 from CTFd.models import db
 from CTFd.utils.user import get_current_user, is_admin
 
+from ...i18n import DEFAULT_LANGUAGE, current_language
 from ...models import Dojos, DojoAdmins, DojoModules, DojoChallenges
 
 search_namespace = Namespace("search", description="Search across dojos, modules, and challenges")
+
+
+def translated_match(model, language, like_query):
+    if language == DEFAULT_LANGUAGE:
+        return None
+    return model.data["translations"][language].astext.ilike(like_query, escape="\\")
+
+
+def matches(model, language, like_query, *columns):
+    conditions = [column.ilike(like_query, escape="\\") for column in columns]
+    translated = translated_match(model, language, like_query)
+    if translated is not None:
+        conditions.append(translated)
+    return or_(*conditions)
+
 
 @search_namespace.route("")
 class Search(Resource):
@@ -14,6 +30,7 @@ class Search(Resource):
         query = request.args.get("q", "").strip()
 
         user = get_current_user()
+        language = current_language()
 
         if not query or len(query) < 2:
             return {"success": False, "error": "Query too short."}, 400
@@ -22,18 +39,18 @@ class Search(Resource):
         escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
         like_query = f"%{escaped}%"
 
-        def ilike(*columns):
-            return or_(*(column.ilike(like_query, escape="\\") for column in columns))
-
-        dojos = Dojos.viewable(user=user).filter(ilike(Dojos.name, Dojos.description))
+        dojos = Dojos.viewable(user=user).filter(
+            matches(Dojos, language, like_query, Dojos.name, Dojos.description))
         modules = (DojoModules.query
                    .join(Dojos.viewable(user=user))
-                   .filter(ilike(DojoModules.name, DojoModules.description)))
+                   .filter(matches(DojoModules, language, like_query,
+                                   DojoModules.name, DojoModules.description)))
         challenges = (DojoChallenges.query
                       .join(Dojos.viewable(user=user))
                       .join(DojoModules, and_(DojoModules.dojo_id == DojoChallenges.dojo_id,
                                               DojoModules.module_index == DojoChallenges.module_index))
-                      .filter(ilike(DojoChallenges.name, DojoChallenges.description)))
+                      .filter(matches(DojoChallenges, language, like_query,
+                                      DojoChallenges.name, DojoChallenges.description)))
 
         if not is_admin():
             admin_dojo_ids = (db.session.query(DojoAdmins.dojo_id)
@@ -57,42 +74,42 @@ class Search(Resource):
                 "dojos": [
                     {
                         "id": dojo.reference_id,
-                        "name": dojo.name,
+                        "name": dojo.localized_name,
                         "link": f"/{dojo.reference_id}",
-                        "description": dojo.description,
+                        "description": dojo.localized_description,
                     }
                     for dojo in dojos
                 ],
                 "modules": [
                     {
                         "id": module.id,
-                        "name": module.name,
+                        "name": module.localized_name,
                         "dojo": {
                             "id": module.dojo.reference_id,
-                            "name": module.dojo.name,
+                            "name": module.dojo.localized_name,
                             "link": f"/{module.dojo.reference_id}"
                         },
                         "link": f"/{module.dojo.reference_id}/{module.id}",
-                        "description": module.description,
+                        "description": module.localized_description,
                     }
                     for module in modules
                 ],
                 "challenges": [
                     {
                         "id": challenge.id,
-                        "name": challenge.name,
+                        "name": challenge.localized_name,
                         "module": {
                             "id": challenge.module.id,
-                            "name": challenge.module.name,
+                            "name": challenge.module.localized_name,
                             "link": f"/{challenge.module.dojo.reference_id}/{challenge.module.id}"
                         },
                         "dojo": {
                             "id": challenge.module.dojo.reference_id,
-                            "name": challenge.module.dojo.name,
+                            "name": challenge.module.dojo.localized_name,
                             "link": f"/{challenge.module.dojo.reference_id}"
                         },
                         "link": f"/{challenge.module.dojo.reference_id}/{challenge.module.id}/{challenge.id}",
-                        "description": challenge.description,
+                        "description": challenge.localized_description,
                     }
                     for challenge in challenges
                 ]

--- a/dojo_plugin/i18n.py
+++ b/dojo_plugin/i18n.py
@@ -113,10 +113,6 @@ def current_language():
 
 
 def init_language(app):
-    @app.before_request
-    def set_request_language():
-        g.language = select_language()
-
     @app.context_processor
     def inject_language():
         return dict(current_language=current_language(),

--- a/dojo_plugin/i18n.py
+++ b/dojo_plugin/i18n.py
@@ -99,6 +99,8 @@ def select_language():
 
 
 def language_switch_next():
+    if not has_request_context():
+        return "/"
     # a `lang` already in the URL would out-rank the cookie the switcher is about to set
     query = [(key, value) for key, value in request.args.items(multi=True) if key != "lang"]
     return request.path + ("?" + urlencode(query) if query else "")

--- a/dojo_plugin/i18n.py
+++ b/dojo_plugin/i18n.py
@@ -1,0 +1,124 @@
+import re
+from urllib.parse import urlencode
+
+from flask import g, has_request_context, request
+
+
+DEFAULT_LANGUAGE = "en"
+
+LANGUAGES = {
+    "en": "English",
+    "ko": "한국어",
+}
+
+LANGUAGE_COOKIE = "dojo_language"
+LANGUAGE_COOKIE_MAX_AGE = 365 * 24 * 60 * 60
+
+LANGUAGE_PATTERN = r"^[a-z]{2,3}(-[A-Za-z0-9]{2,8})*$"
+LANGUAGE_RE = re.compile(LANGUAGE_PATTERN)
+
+# Content the platform generates rather than the dojo author, but which is stored as dojo
+# content and so needs translating the same way authored content does.
+UI_STRINGS = {
+    "challenges_header": {
+        "ko": "챌린지",
+    },
+}
+
+
+def normalize_language(language):
+    if not isinstance(language, str):
+        return None
+    language = language.strip()
+    if not LANGUAGE_RE.match(language.lower()):
+        return None
+    primary, *subtags = language.split("-")
+    return "-".join([primary.lower(),
+                     *(subtag.upper() if len(subtag) == 2 else subtag.title() for subtag in subtags)])
+
+
+def language_candidates(language):
+    language = normalize_language(language)
+    if not language:
+        return []
+    subtags = language.split("-")
+    return ["-".join(subtags[:length]) for length in range(len(subtags), 0, -1)]
+
+
+def ui_string(key, language=None):
+    translations = UI_STRINGS.get(key, {})
+    for candidate in language_candidates(language or current_language()):
+        if candidate in translations:
+            return translations[candidate]
+    return None
+
+
+def ui_string_translations(key):
+    return {language: {"content": content} for language, content in UI_STRINGS.get(key, {}).items()}
+
+
+def selectable_language(language):
+    for candidate in language_candidates(language):
+        if candidate in LANGUAGES:
+            return candidate
+    return None
+
+
+def _stored_language():
+    from .models import UserPreferences
+    from CTFd.utils.user import authed, get_current_user
+
+    if not authed():
+        return None
+    user = get_current_user()
+    if not user:
+        return None
+    preferences = UserPreferences.query.filter_by(user_id=user.id).first()
+    return preferences.language if preferences else None
+
+
+def _accept_language():
+    for language, _ in request.accept_languages:
+        selected = selectable_language(language)
+        if selected:
+            return selected
+    return None
+
+
+def select_language():
+    sources = [
+        lambda: request.args.get("lang"),
+        _stored_language,
+        lambda: request.cookies.get(LANGUAGE_COOKIE),
+    ]
+    for source in sources:
+        selected = selectable_language(source())
+        if selected:
+            return selected
+    return _accept_language() or DEFAULT_LANGUAGE
+
+
+def language_switch_next():
+    # a `lang` already in the URL would out-rank the cookie the switcher is about to set
+    query = [(key, value) for key, value in request.args.items(multi=True) if key != "lang"]
+    return request.path + ("?" + urlencode(query) if query else "")
+
+
+def current_language():
+    if not has_request_context():
+        return DEFAULT_LANGUAGE
+    if "language" not in g:
+        g.language = select_language()
+    return g.language
+
+
+def init_language(app):
+    @app.before_request
+    def set_request_language():
+        g.language = select_language()
+
+    @app.context_processor
+    def inject_language():
+        return dict(current_language=current_language(),
+                    languages=LANGUAGES,
+                    language_switch_next=language_switch_next())

--- a/dojo_plugin/i18n.py
+++ b/dojo_plugin/i18n.py
@@ -9,6 +9,20 @@ DEFAULT_LANGUAGE = "en"
 LANGUAGES = {
     "en": "English",
     "ko": "한국어",
+    "zh-CN": "简体中文",
+    "zh-TW": "繁體中文",
+    "it": "Italiano",
+}
+
+# Browsers name Chinese by script (`zh-Hans`) or generically (`zh`) as often as they name
+# it by region, and none of those truncate down to a tag offered above.
+LANGUAGE_ALIASES = {
+    "zh": "zh-CN",
+    "zh-Hans": "zh-CN",
+    "zh-SG": "zh-CN",
+    "zh-Hant": "zh-TW",
+    "zh-HK": "zh-TW",
+    "zh-MO": "zh-TW",
 }
 
 LANGUAGE_COOKIE = "dojo_language"
@@ -22,6 +36,9 @@ LANGUAGE_RE = re.compile(LANGUAGE_PATTERN)
 UI_STRINGS = {
     "challenges_header": {
         "ko": "챌린지",
+        "zh-CN": "挑战",
+        "zh-TW": "挑戰",
+        "it": "Sfide",
     },
 }
 
@@ -61,6 +78,8 @@ def selectable_language(language):
     for candidate in language_candidates(language):
         if candidate in LANGUAGES:
             return candidate
+        if candidate in LANGUAGE_ALIASES:
+            return LANGUAGE_ALIASES[candidate]
     return None
 
 

--- a/dojo_plugin/i18n.py
+++ b/dojo_plugin/i18n.py
@@ -1,5 +1,4 @@
 import re
-from urllib.parse import urlencode
 
 from flask import g, has_request_context, request
 
@@ -102,9 +101,11 @@ def select_language():
 def language_switch_next():
     if not has_request_context():
         return "/"
-    # a `lang` already in the URL would out-rank the cookie the switcher is about to set
-    query = [(key, value) for key, value in request.args.items(multi=True) if key != "lang"]
-    return request.path + ("?" + urlencode(query) if query else "")
+    # The path only. This renders into every page's navbar, error pages included, so
+    # echoing the query string back would make two error responses differ by whatever the
+    # caller passed. Dropping it also drops any `lang`, which would otherwise out-rank the
+    # cookie the switcher is about to set.
+    return request.path
 
 
 def current_language():

--- a/dojo_plugin/i18n.py
+++ b/dojo_plugin/i18n.py
@@ -64,19 +64,6 @@ def selectable_language(language):
     return None
 
 
-def _stored_language():
-    from .models import UserPreferences
-    from CTFd.utils.user import authed, get_current_user
-
-    if not authed():
-        return None
-    user = get_current_user()
-    if not user:
-        return None
-    preferences = UserPreferences.query.filter_by(user_id=user.id).first()
-    return preferences.language if preferences else None
-
-
 def _accept_language():
     for language, _ in request.accept_languages:
         selected = selectable_language(language)
@@ -86,13 +73,8 @@ def _accept_language():
 
 
 def select_language():
-    sources = [
-        lambda: request.args.get("lang"),
-        _stored_language,
-        lambda: request.cookies.get(LANGUAGE_COOKIE),
-    ]
-    for source in sources:
-        selected = selectable_language(source())
+    for source in [request.args.get("lang"), request.cookies.get(LANGUAGE_COOKIE)]:
+        selected = selectable_language(source)
         if selected:
             return selected
     return _accept_language() or DEFAULT_LANGUAGE

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -444,8 +444,9 @@ class DojoModules(LocalizedMixin, db.Model):
         if default:
             for field in ["id", "name", "description"]:
                 kwargs[field] = kwargs[field] if kwargs.get(field) is not None else getattr(default, field, None)
-            kwargs["data"]["translations"] = merge_translations(
-                kwargs["data"].get("translations"), default.translations)
+            translations = merge_translations(kwargs["data"].get("translations"), default.translations)
+            if translations:
+                kwargs["data"]["translations"] = translations
 
         def set_module_import(challenge):
             challenge.data["module_import"] = True
@@ -649,8 +650,9 @@ class DojoChallenges(LocalizedMixin, db.Model):
                 kwargs[field] = kwargs[field] if kwargs.get(field) is not None else getattr(default, field, None)
 
             # TODO: maybe we should track the entire import
-            kwargs["data"]["translations"] = merge_translations(
-                kwargs["data"].get("translations"), default.translations)
+            translations = merge_translations(kwargs["data"].get("translations"), default.translations)
+            if translations:
+                kwargs["data"]["translations"] = translations
             kwargs["data"]["image"] = default.data.get("image")
             kwargs["data"]["path_override"] = str(default.path)
             # only update the unified_index for module and dojo imports, not challenge specific ones

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -942,17 +942,6 @@ class SSHKeys(db.Model):
     __repr__ = columns_repr(["user", "value"])
 
 
-class UserPreferences(db.Model):
-    __tablename__ = "dojo_user_preferences"
-
-    user_id = db.Column(db.Integer, db.ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
-    language = db.Column(db.String(16))
-
-    user = db.relationship("Users")
-
-    __repr__ = columns_repr(["user", "language"])
-
-
 class DiscordUserActivity(db.Model):
     __tablename__ = "discord_user_activity"
     id = db.Column(db.Integer, primary_key=True)

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -29,6 +29,15 @@ from ..config import DOJOS_DIR
 from ..i18n import current_language, language_candidates
 
 
+def merge_translations(translations, inherited):
+    # per-language, per-field: an import inherits the source's translations for every
+    # field it does not translate itself
+    merged = {language: dict(fields) for language, fields in (inherited or {}).items()}
+    for language, fields in (translations or {}).items():
+        merged.setdefault(language, {}).update(fields)
+    return merged
+
+
 class LocalizedMixin:
     def localized(self, field, language=None):
         translations = self.translations or {}
@@ -435,8 +444,8 @@ class DojoModules(LocalizedMixin, db.Model):
         if default:
             for field in ["id", "name", "description"]:
                 kwargs[field] = kwargs[field] if kwargs.get(field) is not None else getattr(default, field, None)
-            if not kwargs["data"].get("translations"):
-                kwargs["data"]["translations"] = default.translations
+            kwargs["data"]["translations"] = merge_translations(
+                kwargs["data"].get("translations"), default.translations)
 
         def set_module_import(challenge):
             challenge.data["module_import"] = True
@@ -640,8 +649,8 @@ class DojoChallenges(LocalizedMixin, db.Model):
                 kwargs[field] = kwargs[field] if kwargs.get(field) is not None else getattr(default, field, None)
 
             # TODO: maybe we should track the entire import
-            if not kwargs["data"].get("translations"):
-                kwargs["data"]["translations"] = default.translations
+            kwargs["data"]["translations"] = merge_translations(
+                kwargs["data"].get("translations"), default.translations)
             kwargs["data"]["image"] = default.data.get("image")
             kwargs["data"]["path_override"] = str(default.path)
             # only update the unified_index for module and dojo imports, not challenge specific ones

--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -26,6 +26,29 @@ from CTFd.models import db, get_class_by_tablename, Challenges, Solves, Flags, U
 from CTFd.utils.user import get_current_user, is_admin
 
 from ..config import DOJOS_DIR
+from ..i18n import current_language, language_candidates
+
+
+class LocalizedMixin:
+    def localized(self, field, language=None):
+        translations = self.translations or {}
+        for candidate in language_candidates(language or current_language()):
+            value = translations.get(candidate, {}).get(field)
+            if value:
+                return value
+        return getattr(self, field, None)
+
+    @property
+    def localized_name(self):
+        return self.localized("name")
+
+    @property
+    def localized_description(self):
+        return self.localized("description")
+
+    @property
+    def localized_content(self):
+        return self.localized("content")
 
 
 def delete_before_insert(column, null=[]):
@@ -55,7 +78,7 @@ def columns_repr(column_names):
     return __repr__
 
 
-class Dojos(db.Model):
+class Dojos(LocalizedMixin, db.Model):
     __tablename__ = "dojos"
 
     dojo_id = db.Column(db.Integer, primary_key=True)
@@ -73,7 +96,7 @@ class Dojos(db.Model):
     password = db.Column(db.String(128))
 
     data = db.Column(JSONB)
-    data_fields = ["type", "award", "course", "permissions", "pages", "privileged", "importable", "comparator", "show_scoreboard", "custom_js"]
+    data_fields = ["type", "award", "course", "permissions", "pages", "privileged", "importable", "comparator", "show_scoreboard", "custom_js", "translations", "languages"]
     data_defaults = {
         "permissions": [],
         "pages": [],
@@ -81,6 +104,8 @@ class Dojos(db.Model):
         "importable": True,
         "show_scoreboard": True,
         "custom_js": None,
+        "translations": {},
+        "languages": [],
     }
 
     users = db.relationship("DojoUsers", back_populates="dojo")
@@ -360,7 +385,7 @@ class DojoStudents(DojoUsers):
         return self.token in (self.dojo.course or {}).get("students", [])
 
 
-class DojoModules(db.Model):
+class DojoModules(LocalizedMixin, db.Model):
     __tablename__ = "dojo_modules"
     __table_args__ = (
         db.UniqueConstraint("dojo_id", "id"),
@@ -374,11 +399,12 @@ class DojoModules(db.Model):
     description = db.Column(db.Text)
 
     data = db.Column(JSONB)
-    data_fields = ["importable", "show_scoreboard", "show_challenges"]
+    data_fields = ["importable", "show_scoreboard", "show_challenges", "translations"]
     data_defaults = {
         "importable": True,
         "show_scoreboard": True,
         "show_challenges": True,
+        "translations": {},
     }
 
     dojo = db.relationship("Dojos", back_populates="_modules")
@@ -409,6 +435,8 @@ class DojoModules(db.Model):
         if default:
             for field in ["id", "name", "description"]:
                 kwargs[field] = kwargs[field] if kwargs.get(field) is not None else getattr(default, field, None)
+            if not kwargs["data"].get("translations"):
+                kwargs["data"]["translations"] = default.translations
 
         def set_module_import(challenge):
             challenge.data["module_import"] = True
@@ -547,7 +575,7 @@ class DojoModules(db.Model):
     __repr__ = columns_repr(["dojo", "id"])
 
 
-class DojoChallenges(db.Model):
+class DojoChallenges(LocalizedMixin, db.Model):
     __tablename__ = "dojo_challenges"
     item_type = "challenge"
     __table_args__ = (
@@ -569,7 +597,7 @@ class DojoChallenges(db.Model):
     required = db.Column(db.Boolean, default=True, nullable=False)
 
     data = db.Column(JSONB)
-    data_fields = ["image", "privileged", "path_override", "importable", "allow_privileged", "progression_locked", "survey", "unified_index", "interfaces"]
+    data_fields = ["image", "privileged", "path_override", "importable", "allow_privileged", "progression_locked", "survey", "unified_index", "interfaces", "translations"]
     data_defaults = {
         "privileged": False,
         "importable": True,
@@ -581,6 +609,7 @@ class DojoChallenges(db.Model):
             dict(name="Desktop",  port=6080),
             dict(name="SSH"),
         ],
+        "translations": {},
     }
 
     dojo = db.relationship("Dojos",
@@ -611,6 +640,8 @@ class DojoChallenges(db.Model):
                 kwargs[field] = kwargs[field] if kwargs.get(field) is not None else getattr(default, field, None)
 
             # TODO: maybe we should track the entire import
+            if not kwargs["data"].get("translations"):
+                kwargs["data"]["translations"] = default.translations
             kwargs["data"]["image"] = default.data.get("image")
             kwargs["data"]["path_override"] = str(default.path)
             # only update the unified_index for module and dojo imports, not challenge specific ones
@@ -748,7 +779,7 @@ class SurveyResponses(db.Model):
 
 
 
-class DojoResources(db.Model):
+class DojoResources(LocalizedMixin, db.Model):
     __tablename__ = "dojo_resources"
     item_type = "resource"
 
@@ -766,8 +797,8 @@ class DojoResources(db.Model):
     name = db.Column(db.String(128))
 
     data = db.Column(JSONB)
-    data_fields = ["content", "video", "playlist", "slides", "expandable"]
-    data_defaults = {"expandable": True}
+    data_fields = ["content", "video", "playlist", "slides", "expandable", "translations"]
+    data_defaults = {"expandable": True, "translations": {}}
 
     dojo = db.relationship("Dojos", back_populates="resources", viewonly=True)
     module = db.relationship("DojoModules", back_populates="_resources")
@@ -900,6 +931,17 @@ class SSHKeys(db.Model):
     user = db.relationship("Users")
 
     __repr__ = columns_repr(["user", "value"])
+
+
+class UserPreferences(db.Model):
+    __tablename__ = "dojo_user_preferences"
+
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
+    language = db.Column(db.String(16))
+
+    user = db.relationship("Users")
+
+    __repr__ = columns_repr(["user", "language"])
 
 
 class DiscordUserActivity(db.Model):

--- a/dojo_plugin/pages/dojo.py
+++ b/dojo_plugin/pages/dojo.py
@@ -17,6 +17,7 @@ from CTFd.utils.decorators import authed_only
 from CTFd.utils.user import get_current_user, is_admin
 from CTFd.utils.helpers import get_infos
 
+from ..i18n import DEFAULT_LANGUAGE, current_language
 from ..utils import get_current_container, get_all_containers, render_markdown
 from ..utils.background_stats import invalidate_dojo_cached_stats
 from ..utils.stats import get_container_stats, get_dojo_stats, get_challenge_solves
@@ -45,9 +46,12 @@ def get_dojo_branch(dojo):
 
     return "main"
 
-def find_description_edit_url(dojo, relative_paths, search_pattern=None, branch="main"):
+def find_description_edit_url(dojo, relative_paths, search_pattern=None, branch="main", language=None):
     if not (dojo.official and dojo.repository):
         return None
+
+    if language and language != DEFAULT_LANGUAGE:
+        relative_paths = [f"i18n/{language}/{path}" for path in relative_paths] + relative_paths
 
     for relative_path in relative_paths:
         full_path = dojo.path / relative_path
@@ -93,11 +97,12 @@ def listing(dojo):
     stats["active"] = sum(module_container_counts.values())
 
     description_edit_url = None
-    if dojo.description and dojo.path.exists():
+    if dojo.localized_description and dojo.path.exists():
         description_edit_url = find_description_edit_url(
             dojo, ["DESCRIPTION.md", "dojo.yml"],
             search_pattern=re.compile(r"^description:"),
-            branch=get_dojo_branch(dojo)
+            branch=get_dojo_branch(dojo),
+            language=current_language(),
         )
 
     return render_template(
@@ -155,14 +160,14 @@ def active_module():
         if not challenge:
             return {}
         return {
-            "module_name": challenge.module.name,
+            "module_name": challenge.module.localized_name,
             "module_id": challenge.module.id,
-            "dojo_name": challenge.dojo.name,
+            "dojo_name": challenge.dojo.localized_name,
             "dojo_reference_id": challenge.dojo.reference_id,
             "challenge_id": challenge.challenge_id,
-            "challenge_name": challenge.name,
+            "challenge_name": challenge.localized_name,
             "challenge_reference_id": challenge.id,
-            "description": render_markdown(challenge.description).strip() if challenge == current_challenge else None,
+            "description": render_markdown(challenge.localized_description).strip() if challenge == current_challenge else None,
         }
 
     return {
@@ -403,15 +408,17 @@ def view_module(dojo, module, scroll_to_challenge=None):
     if dojo.path.exists():
         branch = get_dojo_branch(dojo)
 
-        if module.description:
+        language = current_language()
+
+        if module.localized_description:
             module_description_edit_url = find_description_edit_url(dojo, [
                 f"{module.id}/DESCRIPTION.md",
                 f"{module.id}/module.yml",
                 "dojo.yml"
-            ], search_pattern=re.compile(r"^description:"), branch=branch)
+            ], search_pattern=re.compile(r"^description:"), branch=branch, language=language)
 
         for challenge in module.challenges:
-            if challenge.description:
+            if challenge.localized_description:
                 # Search for "- id: challenge_name" with optional quotes
                 challenge_description_edit_urls[challenge.id] = find_description_edit_url(
                     dojo, [
@@ -420,7 +427,7 @@ def view_module(dojo, module, scroll_to_challenge=None):
                         f"{module.id}/module.yml",
                         "dojo.yml"
                     ], search_pattern=re.compile(rf"^\s*-?\s*id:\s*[\"']?{re.escape(challenge.id)}[\"']?"),
-                    branch=branch
+                    branch=branch, language=language
                 )
 
         for resource in module.resources:
@@ -429,7 +436,7 @@ def view_module(dojo, module, scroll_to_challenge=None):
                 resource_description_edit_urls[resource.resource_index] = find_description_edit_url(
                     dojo, [f"{module.id}/module.yml", "dojo.yml"],
                     search_pattern=re.compile(rf"^\s*-?\s*name:\s*[\"']?{re.escape(resource.name)}[\"']?"),
-                    branch=branch
+                    branch=branch, language=language
                 )
 
     visible_challenges = set(module.visible_challenges())

--- a/dojo_plugin/pages/language.py
+++ b/dojo_plugin/pages/language.py
@@ -1,0 +1,38 @@
+from flask import Blueprint, redirect, request
+from CTFd.models import db
+from CTFd.utils.user import authed, get_current_user
+
+from ..i18n import LANGUAGE_COOKIE, LANGUAGE_COOKIE_MAX_AGE, selectable_language
+from ..models import UserPreferences
+
+language = Blueprint("pwncollege_language", __name__)
+
+
+def safe_next(target):
+    if not target or not target.startswith("/") or target.startswith("//") or target.startswith("/\\"):
+        return "/"
+    return target
+
+
+@language.route("/language", methods=["POST"])
+def set_language():
+    selected = selectable_language(request.form.get("language"))
+    target = safe_next(request.form.get("next"))
+    if not selected:
+        return redirect(target)
+
+    if authed():
+        user = get_current_user()
+        preferences = UserPreferences.query.filter_by(user_id=user.id).first()
+        if preferences:
+            preferences.language = selected
+        else:
+            db.session.add(UserPreferences(user_id=user.id, language=selected))
+        db.session.commit()
+
+    response = redirect(target)
+    response.set_cookie(LANGUAGE_COOKIE, selected,
+                        max_age=LANGUAGE_COOKIE_MAX_AGE,
+                        samesite="Lax",
+                        httponly=False)
+    return response

--- a/dojo_plugin/pages/language.py
+++ b/dojo_plugin/pages/language.py
@@ -1,9 +1,6 @@
 from flask import Blueprint, redirect, request
-from CTFd.models import db
-from CTFd.utils.user import authed, get_current_user
 
 from ..i18n import LANGUAGE_COOKIE, LANGUAGE_COOKIE_MAX_AGE, selectable_language
-from ..models import UserPreferences
 
 language = Blueprint("pwncollege_language", __name__)
 
@@ -20,15 +17,6 @@ def set_language():
     target = safe_next(request.form.get("next"))
     if not selected:
         return redirect(target)
-
-    if authed():
-        user = get_current_user()
-        preferences = UserPreferences.query.filter_by(user_id=user.id).first()
-        if preferences:
-            preferences.language = selected
-        else:
-            db.session.add(UserPreferences(user_id=user.id, language=selected))
-        db.session.commit()
 
     response = redirect(target)
     response.set_cookie(LANGUAGE_COOKIE, selected,

--- a/dojo_plugin/pages/language.py
+++ b/dojo_plugin/pages/language.py
@@ -34,5 +34,5 @@ def set_language():
     response.set_cookie(LANGUAGE_COOKIE, selected,
                         max_age=LANGUAGE_COOKIE_MAX_AGE,
                         samesite="Lax",
-                        httponly=False)
+                        secure=request.is_secure)
     return response

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -306,6 +306,11 @@ def load_dojo_subyamls(data, dojo_dir):
 
     return data
 
+def translations_kwarg(data):
+    translations = data.get("translations")
+    return {"translations": translations} if translations else {}
+
+
 def setdefault_translation(entry, language, field, value):
     if value is None:
         return
@@ -417,7 +422,8 @@ def load_dojo_translations(data, dojo_dir):
         languages.append(language)
         load_language_translations(data, language_dir, language)
 
-    data.setdefault("languages", languages)
+    if languages:
+        data.setdefault("languages", languages)
     return data
 
 
@@ -546,8 +552,13 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None, platform_admin=False):
         field: dojo_data.get(field, getattr(import_dojo, field, None))
         for field in ["id", "name", "description", "password", "type", "award"]
     }
-    dojo_kwargs["translations"] = dojo_data.get("translations") or getattr(import_dojo, "translations", None) or {}
-    dojo_kwargs["languages"] = dojo_data.get("languages") or getattr(import_dojo, "languages", None) or []
+    # only put i18n keys in `data` when there is something to store, so an untranslated
+    # dojo's row stays exactly as it was -- but an update that drops translations still
+    # has to clear whatever is already stored
+    for field, default in [("translations", {}), ("languages", [])]:
+        value = dojo_data.get(field) or getattr(import_dojo, field, None) or default
+        if value or (dojo is not None and (dojo.data or {}).get(field)):
+            dojo_kwargs[field] = value
 
     assert dojo_kwargs.get("id") is not None, "Dojo id must be defined"
 
@@ -641,11 +652,11 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None, platform_admin=False):
     dojo.modules = [
         DojoModules(
             **{kwarg: module_data.get(kwarg) for kwarg in ["id", "name", "description"]},
-            translations=module_data.get("translations") or {},
+            **translations_kwarg(module_data),
             challenges=[
                 DojoChallenges(
                     **{kwarg: challenge_data.get(kwarg) for kwarg in ["id", "name", "description"]},
-                    translations=challenge_data.get("translations") or {},
+                    **translations_kwarg(challenge_data),
                     image=shadow("image", dojo_data, module_data, challenge_data, default=None),
                     privileged=shadow("privileged", dojo_data, module_data, challenge_data, default_dict=DojoChallenges.data_defaults),
                     allow_privileged=shadow("allow_privileged", dojo_data, module_data, challenge_data, default_dict=DojoChallenges.data_defaults),
@@ -668,7 +679,7 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None, platform_admin=False):
             resources = [
                 DojoResources(
                     **{kwarg: resource_data.get(kwarg) for kwarg in ["name", "type", "content", "video", "playlist", "slides", "expandable"]},
-                    translations=resource_data.get("translations") or {},
+                    **translations_kwarg(resource_data),
                     visibility=visibility(DojoResourceVisibilities, dojo_data, module_data, resource_data),
                     resource_index=resource_index,
                 )

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from CTFd.models import db, Challenges, Flags
 from CTFd.utils.user import get_current_user, is_admin
 
-from ..models import DojoAdmins, Dojos, DojoModules, DojoChallenges, DojoResources, DojoChallengeVisibilities, DojoResourceVisibilities, DojoModuleVisibilities
+from ..models import DojoAdmins, Dojos, DojoModules, DojoChallenges, DojoResources, DojoChallengeVisibilities, DojoResourceVisibilities, DojoModuleVisibilities, merge_translations
 from ..config import DOJOS_DIR
 from ..i18n import LANGUAGE_PATTERN, normalize_language, ui_string_translations
 from ..utils import get_current_container, sanitize_survey
@@ -312,7 +312,8 @@ def translations_kwarg(data):
 
 
 def setdefault_translation(entry, language, field, value):
-    if value is None:
+    # an empty translation file is a stub, not an instruction to render nothing
+    if not value:
         return
     translations = entry.setdefault("translations", {})
     translations.setdefault(language, {}).setdefault(field, value)
@@ -552,11 +553,18 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None, platform_admin=False):
         field: dojo_data.get(field, getattr(import_dojo, field, None))
         for field in ["id", "name", "description", "password", "type", "award"]
     }
+    # merged per language and per field, the same as an imported module or challenge: a
+    # dojo that translates only its own name still inherits the source's translated
+    # description
+    i18n_kwargs = [
+        ("translations", merge_translations(dojo_data.get("translations"),
+                                            getattr(import_dojo, "translations", None))),
+        ("languages", dojo_data.get("languages") or getattr(import_dojo, "languages", None) or []),
+    ]
     # only put i18n keys in `data` when there is something to store, so an untranslated
     # dojo's row stays exactly as it was -- but an update that drops translations still
     # has to clear whatever is already stored
-    for field, default in [("translations", {}), ("languages", [])]:
-        value = dojo_data.get(field) or getattr(import_dojo, field, None) or default
+    for field, value in i18n_kwargs:
         if value or (dojo is not None and (dojo.data or {}).get(field)):
             dojo_kwargs[field] = value
 

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -25,6 +25,7 @@ from CTFd.utils.user import get_current_user, is_admin
 
 from ..models import DojoAdmins, Dojos, DojoModules, DojoChallenges, DojoResources, DojoChallengeVisibilities, DojoResourceVisibilities, DojoModuleVisibilities
 from ..config import DOJOS_DIR
+from ..i18n import LANGUAGE_PATTERN, normalize_language, ui_string_translations
 from ..utils import get_current_container, sanitize_survey
 
 
@@ -40,10 +41,23 @@ FILE_URL_REGEX = Regex(r"^https://www\.dropbox\.com/[a-zA-Z0-9]+/[a-zA-Z0-9]+/[a
 INTERFACES_LIST = [Or({"name": Regex(r"^[a-zA-Z][a-zA-Z0-9 _-]{0,31}$"),"port": int},{"name": "SSH"})]
 DATE = Use(datetime.datetime.fromisoformat)
 
+LANGUAGE_REGEX = Regex(LANGUAGE_PATTERN)
+
+TRANSLATABLE = {
+    Optional("name"): NAME_REGEX,
+    Optional("description"): str,
+    Optional("content"): str,
+}
+
+TRANSLATIONS = {
+    Optional("translations"): {LANGUAGE_REGEX: TRANSLATABLE},
+}
+
 ID_NAME_DESCRIPTION = {
     Optional("id"): ID_REGEX,
     Optional("name"): NAME_REGEX,
     Optional("description"): str,
+    **TRANSLATIONS,
 }
 
 VISIBILITY = {
@@ -56,6 +70,8 @@ VISIBILITY = {
 DOJO_SPEC = Schema({
     **ID_NAME_DESCRIPTION,
     **VISIBILITY,
+
+    Optional("languages"): [LANGUAGE_REGEX],
 
     Optional("password"): Regex(r"^[\S ]{8,128}$"),
 
@@ -118,6 +134,7 @@ DOJO_SPEC = Schema({
                 Optional("content"): str,
                 Optional("file"): FILE_PATH_REGEX,
                 Optional("expandable", default=True): bool,
+                **TRANSLATIONS,
                 **VISIBILITY,
             },
             {
@@ -126,11 +143,13 @@ DOJO_SPEC = Schema({
                 Optional("video"): str,
                 Optional("playlist"): str,
                 Optional("slides"): str,
+                **TRANSLATIONS,
                 **VISIBILITY,
             },
             {
                 "type": "header",
                 "content": str,
+                **TRANSLATIONS,
                 **VISIBILITY,
             },
             {
@@ -138,6 +157,7 @@ DOJO_SPEC = Schema({
                 "id": ID_REGEX,
                 "name": NAME_REGEX,
                 Optional("description"): str,
+                **TRANSLATIONS,
                 **VISIBILITY,
                 Optional("image"): IMAGE_REGEX,
                 Optional("privileged"): bool,
@@ -222,7 +242,8 @@ def expand_module_challenges(module_data, *, set_names=False):
     if challenges:
         module_data["resources"].append({
             "type": "header",
-            "content": "Challenges"
+            "content": "Challenges",
+            "translations": ui_string_translations("challenges_header"),
         })
 
         for challenge_data in challenges:
@@ -284,6 +305,116 @@ def load_dojo_subyamls(data, dojo_dir):
                     resource_data["name"] = resource_data.get("id", "Imported Challenge").replace("-", " ").title()
 
     return data
+
+def setdefault_translation(entry, language, field, value):
+    if value is None:
+        return
+    translations = entry.setdefault("translations", {})
+    translations.setdefault(language, {}).setdefault(field, value)
+
+
+def load_translation_yml(path):
+    if not path.exists():
+        return {}
+    loaded = yaml.safe_load(path.read_text()) or {}
+    assert isinstance(loaded, dict), f"Error: `{markupsafe.escape(path.name)}` must be a mapping"
+    return loaded
+
+
+def apply_translation(entry, language, translation, description_path=None):
+    for field in ("name", "description", "content"):
+        setdefault_translation(entry, language, field, translation.get(field))
+    if description_path is not None and description_path.exists():
+        setdefault_translation(entry, language, "description", description_path.read_text())
+
+
+def locate_translated_resource(resources, locator, source_path):
+    for key, source_value in [("id", lambda r: r.get("id")), ("source", lambda r: r.get("name"))]:
+        if key in locator:
+            matches = [r for r in resources if source_value(r) == locator[key]]
+            break
+    else:
+        key = "index"
+        assert key in locator, (
+            f"Error: a resource translation in `{markupsafe.escape(source_path)}` has no "
+            "`id`, `source`, or `index` locator"
+        )
+        matches = [resources[locator[key]]] if 0 <= locator[key] < len(resources) else []
+
+    assert matches, (
+        f"Error: `{markupsafe.escape(source_path)}` translates a resource with {key} "
+        f"`{markupsafe.escape(locator[key])}`, which does not exist"
+    )
+    return matches[0]
+
+
+def language_subdir(parent, name):
+    subdir = (parent / name).resolve()
+    assert parent.resolve() in subdir.parents, \
+        f"Error: `{markupsafe.escape(name)}` references a path outside of the dojo"
+    return subdir
+
+
+def load_language_translations(data, language_dir, language):
+    apply_translation(data, language,
+                      load_translation_yml(language_dir / "dojo.yml"),
+                      language_dir / "DESCRIPTION.md")
+
+    for module_data in data.get("modules", []):
+        if "id" not in module_data:
+            continue
+
+        module_language_dir = language_subdir(language_dir, module_data["id"])
+        module_translation = load_translation_yml(module_language_dir / "module.yml")
+        apply_translation(module_data, language, module_translation,
+                          module_language_dir / "DESCRIPTION.md")
+
+        resources = module_data.get("resources", [])
+        source_path = f"i18n/{language}/{module_data['id']}/module.yml"
+        for locator in module_translation.get("resources", []):
+            resource_data = locate_translated_resource(resources, locator, source_path)
+            apply_translation(resource_data, language, locator)
+
+        for resource_data in resources:
+            if resource_data.get("type") != "challenge" or "id" not in resource_data:
+                continue
+            challenge_language_dir = language_subdir(module_language_dir, resource_data["id"])
+            apply_translation(resource_data, language,
+                              load_translation_yml(challenge_language_dir / "challenge.yml"),
+                              challenge_language_dir / "DESCRIPTION.md")
+
+
+def load_dojo_translations(data, dojo_dir):
+    """
+    Translations live in a parallel tree mirroring the dojo's own structure:
+
+    repo-root/i18n/<lang>/dojo.yml <- translated dojo name
+    repo-root/i18n/<lang>/DESCRIPTION.md <- translated dojo description
+    repo-root/i18n/<lang>/module-id/module.yml <- translated module and resource names
+    repo-root/i18n/<lang>/module-id/DESCRIPTION.md <- translated module description
+    repo-root/i18n/<lang>/module-id/challenge-id/challenge.yml <- translated challenge name
+    repo-root/i18n/<lang>/module-id/challenge-id/DESCRIPTION.md <- translated challenge description
+
+    `translations` written directly into the dojo's own ymls wins over this tree, the same
+    way a `description` in dojo.yml wins over DESCRIPTION.md.
+    """
+
+    i18n_dir = dojo_dir / "i18n"
+    if not i18n_dir.is_dir():
+        return data
+
+    languages = []
+    for language_dir in sorted(i18n_dir.iterdir()):
+        if not language_dir.is_dir():
+            continue
+        language = normalize_language(language_dir.name)
+        assert language, f"Error: `i18n/{markupsafe.escape(language_dir.name)}` is not a valid language tag"
+        languages.append(language)
+        load_language_translations(data, language_dir, language)
+
+    data.setdefault("languages", languages)
+    return data
+
 
 def load_surveys(data, dojo_dir):
     """
@@ -353,6 +484,7 @@ def dojo_from_dir(dojo_dir, *, dojo=None, platform_admin=False):
 
     data_raw = yaml.safe_load(dojo_yml_path.read_text())
     data = load_dojo_subyamls(data_raw, dojo_dir)
+    data = load_dojo_translations(data, dojo_dir)
     data = load_surveys(data, dojo_dir)
     return dojo_from_spec(data, dojo_dir=dojo_dir, dojo=dojo, platform_admin=platform_admin)
 
@@ -409,6 +541,8 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None, platform_admin=False):
         field: dojo_data.get(field, getattr(import_dojo, field, None))
         for field in ["id", "name", "description", "password", "type", "award"]
     }
+    dojo_kwargs["translations"] = dojo_data.get("translations") or getattr(import_dojo, "translations", None) or {}
+    dojo_kwargs["languages"] = dojo_data.get("languages") or getattr(import_dojo, "languages", None) or []
 
     assert dojo_kwargs.get("id") is not None, "Dojo id must be defined"
 
@@ -502,9 +636,11 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None, platform_admin=False):
     dojo.modules = [
         DojoModules(
             **{kwarg: module_data.get(kwarg) for kwarg in ["id", "name", "description"]},
+            translations=module_data.get("translations") or {},
             challenges=[
                 DojoChallenges(
                     **{kwarg: challenge_data.get(kwarg) for kwarg in ["id", "name", "description"]},
+                    translations=challenge_data.get("translations") or {},
                     image=shadow("image", dojo_data, module_data, challenge_data, default=None),
                     privileged=shadow("privileged", dojo_data, module_data, challenge_data, default_dict=DojoChallenges.data_defaults),
                     allow_privileged=shadow("allow_privileged", dojo_data, module_data, challenge_data, default_dict=DojoChallenges.data_defaults),
@@ -527,6 +663,7 @@ def dojo_from_spec(data, *, dojo_dir=None, dojo=None, platform_admin=False):
             resources = [
                 DojoResources(
                     **{kwarg: resource_data.get(kwarg) for kwarg in ["name", "type", "content", "video", "playlist", "slides", "expandable"]},
+                    translations=resource_data.get("translations") or {},
                     visibility=visibility(DojoResourceVisibilities, dojo_data, module_data, resource_data),
                     resource_index=resource_index,
                 )

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -345,6 +345,11 @@ def locate_translated_resource(resources, locator, source_path):
         f"Error: `{markupsafe.escape(source_path)}` translates a resource with {key} "
         f"`{markupsafe.escape(locator[key])}`, which does not exist"
     )
+    assert len(matches) == 1, (
+        f"Error: `{markupsafe.escape(source_path)}` translates a resource with {key} "
+        f"`{markupsafe.escape(locator[key])}`, which matches {len(matches)} resources; "
+        "use `index` to say which one"
+    )
     return matches[0]
 
 

--- a/dojo_theme/static/css/custom.css
+++ b/dojo_theme/static/css/custom.css
@@ -1388,3 +1388,28 @@ code {
     margin-right: 2px;
     font-size: 0.65rem;
 }
+
+.language-switcher .dropdown-menu {
+    background-color: #272727;
+    border: 1px solid var(--brand-light-gray);
+    min-width: 8rem;
+}
+
+.language-switcher .dropdown-item {
+    background: none;
+    border: none;
+    width: 100%;
+    text-align: left;
+    color: var(--brand-gold);
+}
+
+.language-switcher .dropdown-item:hover,
+.language-switcher .dropdown-item:focus {
+    background-color: #151515;
+    color: var(--brand-gold);
+}
+
+.language-switcher .dropdown-item.active {
+    background-color: #151515;
+    font-weight: bold;
+}

--- a/dojo_theme/static/css/custom.css
+++ b/dojo_theme/static/css/custom.css
@@ -1389,6 +1389,12 @@ code {
     font-size: 0.65rem;
 }
 
+/* the label is a block span, so bootstrap's inline-block ::after caret would wrap
+   to its own line; the caret is an explicit icon inside the label instead */
+.language-switcher .dropdown-toggle::after {
+    display: none;
+}
+
 .language-switcher .dropdown-menu {
     background-color: #272727;
     border: 1px solid var(--brand-light-gray);

--- a/dojo_theme/templates/base.html
+++ b/dojo_theme/templates/base.html
@@ -2,7 +2,7 @@
 {% set module_id = module.id if module else None %}
 
 <!DOCTYPE html>
-<html>
+<html lang="{{ current_language }}">
   <head>
     <title>{{ Configs.ctf_name }}</title>
     <meta charset="utf-8">

--- a/dojo_theme/templates/components/actionbar.html
+++ b/dojo_theme/templates/components/actionbar.html
@@ -231,7 +231,7 @@
   <div title="Enter flag" class="workspace-control workspace-input">
     <i class="fas fa-flag workspace-highlight input-icon"></i>
     <input id="flag-input" type="text" placeholder="Flag">
-    <input type="hidden" id="current-challenge-id" value="{{ challenge.challenge_id }}" data-challenge-name="{{ challenge.name }}">
+    <input type="hidden" id="current-challenge-id" value="{{ challenge.challenge_id }}" data-challenge-name="{{ challenge.localized_name }}">
   </div>
   <div class="workspace-control-spacer"></div>
   <button id="challenge-restart" title="Restart challenge" class="workspace-control btn btn-md btn-outline-secondary btn-challenge-start">

--- a/dojo_theme/templates/components/navbar.html
+++ b/dojo_theme/templates/components/navbar.html
@@ -1,4 +1,6 @@
-{% from "macros/widgets.html" import navitem, language_switcher %}
+{# language_switcher reads context-processor variables (languages, current_language,
+   language_switch_next, Session), which an import does not carry by default #}
+{% from "macros/widgets.html" import navitem, language_switcher with context %}
 
 <nav class="navbar navbar-expand-md navbar-dark fixed-top">
   <div class="container">

--- a/dojo_theme/templates/components/navbar.html
+++ b/dojo_theme/templates/components/navbar.html
@@ -1,4 +1,4 @@
-{% from "macros/widgets.html" import navitem %}
+{% from "macros/widgets.html" import navitem, language_switcher %}
 
 <nav class="navbar navbar-expand-md navbar-dark fixed-top">
   <div class="container">
@@ -24,6 +24,7 @@
       </ul>
       <hr class="d-sm-flex d-md-flex d-lg-none">
       <ul class="navbar-nav ml-md-auto d-block d-sm-flex d-md-flex">
+        {{ language_switcher() }}
         {% if authed() %}
         {% if is_admin() %}
           {{ navitem("Admin Panel", url_for("admin.view"), "fa-wrench", shrink=True) }}

--- a/dojo_theme/templates/dojo.html
+++ b/dojo_theme/templates/dojo.html
@@ -4,13 +4,13 @@
 {% block content %}
 <div class="jumbotron">
   <div class="container">
-    <h1 class="brand-white brand-mono-bold">{{ dojo.name or dojo.id }}<span class="brand-dot">.</span></h1>
+    <h1 class="brand-white brand-mono-bold">{{ dojo.localized_name or dojo.id }}<span class="brand-dot">.</span></h1>
   </div>
 </div>
 <div class="container">
   {% include "components/errors.html" %}
 
-  {% if dojo.description %}
+  {% if dojo.localized_description %}
   <div>
     {% if description_edit_url %}
       <a href="{{ description_edit_url }}"
@@ -20,7 +20,7 @@
         <i class="fas fa-edit"></i>
       </a>
     {% endif %}
-    {{ dojo.description | markdown }}
+    {{ dojo.localized_description | markdown }}
   </div>
   <br>
   {% endif %}
@@ -72,7 +72,7 @@
     {% if module.visible() or dojo.is_admin(user) %}
       {{ card(
         url_for('pwncollege_dojo.view_dojo_path', dojo=dojo_id, path=module.id),
-	title=module.name or module.id,
+	title=module.localized_name or module.id,
         text_lines = [
           "{} Hacking".format(container_count) if container_count > 0 else "",
           "{} / {}".format(

--- a/dojo_theme/templates/hacker.html
+++ b/dojo_theme/templates/hacker.html
@@ -86,7 +86,7 @@
       {% set max_rank = dojo_scores.dojo_ranks[dojo.reference_id] | length %}
       {% set solves = dojo_scores.user_solves[user.id][dojo.reference_id] %}
       <a class="text-decoration-none" href="{{ url_for('pwncollege_dojo.listing', dojo=dojo.reference_id) }}">
-        <h2>{{ dojo.name }}</h2>
+        <h2>{{ dojo.localized_name }}</h2>
         <h4>
           <i class="fas fa-flag pt-3 pr-3" title="Solves"></i>
           <td>{{ solves }} / {{ dojo.required_challenges_count }}</td>
@@ -104,7 +104,7 @@
           {% set max_rank = module_scores.module_ranks[dojo.reference_id][module.module_index] | length %}
           {% call(header) accordion_item("modules-{}".format(dojo.hex_dojo_id), loop.index) %}
             {% if header %}
-              <h4 class="accordion-item-name">{{ module.name }}</h4>
+              <h4 class="accordion-item-name">{{ module.localized_name }}</h4>
               <span class="challenge-header-right">
                 <i class="fas fa-flag pr-1" title="Solves"></i>
                 <td>{{ solves }} / {{ module.challenges | selectattr("required") | list | length }}</td>
@@ -120,7 +120,7 @@
                       <div class="challenge-info">
                       <h4>
                         <span class="d-sm-block d-md-block d-lg-block">
-                          <i class="fas fa-flag pr-3 {{ solved }}"></i>{{ challenge.name or challenge.id }}
+                          <i class="fas fa-flag pr-3 {{ solved }}"></i>{{ challenge.localized_name or challenge.id }}
                           {% if not challenge.visible() %}
                           <small><small><small>
                                 <i>hidden</i> &mdash; you can see this because you are this dojo's administrator

--- a/dojo_theme/templates/macros/widgets.html
+++ b/dojo_theme/templates/macros/widgets.html
@@ -20,7 +20,12 @@
 </li>
 {% endmacro %}
 
+{# guarded because base.html -- and therefore every page, including error pages --
+   includes the navbar: if the context processor is ever missing (a deploy that
+   swapped templates under a still-running plugin, say), drop the switcher rather
+   than 500 the whole site #}
 {% macro language_switcher() %}
+{% if languages is defined and languages %}
 <li class="nav-item dropdown language-switcher">
   <a class="nav-link dropdown-toggle" href="#" id="language-switcher-toggle" role="button"
      data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -47,6 +52,7 @@
     </form>
   </div>
 </li>
+{% endif %}
 {% endmacro %}
 
 {% macro card(url, title=None, text_lines=None, icon=None, emoji=None, custom=False, solve_percent=0, course=False) -%}

--- a/dojo_theme/templates/macros/widgets.html
+++ b/dojo_theme/templates/macros/widgets.html
@@ -20,6 +20,34 @@
 </li>
 {% endmacro %}
 
+{% macro language_switcher() %}
+<li class="nav-item dropdown language-switcher">
+  <a class="nav-link dropdown-toggle" href="#" id="language-switcher-toggle" role="button"
+     data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <span class="d-block" data-toggle="tooltip" data-placement="bottom" title="Language">
+      <i class="fas fa-globe d-none d-md-block d-lg-none" style="width: 20px"></i>
+    </span>
+    <span class="d-sm-block d-md-none d-lg-block text-nowrap">
+      <i class="fas fa-globe pr-1"></i>
+      {{ languages.get(current_language, current_language) }}
+    </span>
+  </a>
+  <div class="dropdown-menu dropdown-menu-right" aria-labelledby="language-switcher-toggle">
+    <form method="POST" action="{{ url_for('pwncollege_language.set_language') }}">
+      <input type="hidden" name="nonce" value="{{ Session.nonce }}">
+      <input type="hidden" name="next" value="{{ language_switch_next }}">
+      {% for code, label in languages.items() %}
+      <button type="submit" name="language" value="{{ code }}"
+              class="dropdown-item{% if code == current_language %} active{% endif %}"
+              lang="{{ code }}">
+        {{ label }}
+      </button>
+      {% endfor %}
+    </form>
+  </div>
+</li>
+{% endmacro %}
+
 {% macro card(url, title=None, text_lines=None, icon=None, emoji=None, custom=False, solve_percent=0, course=False) -%}
   <a class="text-decoration-none" href="{{ url }}">
     <li class="card card-small">
@@ -81,7 +109,7 @@
       {% set solve_percent = (solves / dojo.required_challenges_count) * 100 if dojo.required_challenges_count else 0 %}
       {{ card(
         url_for("pwncollege_dojo.view_dojo", dojo=dojo.reference_id),
-        title=dojo.name or dojo.id,
+        title=dojo.localized_name or dojo.id,
         text_lines=[
           "{} Hacking".format(dojo_container_counts.get(dojo.reference_id, 0)) if dojo_container_counts.get(dojo.reference_id, 0) else "",
           "{} Module{}".format(dojo.modules_count, "" if dojo.modules_count == 1 else "s"),

--- a/dojo_theme/templates/macros/widgets.html
+++ b/dojo_theme/templates/macros/widgets.html
@@ -30,6 +30,7 @@
     <span class="d-sm-block d-md-none d-lg-block text-nowrap">
       <i class="fas fa-globe pr-1"></i>
       {{ languages.get(current_language, current_language) }}
+      <i class="fas fa-caret-down pl-1"></i>
     </span>
   </a>
   <div class="dropdown-menu dropdown-menu-right" aria-labelledby="language-switcher-toggle">

--- a/dojo_theme/templates/markdown.html
+++ b/dojo_theme/templates/markdown.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="jumbotron">
   <div class="container">
-    <h1>{{ dojo.name or dojo.id }}</h1>
+    <h1>{{ dojo.localized_name or dojo.id }}</h1>
   </div>
 </div>
 <div class="container">

--- a/dojo_theme/templates/module.html
+++ b/dojo_theme/templates/module.html
@@ -40,9 +40,9 @@
 {% block content %}
 <div class="jumbotron">
   <div class="container">
-    <h1 class="brand-white brand-mono-bold">{{ module.name or module.id }}</h1>
+    <h1 class="brand-white brand-mono-bold">{{ module.localized_name or module.id }}</h1>
     <br>
-    <h2 class="module-dojo"><a class="brand-white brand-mono-bold" href="{{ url_for('pwncollege_dojo.view_dojo', dojo=dojo.reference_id) }}">{{ dojo.name or dojo.id }}<span class="brand-dot">.</span></a></h2>
+    <h2 class="module-dojo"><a class="brand-white brand-mono-bold" href="{{ url_for('pwncollege_dojo.view_dojo', dojo=dojo.reference_id) }}">{{ dojo.localized_name or dojo.id }}<span class="brand-dot">.</span></a></h2>
 
     {% if assessments %}
     <br>
@@ -54,7 +54,7 @@
 </div>
 <div class="container">
 
-  {% if module.description %}
+  {% if module.localized_description %}
   <div>
     {% if module_description_edit_url %}
       <a href="{{ module_description_edit_url }}"
@@ -64,7 +64,7 @@
         <i class="fas fa-edit"></i>
       </a>
     {% endif %}
-    {{ module.description | markdown }}
+    {{ module.localized_description | markdown }}
   </div>
   <br>
   {% endif %}
@@ -83,18 +83,18 @@
         {% set resource = item %}
         {% if resource.type == 'markdown' and resource.expandable == False %}
           <div class="description-content my-3">
-            {{ resource.content | markdown }}
+            {{ resource.localized_content | markdown }}
           </div>
         {% elif resource.type == 'header' %}
           <br>
-          <h2>{{ resource.content }}</h2>
+          <h2>{{ resource.localized_content }}</h2>
         {% else %}
         {% call(header) accordion_item("module-content", loop.index) %}
           {% if header %}
             {% set resource_icon = "fa-video" if resource.type == "lecture" else "fa-file-alt" %}
             <h4 class="accordion-item-name">
               <i class="resource-icon pr-3 fas {{ resource_icon }}"></i>
-              <span class="pr-2">{{ resource.name }}</span>
+              <span class="pr-2">{{ resource.localized_name }}</span>
             </h4>
           {% else %}
             {% if resource.type == "lecture" %}
@@ -122,7 +122,7 @@
                   <i class="fas fa-edit"></i>
                 </a>
               {% endif %}
-              {{ resource.content | markdown }}
+              {{ resource.localized_content | markdown }}
             </div>
             {% endif %}
           {% endif %}
@@ -151,16 +151,16 @@
 
         {% call(header) accordion_item("module-content", loop.index, lock_challenge, challenge_index=ns.challenge_count) %}
           {% if header %}
-            <h4 class="accordion-item-name challenge-name {{ active }}" data-challenge-index="{{ ns.challenge_count }}" data-challenge-id="{{ challenge.id }}" data-challenge-name="{{ challenge.name or challenge.id }}" id="challenges-header-{{ ns.challenge_count }}">
+            <h4 class="accordion-item-name challenge-name {{ active }}" data-challenge-index="{{ ns.challenge_count }}" data-challenge-id="{{ challenge.id }}" data-challenge-name="{{ challenge.localized_name or challenge.id }}" id="challenges-header-{{ ns.challenge_count }}">
                 <i class="challenge-icon pr-3 {{ icon }} {{ solved }} "></i>
                 {% if lock_challenge %}
                 <div class="challenge-text-wrapper">
-                  <span class="challenge-name-text">{{ challenge.name or challenge.id }}</span>
-                  <span class="challenge-locked-text">Solve <strong></string><span style="color: white">{{ previous_challenge.name or previous_challenge.id }}</span></strong> to unlock this challenge</span>
-                  <span class="invisible-placeholder pr-2">{{ challenge.name or challenge.id }}</span>
+                  <span class="challenge-name-text">{{ challenge.localized_name or challenge.id }}</span>
+                  <span class="challenge-locked-text">Solve <strong></string><span style="color: white">{{ previous_challenge.localized_name or previous_challenge.id }}</span></strong> to unlock this challenge</span>
+                  <span class="invisible-placeholder pr-2">{{ challenge.localized_name or challenge.id }}</span>
                 </div>
                 {% else %}
-                <span class="pr-2">{{ challenge.name or challenge.id }}</span>
+                <span class="pr-2">{{ challenge.localized_name or challenge.id }}</span>
                 {% endif %}
                 {% if is_dojo_admin and (progression_locked or hidden) %}
                 <small><small><small>
@@ -197,7 +197,7 @@
                     <i class="fas fa-edit"></i>
                   </a>
                 {% endif %}
-                {{ challenge.description | markdown }}
+                {{ challenge.localized_description | markdown }}
               {% endif %}
             </div>
             <div class="challenge-init row{% if active %} challenge-hidden{% endif %}">

--- a/dojo_theme/templates/workspace.html
+++ b/dojo_theme/templates/workspace.html
@@ -69,7 +69,7 @@
     Link your <a href="/settings#ssh-key" target="_blank">SSH key</a>, then connect with: <code>ssh hacker@dojo.pwn.college</code>
   </div>
   <div class="workspace-description" style="display: none;">
-    {{ challenge.description | markdown }}
+    {{ challenge.localized_description | markdown }}
   </div>
   {% include "components/actionbar.html" %}
 </div>

--- a/test/dojos/i18n_dojo.yml
+++ b/test/dojos/i18n_dojo.yml
@@ -1,0 +1,51 @@
+id: i18n-test
+name: I18n Test Dojo
+description: An English dojo description, marker DOJODESC_EN.
+translations:
+  ko:
+    name: 국제화 시험 도장
+    description: 한국어 도장 설명, 표식 DOJODESC_KO.
+
+modules:
+  - id: translated
+    name: Translated Module
+    description: An English module description, marker MODDESC_EN.
+    translations:
+      ko:
+        name: 번역된 모듈
+        description: 한국어 모듈 설명, 표식 MODDESC_KO.
+    resources:
+      - type: markdown
+        name: English Resource Name
+        content: |
+          English resource content, marker RESOURCE_EN.
+        translations:
+          ko:
+            name: 한국어 자료 이름
+            content: |
+              한국어 자료 내용, 표식 RESOURCE_KO.
+      - type: header
+        content: English Header
+        translations:
+          ko:
+            content: 한국어 헤더
+      - type: challenge
+        id: translated
+        name: Translated Challenge
+        description: An English challenge description, marker CHALDESC_EN.
+        translations:
+          ko:
+            name: 번역된 챌린지
+            description: 한국어 챌린지 설명, 표식 CHALDESC_KO.
+        import:
+          dojo: example
+          module: hello
+          challenge: apple
+      - type: challenge
+        id: untranslated
+        name: Untranslated Challenge
+        description: An untranslated challenge description, marker UNTRANSLATED_EN.
+        import:
+          dojo: example
+          module: hello
+          challenge: banana

--- a/test/dojos/i18n_dojo.yml
+++ b/test/dojos/i18n_dojo.yml
@@ -1,5 +1,6 @@
 id: i18n-test
 name: I18n Test Dojo
+type: public
 description: An English dojo description, marker DOJODESC_EN.
 translations:
   ko:

--- a/test/dojos/i18n_dojo_import.yml
+++ b/test/dojos/i18n_dojo_import.yml
@@ -1,0 +1,9 @@
+id: i18n-dojo-import-test
+name: I18n Dojo Import Test
+
+translations:
+  ko:
+    name: 국제화 도장 가져오기 시험
+
+import:
+  dojo: i18n-test

--- a/test/dojos/i18n_import_dojo.yml
+++ b/test/dojos/i18n_import_dojo.yml
@@ -1,0 +1,25 @@
+id: i18n-import-test
+name: I18n Import Test Dojo
+
+modules:
+  - id: reimporting
+    name: Reimporting Module
+    description: An English module description, marker REIMPORT_EN.
+    resources:
+      - type: challenge
+        id: inherited
+        name: Inherited Challenge
+        import:
+          dojo: i18n-test
+          module: translated
+          challenge: translated
+      - type: challenge
+        id: renamed
+        name: Renamed Challenge
+        translations:
+          ko:
+            name: 이름을 바꾼 챌린지
+        import:
+          dojo: i18n-test
+          module: translated
+          challenge: translated

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -19,6 +19,11 @@ def i18n_import_dojo(admin_session, i18n_dojo):
     return create_dojo_yml(open(TEST_DOJOS_LOCATION / "i18n_import_dojo.yml").read(), session=admin_session)
 
 
+@pytest.fixture(scope="session")
+def i18n_dojo_import(admin_session, i18n_import_dojo):
+    return create_dojo_yml(open(TEST_DOJOS_LOCATION / "i18n_dojo_import.yml").read(), session=admin_session)
+
+
 def module_page(session, dojo, language=None):
     params = {"lang": language} if language else {}
     response = session.get(f"{DOJO_URL}/{dojo}/translated/", params=params)
@@ -185,6 +190,14 @@ def test_local_translation_does_not_discard_inherited_fields(i18n_import_dojo, a
     assert korean.count("CHALDESC_KO") == 2, (
         "translating only the name must not discard the inherited translated description")
     assert "CHALDESC_EN" not in korean
+
+
+def test_dojo_level_import_merges_translations_per_field(i18n_dojo_import, admin_session):
+    korean = admin_session.get(f"{DOJO_URL}/{i18n_dojo_import}/", params={"lang": "ko"}).text
+    assert "국제화 도장 가져오기 시험" in korean, "a local translated name should win over the inherited one"
+    assert "DOJODESC_KO" in korean, (
+        "translating only the dojo name must not discard the inherited translated description")
+    assert "DOJODESC_EN" not in korean
 
 
 def main_content(text):

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -107,7 +107,7 @@ def test_switcher_rejects_offsite_next(i18n_dojo):
         assert response.headers["Location"].endswith("/"), f"redirected off-site for {target}"
 
 
-def test_preference_persists_across_sessions(i18n_dojo):
+def test_language_is_per_session_not_per_account(i18n_dojo):
     name = "".join(random.choices(string.ascii_lowercase, k=16))
     session = login(name, name, register=True)
     switch_language(session, "ko")
@@ -115,7 +115,16 @@ def test_preference_persists_across_sessions(i18n_dojo):
 
     fresh = login(name, name)
     assert fresh.cookies.get("dojo_language") is None
-    assert "MODDESC_KO" in module_page(fresh, i18n_dojo)
+    assert "MODDESC_EN" in module_page(fresh, i18n_dojo)
+
+
+def test_accept_language_header_is_honored(i18n_dojo):
+    session = requests.Session()
+    session.headers["Accept-Language"] = "ko-KR,ko;q=0.9,en;q=0.8"
+    assert "MODDESC_KO" in module_page(session, i18n_dojo)
+
+    session.headers["Accept-Language"] = "fr-FR,fr;q=0.9"
+    assert "MODDESC_EN" in module_page(session, i18n_dojo)
 
 
 def test_api_returns_localized_content(i18n_dojo, admin_session):

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -4,12 +4,19 @@ import string
 import pytest
 import requests
 
-from utils import DOJO_URL, TEST_DOJOS_LOCATION, create_dojo_yml, login, parse_csrf_token
+from utils import (DOJO_URL, TEST_DOJOS_LOCATION, create_dojo_yml, login,
+                   make_dojo_official, parse_csrf_token)
 
 
 @pytest.fixture(scope="session")
 def i18n_dojo(admin_session, example_dojo):
     return create_dojo_yml(open(TEST_DOJOS_LOCATION / "i18n_dojo.yml").read(), session=admin_session)
+
+
+@pytest.fixture(scope="session")
+def i18n_import_dojo(admin_session, i18n_dojo):
+    make_dojo_official(i18n_dojo, admin_session)
+    return create_dojo_yml(open(TEST_DOJOS_LOCATION / "i18n_import_dojo.yml").read(), session=admin_session)
 
 
 def module_page(session, dojo, language=None):
@@ -134,6 +141,22 @@ def test_search_matches_translations(i18n_dojo, admin_session):
 
     results = admin_session.get(url, params={"q": "MODDESC_KO", "lang": "en"}).json()["results"]
     assert not results["modules"], "English search should not match Korean translations"
+
+
+def test_import_inherits_translations(i18n_import_dojo, admin_session):
+    korean = admin_session.get(f"{DOJO_URL}/{i18n_import_dojo}/reimporting/",
+                               params={"lang": "ko"}).text
+    assert "번역된 챌린지" in korean, "an import with no local translation should inherit the source's"
+    assert "CHALDESC_KO" in korean, "an import should inherit the source's translated description"
+
+
+def test_local_translation_does_not_discard_inherited_fields(i18n_import_dojo, admin_session):
+    korean = admin_session.get(f"{DOJO_URL}/{i18n_import_dojo}/reimporting/",
+                               params={"lang": "ko"}).text
+    assert "이름을 바꾼 챌린지" in korean, "a local translated name should win over the inherited one"
+    assert korean.count("CHALDESC_KO") == 2, (
+        "translating only the name must not discard the inherited translated description")
+    assert "CHALDESC_EN" not in korean
 
 
 def main_content(text):

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -75,8 +75,18 @@ def test_language_switcher_rendered(i18n_dojo):
     anonymous = requests.Session()
     page = anonymous.get(f"{DOJO_URL}/").text
     assert 'class="nav-item dropdown language-switcher"' in page
-    assert 'value="ko"' in page
-    assert "한국어" in page
+    for code, label in [("en", "English"), ("ko", "한국어"), ("zh-CN", "简体中文"),
+                        ("zh-TW", "繁體中文"), ("it", "Italiano")]:
+        assert f'value="{code}"' in page, f"switcher is missing {code}"
+        assert label in page, f"switcher is missing the label for {code}"
+
+
+def test_browser_language_variants_resolve_to_an_offered_language(i18n_dojo, admin_session):
+    for tag, expected in [("zh-Hans-CN", "zh-CN"), ("zh", "zh-CN"), ("zh-SG", "zh-CN"),
+                          ("zh-Hant-TW", "zh-TW"), ("zh-HK", "zh-TW"),
+                          ("it-CH", "it"), ("ko-KR", "ko"), ("fr", "en")]:
+        page = admin_session.get(f"{DOJO_URL}/{i18n_dojo}/", params={"lang": tag}).text
+        assert f'<html lang="{expected}">' in page, f"{tag} did not resolve to {expected}"
 
 
 def test_switcher_sets_cookie_and_sticks(i18n_dojo, admin_session):

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -1,0 +1,146 @@
+import random
+import string
+
+import pytest
+import requests
+
+from utils import DOJO_URL, TEST_DOJOS_LOCATION, create_dojo_yml, login, parse_csrf_token
+
+
+@pytest.fixture(scope="session")
+def i18n_dojo(admin_session, example_dojo):
+    return create_dojo_yml(open(TEST_DOJOS_LOCATION / "i18n_dojo.yml").read(), session=admin_session)
+
+
+def module_page(session, dojo, language=None):
+    params = {"lang": language} if language else {}
+    response = session.get(f"{DOJO_URL}/{dojo}/translated/", params=params)
+    assert response.status_code == 200
+    return response.text
+
+
+def switch_language(session, language, next_url="/"):
+    nonce = parse_csrf_token(session.get(f"{DOJO_URL}/").text)
+    return session.post(f"{DOJO_URL}/language",
+                        data={"language": language, "next": next_url, "nonce": nonce},
+                        allow_redirects=False)
+
+
+def test_dojo_page_uses_query_language(i18n_dojo, admin_session):
+    korean = admin_session.get(f"{DOJO_URL}/{i18n_dojo}/", params={"lang": "ko"}).text
+    assert "국제화 시험 도장" in korean
+    assert "DOJODESC_KO" in korean
+    assert "DOJODESC_EN" not in korean
+
+    english = admin_session.get(f"{DOJO_URL}/{i18n_dojo}/", params={"lang": "en"}).text
+    assert "I18n Test Dojo" in english
+    assert "DOJODESC_EN" in english
+    assert "DOJODESC_KO" not in english
+
+
+def test_module_page_translates_every_level(i18n_dojo, admin_session):
+    korean = module_page(admin_session, i18n_dojo, "ko")
+    for expected in ["번역된 모듈", "MODDESC_KO", "한국어 자료 이름", "RESOURCE_KO",
+                     "한국어 헤더", "번역된 챌린지", "CHALDESC_KO"]:
+        assert expected in korean, f"missing translation: {expected}"
+    for unexpected in ["MODDESC_EN", "RESOURCE_EN", "CHALDESC_EN", "English Header"]:
+        assert unexpected not in korean, f"untranslated leftover: {unexpected}"
+
+
+def test_untranslated_content_falls_back(i18n_dojo, admin_session):
+    korean = module_page(admin_session, i18n_dojo, "ko")
+    assert "Untranslated Challenge" in korean
+    assert "UNTRANSLATED_EN" in korean
+
+
+def test_unsupported_language_falls_back_to_source(i18n_dojo, admin_session):
+    page = module_page(admin_session, i18n_dojo, "xx")
+    assert "MODDESC_EN" in page
+    assert "MODDESC_KO" not in page
+
+
+def test_html_lang_attribute(i18n_dojo, admin_session):
+    assert '<html lang="ko">' in module_page(admin_session, i18n_dojo, "ko")
+    assert '<html lang="en">' in module_page(admin_session, i18n_dojo, "en")
+
+
+def test_language_switcher_rendered(i18n_dojo):
+    anonymous = requests.Session()
+    page = anonymous.get(f"{DOJO_URL}/").text
+    assert 'class="nav-item dropdown language-switcher"' in page
+    assert 'value="ko"' in page
+    assert "한국어" in page
+
+
+def test_switcher_sets_cookie_and_sticks(i18n_dojo, admin_session):
+    session = requests.Session()
+    response = switch_language(session, "ko", f"/{i18n_dojo}/translated/")
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(f"/{i18n_dojo}/translated/")
+    assert session.cookies.get("dojo_language") == "ko"
+
+    assert "MODDESC_KO" in module_page(session, i18n_dojo)
+
+    switch_language(session, "en")
+    assert "MODDESC_EN" in module_page(session, i18n_dojo)
+
+
+def test_switcher_ignores_unsupported_language(i18n_dojo):
+    session = requests.Session()
+    response = switch_language(session, "xx")
+    assert response.status_code == 302
+    assert session.cookies.get("dojo_language") is None
+
+
+def test_switcher_rejects_offsite_next(i18n_dojo):
+    session = requests.Session()
+    for target in ["https://example.com/evil", "//example.com/evil", "/\\example.com"]:
+        response = switch_language(session, "ko", target)
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("/"), f"redirected off-site for {target}"
+
+
+def test_preference_persists_across_sessions(i18n_dojo):
+    name = "".join(random.choices(string.ascii_lowercase, k=16))
+    session = login(name, name, register=True)
+    switch_language(session, "ko")
+    assert "MODDESC_KO" in module_page(session, i18n_dojo)
+
+    fresh = login(name, name)
+    assert fresh.cookies.get("dojo_language") is None
+    assert "MODDESC_KO" in module_page(fresh, i18n_dojo)
+
+
+def test_api_returns_localized_content(i18n_dojo, admin_session):
+    url = f"{DOJO_URL}/pwncollege_api/v1/dojos/{i18n_dojo}/modules"
+
+    modules = admin_session.get(url, params={"lang": "ko"}).json()["modules"]
+    module = next(m for m in modules if m["id"] == "translated")
+    assert module["name"] == "번역된 모듈"
+    assert "MODDESC_KO" in module["description"]
+    assert any("CHALDESC_KO" in (c["description"] or "") for c in module["challenges"])
+
+    modules = admin_session.get(url, params={"lang": "en"}).json()["modules"]
+    module = next(m for m in modules if m["id"] == "translated")
+    assert module["name"] == "Translated Module"
+    assert "MODDESC_EN" in module["description"]
+
+
+def test_search_matches_translations(i18n_dojo, admin_session):
+    url = f"{DOJO_URL}/pwncollege_api/v1/search"
+
+    results = admin_session.get(url, params={"q": "MODDESC_KO", "lang": "ko"}).json()["results"]
+    assert any(m["name"] == "번역된 모듈" for m in results["modules"])
+
+    results = admin_session.get(url, params={"q": "MODDESC_KO", "lang": "en"}).json()["results"]
+    assert not results["modules"], "English search should not match Korean translations"
+
+
+def main_content(text):
+    return text.split('<main role="main">', 1)[1].split("</main>", 1)[0]
+
+
+def test_untranslated_dojo_is_unaffected(example_dojo, admin_session):
+    english = admin_session.get(f"{DOJO_URL}/{example_dojo}/", params={"lang": "en"}).text
+    korean = admin_session.get(f"{DOJO_URL}/{example_dojo}/", params={"lang": "ko"}).text
+    assert main_content(english) == main_content(korean)

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -89,6 +89,15 @@ def test_browser_language_variants_resolve_to_an_offered_language(i18n_dojo, adm
         assert f'<html lang="{expected}">' in page, f"{tag} did not resolve to {expected}"
 
 
+def test_switcher_next_does_not_reflect_the_query_string(i18n_dojo, admin_session):
+    probed = admin_session.get(f"{DOJO_URL}/{i18n_dojo}/",
+                               params={"lang": "ko", "probe": "PROBEVALUE"}).text
+    assert 'class="nav-item dropdown language-switcher"' in probed, "the switcher must be on the page"
+    assert "PROBEVALUE" not in probed, (
+        "the switcher's next field renders in every page's navbar, error pages included, so "
+        "echoing the query string makes two error responses differ by the caller's own input")
+
+
 def test_switcher_sets_cookie_and_sticks(i18n_dojo, admin_session):
     session = requests.Session()
     response = switch_language(session, "ko", f"/{i18n_dojo}/translated/")

--- a/test/tiers.py
+++ b/test/tiers.py
@@ -17,6 +17,7 @@ TEST_FILE_TIERS = {
     "test_feed_search.py": "semantic",
     "test_hidden_profile.py": "semantic",
     "test_homefs_semantics.py": "semantic",
+    "test_i18n.py": "semantic",
     "test_integrations.py": "semantic",
     "test_middleware.py": "integration",
     "test_module_resources.py": "semantic",


### PR DESCRIPTION
This PR adds internationalization (multi-language) support to dojo, module, and challenge descriptions. All descriptions in another language are stored along side the dojo in `i18n/<la>/dojo/module/challenges` where `<la>` is a two-letter language code, e.g., `ko` for Korean.

This PR does not alter the schema of the database.