### PR TITLE
Skip OpenCode embedded web UI build

### DIFF
--- a/workspace/overlays/opencode.nix
+++ b/workspace/overlays/opencode.nix
@@ -26,7 +26,7 @@ in
 
     buildPhase = builtins.replaceStrings
       [ "bun --bun ./script/build.ts --single --skip-install" ]
-      [ "bun --bun ./script/build.ts --single --baseline --skip-install" ]
+      [ "bun --bun ./script/build.ts --single --baseline --skip-embed-web-ui --skip-install" ]
       oldAttrs.buildPhase;
   });
 }


### PR DESCRIPTION
The production workspace nodes do not have AVX2. Although #1144 switches Bun and the OpenCode output to baseline x86-64, OpenCode's optional embedded web UI build still executes Tailwind's AVX2 native binding and fails on those nodes.

Pass upstream's --skip-embed-web-ui flag. The terminal/TUI client we install does not require those browser assets.

Validated:
- the isolated overlaid OpenCode derivation builds successfully
- opencode --version reports 1.15.10
- the resulting binary reports 1.15.10 under qemu-x86_64 -cpu SandyBridge
- opencode --help starts successfully