### PR TITLE
Workspace: preserve home mount mode on restart

### DIFF
--- a/dojo_plugin/api/v1/docker.py
+++ b/dojo_plugin/api/v1/docker.py
@@ -607,7 +607,10 @@ class RunDocker(Resource):
             "module": dojo_challenge.module.id,
             "challenge": dojo_challenge.id,
             "practice" : practice,
-            "home": any(mount["Destination"] == "/home/hacker" for mount in container.attrs.get("Mounts", [])),
+            "home": any(
+                mount["Destination"] == "/home/hacker" and mount.get("Driver") == "homefs"
+                for mount in container.attrs.get("Mounts", [])
+            ),
         }
 
     @authed_only

--- a/dojo_plugin/api/v1/docker.py
+++ b/dojo_plugin/api/v1/docker.py
@@ -607,6 +607,7 @@ class RunDocker(Resource):
             "module": dojo_challenge.module.id,
             "challenge": dojo_challenge.id,
             "practice" : practice,
+            "home": any(mount["Destination"] == "/home/hacker" for mount in container.attrs.get("Mounts", [])),
         }
 
     @authed_only

--- a/dojo_theme/static/js/dojo/actionbar.js
+++ b/dojo_theme/static/js/dojo/actionbar.js
@@ -367,6 +367,7 @@ function actionStartChallenge(event, privileged) {
             "module": result.module,
             "challenge": result.challenge,
             "practice": privileged,
+            "home": result.home,
         };
 
         return CTFd.fetch('/pwncollege_api/v1/docker', {

--- a/test/test_challenges.py
+++ b/test/test_challenges.py
@@ -4,6 +4,7 @@ from urllib.parse import quote, urlencode
 import pytest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 from utils import (
     DOJO_URL,
@@ -153,3 +154,41 @@ def test_workspace_auto_start_without_home_mount(
     workspace_run("touch /home/hacker/ephemeral", user=random_user_name)
     start_challenge(example_dojo, "hello", "apple", session=random_user_session, home=False)
     workspace_run("test ! -e /home/hacker/ephemeral", user=random_user_name)
+
+
+@pytest.mark.parametrize("home", [False, True])
+def test_workspace_restart_preserves_home_mount(
+    random_user_name, random_user_session, random_user_browser, example_dojo, home
+):
+    start_challenge(example_dojo, "hello", "apple", session=random_user_session, home=home)
+    workspace_run("touch /tmp/restart-marker /home/hacker/restart-marker", user=random_user_name)
+    random_user_browser.get(f"{DOJO_URL}/workspace/terminal")
+    wait = WebDriverWait(random_user_browser, 60)
+    restart = wait.until(EC.element_to_be_clickable((By.ID, "challenge-restart")))
+    restart.click()
+    wait.until(lambda _: restart.is_enabled())
+
+    def check_home(practice):
+        state = random_user_session.get(f"{DOJO_URL}/pwncollege_api/v1/docker").json()
+        assert state["success"]
+        assert state["home"] is home
+        assert state["practice"] is practice
+        if home:
+            workspace_run("findmnt --mountpoint /home/hacker", user=random_user_name)
+        else:
+            with pytest.raises(subprocess.CalledProcessError):
+                workspace_run("findmnt --mountpoint /home/hacker", user=random_user_name)
+
+    check_home(practice=False)
+    workspace_run("test ! -e /tmp/restart-marker", user=random_user_name)
+    workspace_run(
+        "test -e /home/hacker/restart-marker" if home else "test ! -e /home/hacker/restart-marker",
+        user=random_user_name,
+    )
+
+    checkbox = random_user_browser.find_element(By.CSS_SELECTOR, "#workspace-change-privilege input")
+    checkbox.click()
+    wait.until(EC.alert_is_present())
+    random_user_browser.switch_to.alert.accept()
+    wait.until(lambda _: checkbox.is_enabled())
+    check_home(practice=True)

--- a/test/test_challenges.py
+++ b/test/test_challenges.py
@@ -1,4 +1,5 @@
 import subprocess
+import json
 from urllib.parse import quote, urlencode
 
 import pytest
@@ -9,6 +10,8 @@ from selenium.webdriver.support import expected_conditions as EC
 from utils import (
     DOJO_URL,
     create_dojo_yml,
+    dojo_run,
+    get_outer_container_for,
     get_user_id,
     start_challenge,
     suppress_award_popup,
@@ -192,3 +195,34 @@ def test_workspace_restart_preserves_home_mount(
     random_user_browser.switch_to.alert.accept()
     wait.until(lambda _: checkbox.is_enabled())
     check_home(practice=True)
+
+
+def test_workspace_home_option_ignores_image_volume(
+    random_user_name, random_user_session, example_dojo
+):
+    start_challenge(example_dojo, "hello", "apple", session=random_user_session, home=False)
+    container = f"user_{get_user_id(random_user_name)}"
+    outer = get_outer_container_for(container)
+    image = "pwncollege/test-home-volume"
+    dojo_run(
+        "docker", "build", "-t", image, "-", container=outer,
+        input="FROM pwncollege/challenge-simple\nVOLUME /home/hacker\n",
+    )
+    dojo_run("docker", "rm", "-f", container, container=outer)
+    try:
+        dojo_run(
+            "docker", "create", "--name", container,
+            "--label", f"dojo.dojo_id={example_dojo}",
+            "--label", "dojo.module_id=hello",
+            "--label", "dojo.challenge_id=apple",
+            "--label", "dojo.mode=standard",
+            image, container=outer,
+        )
+        mounts = json.loads(dojo_run("docker", "inspect", container, container=outer).stdout)[0]["Mounts"]
+        assert any(mount["Destination"] == "/home/hacker" and mount["Driver"] == "local" for mount in mounts)
+        response = random_user_session.get(f"{DOJO_URL}/pwncollege_api/v1/docker")
+        assert response.status_code == 200
+        assert response.json()["success"]
+        assert response.json()["home"] is False
+    finally:
+        dojo_run("docker", "rm", "-fv", container, container=outer)

--- a/test/test_workspace_api.py
+++ b/test/test_workspace_api.py
@@ -519,7 +519,7 @@ def test_started_container_is_labeled_with_the_running_challenge(standard_worksp
 
     current = session.get(DOCKER_API)
     assert current.json() == {
-        "success": True, "dojo": example_dojo, "module": "hello", "challenge": "apple", "practice": False
+        "success": True, "dojo": example_dojo, "module": "hello", "challenge": "apple", "practice": False, "home": True
     }, f"Unexpected active challenge: {current.json()}"
 
     workspace = session.get(WORKSPACE_API).json()
@@ -686,7 +686,7 @@ def test_practice_mode_workspace_is_privileged_and_carries_the_practice_flag(pra
 
     current = session.get(DOCKER_API)
     assert current.json() == {
-        "success": True, "dojo": example_dojo, "module": "hello", "challenge": "apple", "practice": True
+        "success": True, "dojo": example_dojo, "module": "hello", "challenge": "apple", "practice": True, "home": True
     }, f"Expected the active challenge to be reported as practice, but got {current.json()}"
 
 

--- a/test/tiers.py
+++ b/test/tiers.py
@@ -55,6 +55,7 @@ TEST_TIER_OVERRIDES = {
 
 MULTINODE_TESTS = {
     "test_challenges.py::test_workspace_auto_start_without_home_mount",
+    "test_challenges.py::test_workspace_restart_preserves_home_mount",
     "test_dojo_cli.py::test_enter_finds_container_on_worker_node",
     "test_dojo_cli.py::test_compose_selects_profiles_by_node_role",
     "test_dojo_cli.py::test_startup_gates_are_satisfied",

--- a/test/tiers.py
+++ b/test/tiers.py
@@ -56,6 +56,7 @@ TEST_TIER_OVERRIDES = {
 MULTINODE_TESTS = {
     "test_challenges.py::test_workspace_auto_start_without_home_mount",
     "test_challenges.py::test_workspace_restart_preserves_home_mount",
+    "test_challenges.py::test_workspace_home_option_ignores_image_volume",
     "test_dojo_cli.py::test_enter_finds_container_on_worker_node",
     "test_dojo_cli.py::test_compose_selects_profiles_by_node_role",
     "test_dojo_cli.py::test_startup_gates_are_satisfied",


### PR DESCRIPTION
The workspace Restart button and sudo toggle omit `home` when starting the replacement container, causing a workspace launched with `home=false` to regain its persistent home mount. Return whether the current container has a managed `homefs` mount at `/home/hacker` and pass that setting through the existing restart request. Anonymous volumes declared by an image do not count as a managed home mount.

Add browser regression coverage for both home modes, checking the actual Restart button, file persistence, and sudo toggle, plus an API regression using a real Docker-created anonymous home volume. Update the API response expectations and include the new tests in the multinode selection.

Validation: 11 focused browser/API tests passed against an isolated local dojo using Firefox and Docker. Python and JavaScript syntax checks and `git diff --check` passed. The full suite and multinode tests were not run locally.
