### PR TITLE
Handle HTTPS for managed LLM access

### DIFF
--- a/dojo_plugin/api/v1/llm.py
+++ b/dojo_plugin/api/v1/llm.py
@@ -1,7 +1,7 @@
 import logging
 
 import redis
-from flask import current_app
+from flask import current_app, request
 from flask_restx import Namespace, Resource
 from CTFd.utils.decorators import authed_only
 from CTFd.utils.user import get_current_user
@@ -20,7 +20,6 @@ from ...utils.llm import LiteLLMKeyManager
 
 logger = logging.getLogger(__name__)
 llm_namespace = Namespace("llm", description="Managed LLM credentials")
-LLM_BASE_URL = f"http://{DOJO_HOST}/llm"
 
 
 def key_manager():
@@ -62,7 +61,7 @@ class LLMCredentials(Resource):
 
         return {
             "success": True,
-            "base_url": LLM_BASE_URL,
+            "base_url": f"{request.scheme}://{DOJO_HOST}/llm",
             **credentials,
         }
 

--- a/workspace/core/llm-wrapper.py
+++ b/workspace/core/llm-wrapper.py
@@ -6,6 +6,7 @@ import pathlib
 import subprocess
 import sys
 from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin, urlsplit
 from urllib.request import Request, urlopen
 
 
@@ -50,6 +51,32 @@ def is_authenticated(client, executable):
     ).returncode == 0
 
 
+def fetch_managed_credentials(url, headers):
+    request = Request(url, data=b"", method="POST", headers=headers)
+    try:
+        response = urlopen(request, timeout=15)
+    except HTTPError as error:
+        if error.code not in (307, 308):
+            raise
+
+        redirected_url = urljoin(url, error.headers.get("Location", ""))
+        redirected = urlsplit(redirected_url)
+        dojo_host = urlsplit(f"//{os.environ.get('DOJO_HOST', 'pwn.college')}").hostname
+        if (
+            redirected.scheme != "https"
+            or redirected.hostname != dojo_host
+            or redirected.port not in (None, 443)
+        ):
+            raise URLError("Refusing untrusted managed LLM redirect")
+
+        error.close()
+        request = Request(redirected_url, data=b"", method="POST", headers=headers)
+        response = urlopen(request, timeout=15)
+
+    with response:
+        return json.load(response)
+
+
 def managed_credentials():
     token = os.environ.get("DOJO_AUTH_TOKEN")
     if not token:
@@ -58,15 +85,11 @@ def managed_credentials():
     headers = {"Authorization": f"Bearer {token}"}
     if dojo_host := os.environ.get("DOJO_HOST"):
         headers["Host"] = dojo_host
-    request = Request(
-        "http://pwn.college:80/pwncollege_api/v1/llm/credentials",
-        data=b"",
-        method="POST",
-        headers=headers,
-    )
     try:
-        with urlopen(request, timeout=15) as response:
-            result = json.load(response)
+        result = fetch_managed_credentials(
+            "http://pwn.college:80/pwncollege_api/v1/llm/credentials",
+            headers,
+        )
     except HTTPError as error:
         if error.code not in (401, 403):
             print("Managed dojo LLM access is unavailable; using the client's normal login.", file=sys.stderr)


### PR DESCRIPTION
## Summary

- replay production's 307/308 credential redirect as the original authenticated POST
- only forward the workspace token to HTTPS on the configured dojo host and standard HTTPS port
- derive the exposed LiteLLM gateway URL from the effective request scheme, retaining HTTP in development and returning HTTPS in production

## Testing

- compiled both changed Python modules
- exercised direct HTTP, trusted HTTP-to-HTTPS redirect, and untrusted redirect rejection with an isolated URL opener
- verified the patched wrapper follows the live production redirect and receives managed credentials

## Deployment

After merge:

1. Pull and recreate `ctfd` on the main node.
2. Pull and rebuild `workspace-builder` on each workspace node.

LiteLLM and nginx do not need to be restarted.
