### PR TITLE
Update noVNC to latest upstream snapshot for automatic clipboard

### DIFF
--- a/workspace/services/desktop.nix
+++ b/workspace/services/desktop.nix
@@ -15,6 +15,13 @@ let
     +        else if (UI.getSetting('reconnect', false) === true && !UI.inhibitReconnect) {
   '';
   novnc = pkgs.novnc.overrideAttrs (oldAttrs: {
+    version = "unstable-2026-09-07";
+    src = pkgs.fetchFromGitHub {
+      owner = "novnc";
+      repo = "noVNC";
+      rev = "acca57b997f206683d27796829ee1f72da37002a";
+      hash = "sha256-MlnFM3DkBBuGIAXbJYjyb5qEDz8ayxN4E7lCZ3kT6Pw=";
+    };
     postInstall = (oldAttrs.postInstall or "") + ''
       patch -p1 -d $out < ${reconnectPatch}
     '';


### PR DESCRIPTION
## Summary

Pin noVNC to upstream master `acca57b997f206683d27796829ee1f72da37002a` (2026-09-07), the latest upstream commit checked on 2026-09-09. The locked Nixpkgs package currently provides 1.7.0; this is an explicitly pinned **unreleased snapshot**, not a new numbered release.

Preserves TigerVNC, websockify, workspace routing, and the existing reconnect patch.

## Notable upstream changes since 1.7.0

- Automatic clipboard synchronization when browser permissions allow ([noVNC #1993](https://github.com/novnc/noVNC/pull/1993)). This is not present in the 1.7.0 release, despite that release being newer than the merge date.
- Screen wake-lock support, warning before closing an active non-view-only session, and the ability to attach the control bar to the top/bottom.
- Android Chrome endless-loading workaround, older Chrome VideoDecoder feature-detection fix, and URL-handling alignment for vnc_lite.
- Translation and development/CI updates.

## Validation

- Built the exact noVNC derivation selected by desktop.nix against the locked Nixpkgs revision. Source hash verified; inherited packaging patches and Dojo reconnect patch applied.
- Tested built assets with real Firefox 155.0.1 and Chrome 153.0.8010.36 in an isolated Linux container, with separate local/remote X displays and real OS clipboards. Cross-origin iframe uses Dojo's clipboard allow attributes; no Clipboard API mocks.
- Chrome with permissions granted: Unicode local-to-remote on focus and remote-to-local, including after seven seconds idle, passed. Permission grants were automated through CDP; manual permission-prompt UX was not tested.
- Firefox retains upstream's manual clipboard panel. A gesture-based fallback is separate follow-up work.
- Fresh Chrome without grants can hide the clipboard panel even when automatic reads fail; this upstream UX limitation is also follow-up work.
- Same-server local key-to-canvas comparison (60 samples/client): 1.7.0 p50 25.65 ms / p95 33.1 ms; snapshot p50 26.0 ms / p95 32.8 ms. Short local measurements, not a WAN or physical input-to-photon guarantee.

Full Dojo deployment, full desktop closure, and Safari were not tested. Nothing deployed by this PR.
