### PR TITLE
Workspace: support fullscreen launch URLs

### DIFF
--- a/dojo_plugin/pages/workspace.py
+++ b/dojo_plugin/pages/workspace.py
@@ -57,7 +57,7 @@ def render_workspace(*, service=None, port=None):
             ), 400
 
         launch_options = {}
-        for key, default in (("practice", False), ("home", True)):
+        for key, default in (("practice", False), ("home", True), ("fullscreen", False)):
             value = request.args.get(key)
             if value is None:
                 launch_options[key] = default
@@ -71,10 +71,11 @@ def render_workspace(*, service=None, port=None):
                     error=f"{key} must be true or false",
                 ), 400
 
+        fullscreen = launch_options.pop("fullscreen")
         return render_template(
             "workspace_launch.html",
             launch={**launch_ids, **launch_options},
-            workspace_url=request.path,
+            workspace_url=f"{request.path}?fullscreen=true" if fullscreen else request.path,
         )
 
     current_challenge = get_current_dojo_challenge()

--- a/dojo_theme/static/js/dojo/workspace.js
+++ b/dojo_theme/static/js/dojo/workspace.js
@@ -18,8 +18,10 @@ function doFullscreen() {
 }
 
 $(() => {
-    if (new URLSearchParams(window.location.search).has("hide-navbar")) {
+    const query = new URLSearchParams(window.location.search);
+    if (query.has("hide-navbar") || query.get("fullscreen") === "true") {
         hideNavbar();
+        $("#fullscreen i").removeClass("fa-expand").addClass("fa-compress");
     }
     $(".close-link").hide();
     $("footer").hide();

--- a/test/test_challenges.py
+++ b/test/test_challenges.py
@@ -122,11 +122,18 @@ def test_workspace_auto_start_without_home_mount(
         "module": "hello",
         "challenge": "apple",
         "home": "false",
+        "fullscreen": "true",
     })
     random_user_browser.get(f"{DOJO_URL}/workspace/terminal?{query}")
 
     WebDriverWait(random_user_browser, 60).until(
-        lambda browser: browser.current_url.rstrip("/").endswith("/workspace/terminal")
+        lambda browser: browser.current_url.endswith("/workspace/terminal?fullscreen=true")
+    )
+    navbar = random_user_browser.find_element(By.CLASS_NAME, "navbar")
+    fullscreen_icon = random_user_browser.find_element(By.CSS_SELECTOR, "#fullscreen i")
+    WebDriverWait(random_user_browser, 30).until(
+        lambda _: "navbar-hidden" in navbar.get_attribute("class")
+        and "fa-compress" in fullscreen_icon.get_attribute("class")
     )
     workspace_iframe = random_user_browser.find_element(By.ID, "workspace-iframe")
     terminal_button = random_user_browser.find_element(


### PR DESCRIPTION
## Summary
- accept `fullscreen=true` alongside workspace auto-launch options
- retain fullscreen state after stripping challenge launch parameters from the redirect
- initialize the workspace navbar and control icon in their fullscreen state

## Testing
- `test/test_challenges.py::test_workspace_auto_start_without_home_mount`
