### PR TITLE
Fix hidden users' own progress bars within a dojo

### DIFF
--- a/dojo_plugin/models/__init__.py
+++ b/dojo_plugin/models/__init__.py
@@ -525,7 +525,6 @@ class DojoModules(db.Model):
     def visible_solves(self, **kwargs):
         return self.solves(ignore_visibility=True, **kwargs).filter(
             DojoChallenges.visible(),
-            ~Users.hidden,
         )
 
     @hybrid_method

--- a/dojo_theme/templates/dojo.html
+++ b/dojo_theme/templates/dojo.html
@@ -68,7 +68,7 @@
     {% for module in dojo.modules %}
     {% set container_count = module_container_counts.get(module.id, 0) %}
     {% set num_challs = module.visible_challenges(required_only=True) | length %}
-    {% set num_solved_required = module.visible_solves(user=user, include_admin_users=True).count() if user else 0 %}
+    {% set num_solved_required = module.visible_solves(user=user, include_hidden_users=True, include_admin_users=True).count() if user else 0 %}
     {% if module.visible() or dojo.is_admin(user) %}
       {{ card(
         url_for('pwncollege_dojo.view_dojo_path', dojo=dojo_id, path=module.id),

--- a/test/test_client_flows.py
+++ b/test/test_client_flows.py
@@ -5,6 +5,7 @@ import time
 from urllib.parse import urlparse
 
 import pytest
+import requests
 
 from utils import (
     DOJO_URL,
@@ -260,6 +261,28 @@ def test_dojo_progress_counts_only_required_solves(flows_dojo, flows_solver):
 
     assert session.get(f"{DOJO_URL}/{flows_dojo}").status_code == 200
     assert session.get(f"{DOJO_URL}/hacker/{get_user_id(name)}").status_code == 200
+
+
+def test_hidden_user_module_progress_is_only_shown_to_self(flows_dojo, random_user):
+    name, session = random_user
+    _, other_session = register_user()
+    solve_challenge_offline(flows_dojo, "flows", "required-one", session=session, user=name)
+
+    def progress(viewer):
+        response = viewer.get(f"{DOJO_URL}/{flows_dojo}")
+        assert response.status_code == 200, response.status_code
+        widths = re.findall(r'class="progress-bar" style="width: ([\d.]+)%"', response.text)
+        assert len(widths) == 1, widths
+        return float(widths[0])
+
+    assert progress(session) == 100
+    response = session.patch(f"{DOJO_URL}/api/v1/users/me", json={"hidden": True})
+    assert response.status_code == 200, response.text
+
+    assert progress(session) == 100, "hidden users must see their own module progress"
+    assert progress(other_session) == 0, "another viewer must only see their own progress"
+    with requests.Session() as anonymous:
+        assert progress(anonymous) == 0, "anonymous viewers must not see another user's progress"
 
 
 def test_module_card_progress_cannot_exceed_denominator(admin_session, example_dojo):


### PR DESCRIPTION
If you set your account's "Visibility" setting to Hidden (so you don't show up on the scoreboard), the progress bars inside a dojo get stuck at 0%, even after you've actually solved challenges. This only affects the view inside a dojo, not on the main dojos listing page.

The per-module progress bar was using the same filter used to hide a user's solves from the public scoreboard. That filter makes sense for rankings, but it was being applied when calculating a user's own progress too, so a hidden user's own solves were being excluded from their own progress bar.

This PR makes "Hidden" setting only affect scoreboard visibility (as I think it's intended) and no longer hides your own progress from yourself.