### PR TITLE
SSH: preserve cursor position during challenge reconnects

### DIFF
--- a/sshd/enter.py
+++ b/sshd/enter.py
@@ -17,7 +17,7 @@ from mac_docker import MacDockerClient
 
 DOJO_CLI = "/nix/var/nix/profiles/dojo-workspace/bin/dojo"
 
-TERMINAL_RESTORE = "\x1b[<u\x1b[?1049l\x1b[?25h\x1b[?7h\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1015l\x1b[?1004l\x1b[?2004l\x1b[?2026l\x1b[0m"
+TERMINAL_RESTORE = "\x1b[<u\x1b7\x1b[?1049l\x1b[?25h\x1b[?7h\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1015l\x1b[?1004l\x1b[?2004l\x1b[?2026l\x1b[0m"
 
 
 def run_challenge_tui(user_id):


### PR DESCRIPTION
Switching challenges over interactive SSH can move the cursor back to an old position and overwrite existing terminal output. After using the challenge picker, the reconnect cleanup added in #1100 restores the cursor saved before the picker opened, even when the normal screen is already active.

Save the active screen's cursor with `ESC 7` immediately before `ESC[?1049l` in `TERMINAL_RESTORE`. On terminals with separate cursor save slots per screen, normal-shell reconnects preserve the current position, while an interrupted full-screen program still returns to the saved normal-screen position. The change is confined to one line in the cleanup constant.

Local validation used the actual dojo CLI/Textual picker with keyboard input through a real PTY, fixture API responses, real Bash shells, and xterm.js 5.5.0:

- Compared pre-August cleanup, current cleanup, and the patch in 27 runs covering 72 reconnects: standard/practice starts, failed-start retry, quit, killed picker, no picker, repeated switches, resize, and existing scrollback.
- Current cleanup reproduced row 22 → 5 after picker use; the patch preserved row 22 and matched pre-August screen/cursor behavior. Both current and patched cleanup recovered the original screen after killing the picker.
- Replayed actual TUI output through tmux 3.6a in nine additional cases. Its existing stale-cursor jump remains unresolved; interrupted-picker recovery still works. Native Windows/macOS terminals were not runtime-tested.

All testing was local. Python syntax and `git diff --check` pass.
