### PR TITLE
Workspace: build ttyd without client support

### DIFF
--- a/workspace/services/terminal.nix
+++ b/workspace/services/terminal.nix
@@ -3,6 +3,15 @@
 let
   service = import ./service.nix { inherit pkgs; };
 
+  libwebsockets' = pkgs.libwebsockets.overrideAttrs (previousAttrs: {
+    cmakeFlags = previousAttrs.cmakeFlags ++ [
+      (pkgs.lib.cmakeBool "LWS_WITH_SOCKS5" false)
+      (pkgs.lib.cmakeBool "LWS_WITHOUT_CLIENT" true)
+    ];
+  });
+
+  ttyd = pkgs.ttyd.override { libwebsockets = libwebsockets'; };
+
   serviceScript = pkgs.writeScript "dojo-terminal" ''
     #!${pkgs.bash}/bin/bash
 
@@ -11,7 +20,7 @@ let
     export TERM=xterm-256color
     
     ${service}/bin/dojo-service start terminal-service/ttyd \
-      ${pkgs.ttyd}/bin/ttyd \
+      ${ttyd}/bin/ttyd \
         --port 7681 \
         --interface 0.0.0.0 \
         --writable \
@@ -23,10 +32,10 @@ let
 
 in pkgs.stdenv.mkDerivation {
   name = "terminal-service";
-  buildInputs = with pkgs; [
+  buildInputs = [
     ttyd
-    bashInteractive
-    curl
+    pkgs.bashInteractive
+    pkgs.curl
   ];
   dontUnpack = true;
 
@@ -36,8 +45,8 @@ in pkgs.stdenv.mkDerivation {
     mkdir -p $out/bin
     cp ${serviceScript} $out/bin/dojo-terminal
     chmod +x $out/bin/dojo-terminal
-    ln -s ${pkgs.ttyd}/bin/ttyd $out/bin/ttyd
-    ln -s ${pkgs.ttyd}/bin/ttyd $out/bin/terminal
+    ln -s ${ttyd}/bin/ttyd $out/bin/ttyd
+    ln -s ${ttyd}/bin/ttyd $out/bin/terminal
 
     runHook postInstall
   '';

--- a/workspace/services/terminal.nix
+++ b/workspace/services/terminal.nix
@@ -3,18 +3,16 @@
 let
   service = import ./service.nix { inherit pkgs; };
 
-  libwebsockets' = pkgs.libwebsockets.overrideAttrs (previousAttrs: {
-    cmakeFlags = previousAttrs.cmakeFlags ++ [
-      (pkgs.lib.cmakeBool "LWS_WITH_SOCKS5" false)
-      (pkgs.lib.cmakeBool "LWS_WITHOUT_CLIENT" true)
-    ];
-  });
+  ttyd = pkgs.ttyd.override {
+    libwebsockets = pkgs.libwebsockets.overrideAttrs (previousAttrs: {
+      cmakeFlags = previousAttrs.cmakeFlags ++ [
+        (pkgs.lib.cmakeBool "LWS_WITH_SOCKS5" false)
+        (pkgs.lib.cmakeBool "LWS_WITHOUT_CLIENT" true)
+      ];
+    });
+  };
 
-  ttyd = pkgs.ttyd.override { libwebsockets = libwebsockets'; };
-
-  serviceScript = pkgs.writeScript "dojo-terminal" ''
-    #!${pkgs.bash}/bin/bash
-
+  serviceScript = pkgs.writeShellScript "dojo-terminal" ''
     until [ -f /run/dojo/var/ready ]; do sleep 0.1; done
 
     export TERM=xterm-256color
@@ -30,24 +28,9 @@ let
     until ${pkgs.curl}/bin/curl -fs localhost:7681 >/dev/null; do sleep 0.1; done
   '';
 
-in pkgs.stdenv.mkDerivation {
-  name = "terminal-service";
-  buildInputs = [
-    ttyd
-    pkgs.bashInteractive
-    pkgs.curl
-  ];
-  dontUnpack = true;
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/bin
-    cp ${serviceScript} $out/bin/dojo-terminal
-    chmod +x $out/bin/dojo-terminal
-    ln -s ${ttyd}/bin/ttyd $out/bin/ttyd
-    ln -s ${ttyd}/bin/ttyd $out/bin/terminal
-
-    runHook postInstall
-  '';
-}
+in
+pkgs.runCommand "terminal-service" { } ''
+  install -Dm755 ${serviceScript} $out/bin/dojo-terminal
+  ln -s ${ttyd}/bin/ttyd $out/bin/ttyd
+  ln -s ttyd $out/bin/terminal
+''


### PR DESCRIPTION
## Summary

- build the terminal service's `ttyd` against a private, server-only `libwebsockets`
- disable SOCKS5 explicitly because the general Nixpkgs `libwebsockets` package enables it
- keep the override local to the terminal service so other workspace packages are unchanged

`ttyd` only uses libwebsockets' server APIs, and its upstream release build also sets
`LWS_WITHOUT_CLIENT=ON`:
https://github.com/tsl0922/ttyd/blob/1.7.7/scripts/cross-build.sh#L90-L114

Besides avoiding unused client functionality, this prevents Secure Streams' automatic
captive-portal check from blocking ttyd's event loop when DNS is unavailable.

## Testing

- `nix build --no-link .#core` from `workspace/`
- verified the resulting libwebsockets feature list contains `SRV` but not `CLI` or Secure Streams
- ran the resulting ttyd with DNS deliberately blackholed; HTTP readiness was 6 ms and no captive-portal lookup was attempted
- repeated the workspace build from cache; it completed in 2.8 seconds
