### PR TITLE
Workspace: Add clangd to code-server

### DIFF
--- a/workspace/services/code.nix
+++ b/workspace/services/code.nix
@@ -39,7 +39,14 @@ let
     substituteInPlace $out/bin/code-server \
       --replace-fail ${pkgs.code-server} $out
   '';
+  clangdExtension = pkgs.vscode-extensions.llvm-vs-code-extensions.vscode-clangd.overrideAttrs (oldAttrs: {
+    postPatch = (oldAttrs.postPatch or "") + ''
+      substituteInPlace package.json \
+        --replace-fail '"default": "clangd"' '"default": "${pkgs.clang-tools}/bin/clangd"'
+    '';
+  });
   codeExtensions = with pkgs.vscode-extensions; [
+    clangdExtension
     ms-python.python
     vadimcn.vscode-lldb
   ];


### PR DESCRIPTION
## Summary

- bundle the official clangd VS Code extension with code-server
- point the extension at the pinned Nix `clangd`, so it works in core workspaces and minimal challenge images without a user-managed install
- keep the `clang` compiler out of the core workspace PATH

## Validation

- `nix flake check --no-build --no-update-lock-file`
- `nix build .#core --no-link --no-update-lock-file --print-build-logs`
- verified `code --list-extensions --show-versions` includes `llvm-vs-code-extensions.vscode-clangd@0.4.0`
- launched code-server in headless Chromium, opened a C++ file, and verified the extension activated `clangd 21.1.8`, built the AST, and published diagnostics
- exercised clangd directly over LSP and verified C++ diagnostics and symbol completion

The core closure grows from approximately 4.7 GiB to 4.9 GiB.
