### PR TITLE
Improve code-server workspace setup

### DIFF
--- a/workspace/services/code.nix
+++ b/workspace/services/code.nix
@@ -2,6 +2,7 @@
 
 let
   service = import ./service.nix { inherit pkgs; };
+
   code-server-libc =
     if pkgs.stdenv.hostPlatform.isMusl then "musl" else "glibc";
 
@@ -14,8 +15,6 @@ let
     "workbench.startupEditor" = "none";
   };
 
-  # Prevent VS Code searches from following workspace symlinks into the host
-  # filesystem and consuming excessive CPU.
   code-server-patched = pkgs.runCommand "${pkgs.code-server.name}-patched" {
     inherit (pkgs.code-server) pname version meta;
     passthru = {
@@ -33,6 +32,8 @@ let
         "var libc = process.env.LIBC || (isAlpine(platform) ? 'musl' : 'glibc')" \
         "var libc = '${code-server-libc}'"
 
+    # Prevent VS Code searches from following workspace symlinks into the host
+    # filesystem and consuming excessive CPU.
     extensionHost=$out/libexec/code-server/lib/vscode/out/vs/workbench/api/node/extensionHostProcess.js
     chmod u+w "$extensionHost"
     substituteInPlace "$extensionHost" \
@@ -55,17 +56,20 @@ let
     substituteInPlace $out/bin/code-server \
       --replace-fail ${pkgs.code-server} $out
   '';
+
   clangdExtension = pkgs.vscode-extensions.llvm-vs-code-extensions.vscode-clangd.overrideAttrs (oldAttrs: {
     postPatch = (oldAttrs.postPatch or "") + ''
       substituteInPlace package.json \
         --replace-fail '"default": "clangd"' '"default": "${pkgs.clang-tools}/bin/clangd"'
     '';
   });
+
   codeExtensions = with pkgs.vscode-extensions; [
     clangdExtension
     ms-python.python
     vadimcn.vscode-lldb
   ];
+
   code-server = pkgs.vscode-with-extensions.override {
     vscode = code-server-patched;
     vscodeExtensions = codeExtensions;

--- a/workspace/services/code.nix
+++ b/workspace/services/code.nix
@@ -55,7 +55,14 @@ let
     substituteInPlace $out/bin/code-server \
       --replace-fail ${pkgs.code-server} $out
   '';
+  clangdExtension = pkgs.vscode-extensions.llvm-vs-code-extensions.vscode-clangd.overrideAttrs (oldAttrs: {
+    postPatch = (oldAttrs.postPatch or "") + ''
+      substituteInPlace package.json \
+        --replace-fail '"default": "clangd"' '"default": "${pkgs.clang-tools}/bin/clangd"'
+    '';
+  });
   codeExtensions = with pkgs.vscode-extensions; [
+    clangdExtension
     ms-python.python
     vadimcn.vscode-lldb
   ];

--- a/workspace/services/code.nix
+++ b/workspace/services/code.nix
@@ -5,6 +5,15 @@ let
   code-server-libc =
     if pkgs.stdenv.hostPlatform.isMusl then "musl" else "glibc";
 
+  codeConfigurationDefaults = {
+    "chat.disableAIFeatures" = true;
+    "extensions.ignoreRecommendations" = true;
+    "telemetry.telemetryLevel" = "off";
+    "workbench.colorTheme" = "Dark 2026";
+    "workbench.secondarySideBar.defaultVisibility" = "hidden";
+    "workbench.startupEditor" = "none";
+  };
+
   # Prevent VS Code searches from following workspace symlinks into the host
   # filesystem and consuming excessive CPU.
   code-server-patched = pkgs.runCommand "${pkgs.code-server.name}-patched" {
@@ -33,6 +42,13 @@ let
       echo "unpatched --follow argument remains in compiled VS Code" >&2
       exit 1
     fi
+
+    serverMain=$out/libexec/code-server/lib/vscode/out/server-main.js
+    chmod u+w "$serverMain"
+    substituteInPlace "$serverMain" \
+      --replace-fail \
+        'productConfiguration:W,callbackRoute:x' \
+        'productConfiguration:W,configurationDefaults:${builtins.toJSON codeConfigurationDefaults},callbackRoute:x'
 
     cp ${pkgs.code-server}/bin/code-server $out/bin/code-server
     chmod u+w $out/bin/code-server
@@ -63,6 +79,8 @@ let
         --bind-addr=0.0.0.0:8080 \
         --trusted-origins='*' \
         --disable-telemetry \
+        --disable-update-check \
+        --disable-getting-started-override \
         "''${extensionArgs[@]}" \
         --config=/dev/null
 


### PR DESCRIPTION
## Summary

- bundle the official clangd VS Code extension and point it at the pinned Nix `clangd`
- provide user-overridable VS Code defaults without modifying persistent user settings
- default to the dark theme, hide Chat and the secondary sidebar, and suppress extension recommendations, telemetry, and the startup editor
- disable code-server update checks and its Coder-specific Getting Started override
- keep the configuration in an alphabetized Nix attribute set serialized with `builtins.toJSON`
- keep related bindings visually separated and place the symlink-search explanation directly beside that patch

This supersedes #1138.

## Testing

- `nix flake check --no-build --no-update-lock-file`
- `nix build .#core --no-link --no-update-lock-file --print-build-logs`
- verified `code --list-extensions --show-versions` includes `llvm-vs-code-extensions.vscode-clangd@0.4.0`, `ms-python.python@2026.4.0`, and `vadimcn.vscode-lldb@1.12.1`
- launched code-server with a fresh user-data directory and verified dark mode, a hidden secondary sidebar, and no Chat, Copilot, Getting Started, or telemetry notice