### PR TITLE
Enable TLS for PgBouncer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -218,7 +218,7 @@ services:
       CLIENT_TLS_CERT_FILE: /etc/pgbouncer/tls/server.crt
       CLIENT_TLS_KEY_FILE: /etc/pgbouncer/tls/server.key
     volumes:
-      - /data/pgbouncer-tls:/etc/pgbouncer/tls:ro
+      - /data/pgbouncer/tls:/etc/pgbouncer/tls:ro
     depends_on:
       db:
         condition: service_started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,6 +214,12 @@ services:
       POOL_MODE: transaction
       MAX_CLIENT_CONN: 10000
       DEFAULT_POOL_SIZE: 20
+      CLIENT_TLS_SSLMODE: allow
+      CLIENT_TLS_CERT_FILE: /etc/pgbouncer/tls/server.crt
+      CLIENT_TLS_KEY_FILE: /etc/pgbouncer/tls/server.key
+      SERVER_TLS_SSLMODE: disable
+    volumes:
+      - /data/pgbouncer-tls:/etc/pgbouncer/tls:ro
     depends_on:
       db:
         condition: service_started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,7 +217,6 @@ services:
       CLIENT_TLS_SSLMODE: allow
       CLIENT_TLS_CERT_FILE: /etc/pgbouncer/tls/server.crt
       CLIENT_TLS_KEY_FILE: /etc/pgbouncer/tls/server.key
-      SERVER_TLS_SSLMODE: disable
     volumes:
       - /data/pgbouncer-tls:/etc/pgbouncer/tls:ro
     depends_on:

--- a/dojo/dojo-init
+++ b/dojo/dojo-init
@@ -105,8 +105,8 @@ mkdir -p /data/ctfd-ipython
 mkdir -p /data/coverage
 
 if [ "$WORKSPACE_NODE" -eq 0 ]; then
-    pgbouncer_ca_dir=/data/pgbouncer-ca
-    pgbouncer_tls_dir=/data/pgbouncer-tls
+    pgbouncer_ca_dir=/data/pgbouncer/ca
+    pgbouncer_tls_dir=/data/pgbouncer/tls
     mkdir -p "$pgbouncer_ca_dir" "$pgbouncer_tls_dir"
     if [ ! -f "$pgbouncer_ca_dir/ca.crt" ] || [ ! -f "$pgbouncer_ca_dir/ca.key" ]; then
         rm -f "$pgbouncer_tls_dir/server.crt" "$pgbouncer_tls_dir/server.key" "$pgbouncer_ca_dir/ca.srl"

--- a/dojo/dojo-init
+++ b/dojo/dojo-init
@@ -104,6 +104,46 @@ mkdir -p /data/workspacefs/bin
 mkdir -p /data/ctfd-ipython
 mkdir -p /data/coverage
 
+if [ "$WORKSPACE_NODE" -eq 0 ]; then
+    pgbouncer_ca_dir=/data/pgbouncer-ca
+    pgbouncer_tls_dir=/data/pgbouncer-tls
+    mkdir -p "$pgbouncer_ca_dir" "$pgbouncer_tls_dir"
+    if [ ! -f "$pgbouncer_ca_dir/ca.crt" ] || [ ! -f "$pgbouncer_ca_dir/ca.key" ] || \
+       [ ! -f "$pgbouncer_tls_dir/server.crt" ] || [ ! -f "$pgbouncer_tls_dir/server.key" ]; then
+        rm -f "$pgbouncer_ca_dir/ca.srl" "$pgbouncer_tls_dir/server.csr"
+        openssl req -x509 -newkey rsa:4096 -sha256 -nodes -days 3650 \
+            -keyout "$pgbouncer_ca_dir/ca.key" \
+            -out "$pgbouncer_ca_dir/ca.crt" \
+            -subj "/CN=pwncollege-pgbouncer-ca" \
+            -addext "basicConstraints=critical,CA:TRUE" \
+            -addext "keyUsage=critical,keyCertSign,cRLSign"
+        openssl req -new -newkey rsa:2048 -sha256 -nodes \
+            -keyout "$pgbouncer_tls_dir/server.key" \
+            -out "$pgbouncer_tls_dir/server.csr" \
+            -subj "/CN=pgbouncer" \
+            -addext "subjectAltName=DNS:pgbouncer" \
+            -addext "basicConstraints=critical,CA:FALSE" \
+            -addext "keyUsage=critical,digitalSignature,keyEncipherment" \
+            -addext "extendedKeyUsage=serverAuth"
+        openssl x509 -req -sha256 -days 825 \
+            -in "$pgbouncer_tls_dir/server.csr" \
+            -CA "$pgbouncer_ca_dir/ca.crt" \
+            -CAkey "$pgbouncer_ca_dir/ca.key" \
+            -CAcreateserial \
+            -copy_extensions copy \
+            -out "$pgbouncer_tls_dir/server.crt"
+        rm "$pgbouncer_tls_dir/server.csr"
+    fi
+    chown -R 0:0 "$pgbouncer_ca_dir"
+    chmod 700 "$pgbouncer_ca_dir"
+    chmod 600 "$pgbouncer_ca_dir/ca.key"
+    chmod 644 "$pgbouncer_ca_dir/ca.crt"
+    chown -R 70:70 "$pgbouncer_tls_dir"
+    chmod 700 "$pgbouncer_tls_dir"
+    chmod 600 "$pgbouncer_tls_dir/server.key"
+    chmod 644 "$pgbouncer_tls_dir/server.crt"
+fi
+
 # Enable systemd journal forwarding to Splunk if configured
 if [ "${ENABLE_SPLUNK}" = "true" ]; then
     echo "[+] Enabling systemd journal forwarding to Splunk..."

--- a/dojo/dojo-init
+++ b/dojo/dojo-init
@@ -108,20 +108,14 @@ if [ "$WORKSPACE_NODE" -eq 0 ]; then
     pgbouncer_ca_dir=/data/pgbouncer-ca
     pgbouncer_tls_dir=/data/pgbouncer-tls
     mkdir -p "$pgbouncer_ca_dir" "$pgbouncer_tls_dir"
-    if [ ! -f "$pgbouncer_ca_dir/ca.crt" ] && [ ! -f "$pgbouncer_ca_dir/ca.key" ]; then
-        if [ -e "$pgbouncer_tls_dir/server.crt" ] || [ -e "$pgbouncer_tls_dir/server.key" ]; then
-            echo "[!] Missing PgBouncer CA: restore ca.crt and ca.key in $pgbouncer_ca_dir" >&2
-            exit 1
-        fi
+    if [ ! -f "$pgbouncer_ca_dir/ca.crt" ] || [ ! -f "$pgbouncer_ca_dir/ca.key" ]; then
+        rm -f "$pgbouncer_tls_dir/server.crt" "$pgbouncer_tls_dir/server.key" "$pgbouncer_ca_dir/ca.srl"
         openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 -sha256 -nodes -days 7300 \
             -keyout "$pgbouncer_ca_dir/ca.key" \
             -out "$pgbouncer_ca_dir/ca.crt" \
             -subj "/CN=pwncollege-pgbouncer-ca" \
             -addext "basicConstraints=critical,CA:TRUE" \
             -addext "keyUsage=critical,keyCertSign,cRLSign" || exit 1
-    elif [ ! -f "$pgbouncer_ca_dir/ca.crt" ] || [ ! -f "$pgbouncer_ca_dir/ca.key" ]; then
-        echo "[!] Incomplete PgBouncer CA: restore ca.crt and ca.key in $pgbouncer_ca_dir" >&2
-        exit 1
     fi
     if [ ! -f "$pgbouncer_tls_dir/server.crt" ] || [ ! -f "$pgbouncer_tls_dir/server.key" ]; then
         openssl req -new -newkey ec -pkeyopt ec_paramgen_curve:P-256 -sha256 -nodes \

--- a/dojo/dojo-init
+++ b/dojo/dojo-init
@@ -111,21 +111,21 @@ if [ "$WORKSPACE_NODE" -eq 0 ]; then
     if [ ! -f "$pgbouncer_ca_dir/ca.crt" ] || [ ! -f "$pgbouncer_ca_dir/ca.key" ] || \
        [ ! -f "$pgbouncer_tls_dir/server.crt" ] || [ ! -f "$pgbouncer_tls_dir/server.key" ]; then
         rm -f "$pgbouncer_ca_dir/ca.srl" "$pgbouncer_tls_dir/server.csr"
-        openssl req -x509 -newkey rsa:4096 -sha256 -nodes -days 3650 \
+        openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 -sha256 -nodes -days 7300 \
             -keyout "$pgbouncer_ca_dir/ca.key" \
             -out "$pgbouncer_ca_dir/ca.crt" \
             -subj "/CN=pwncollege-pgbouncer-ca" \
             -addext "basicConstraints=critical,CA:TRUE" \
             -addext "keyUsage=critical,keyCertSign,cRLSign"
-        openssl req -new -newkey rsa:2048 -sha256 -nodes \
+        openssl req -new -newkey ec -pkeyopt ec_paramgen_curve:P-256 -sha256 -nodes \
             -keyout "$pgbouncer_tls_dir/server.key" \
             -out "$pgbouncer_tls_dir/server.csr" \
             -subj "/CN=pgbouncer" \
             -addext "subjectAltName=DNS:pgbouncer" \
             -addext "basicConstraints=critical,CA:FALSE" \
-            -addext "keyUsage=critical,digitalSignature,keyEncipherment" \
+            -addext "keyUsage=critical,digitalSignature" \
             -addext "extendedKeyUsage=serverAuth"
-        openssl x509 -req -sha256 -days 825 \
+        openssl x509 -req -sha256 -days 3650 \
             -in "$pgbouncer_tls_dir/server.csr" \
             -CA "$pgbouncer_ca_dir/ca.crt" \
             -CAkey "$pgbouncer_ca_dir/ca.key" \

--- a/dojo/dojo-init
+++ b/dojo/dojo-init
@@ -108,15 +108,22 @@ if [ "$WORKSPACE_NODE" -eq 0 ]; then
     pgbouncer_ca_dir=/data/pgbouncer-ca
     pgbouncer_tls_dir=/data/pgbouncer-tls
     mkdir -p "$pgbouncer_ca_dir" "$pgbouncer_tls_dir"
-    if [ ! -f "$pgbouncer_ca_dir/ca.crt" ] || [ ! -f "$pgbouncer_ca_dir/ca.key" ] || \
-       [ ! -f "$pgbouncer_tls_dir/server.crt" ] || [ ! -f "$pgbouncer_tls_dir/server.key" ]; then
-        rm -f "$pgbouncer_ca_dir/ca.srl" "$pgbouncer_tls_dir/server.csr"
+    if [ ! -f "$pgbouncer_ca_dir/ca.crt" ] && [ ! -f "$pgbouncer_ca_dir/ca.key" ]; then
+        if [ -e "$pgbouncer_tls_dir/server.crt" ] || [ -e "$pgbouncer_tls_dir/server.key" ]; then
+            echo "[!] Missing PgBouncer CA: restore ca.crt and ca.key in $pgbouncer_ca_dir" >&2
+            exit 1
+        fi
         openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 -sha256 -nodes -days 7300 \
             -keyout "$pgbouncer_ca_dir/ca.key" \
             -out "$pgbouncer_ca_dir/ca.crt" \
             -subj "/CN=pwncollege-pgbouncer-ca" \
             -addext "basicConstraints=critical,CA:TRUE" \
-            -addext "keyUsage=critical,keyCertSign,cRLSign"
+            -addext "keyUsage=critical,keyCertSign,cRLSign" || exit 1
+    elif [ ! -f "$pgbouncer_ca_dir/ca.crt" ] || [ ! -f "$pgbouncer_ca_dir/ca.key" ]; then
+        echo "[!] Incomplete PgBouncer CA: restore ca.crt and ca.key in $pgbouncer_ca_dir" >&2
+        exit 1
+    fi
+    if [ ! -f "$pgbouncer_tls_dir/server.crt" ] || [ ! -f "$pgbouncer_tls_dir/server.key" ]; then
         openssl req -new -newkey ec -pkeyopt ec_paramgen_curve:P-256 -sha256 -nodes \
             -keyout "$pgbouncer_tls_dir/server.key" \
             -out "$pgbouncer_tls_dir/server.csr" \
@@ -124,14 +131,14 @@ if [ "$WORKSPACE_NODE" -eq 0 ]; then
             -addext "subjectAltName=DNS:pgbouncer" \
             -addext "basicConstraints=critical,CA:FALSE" \
             -addext "keyUsage=critical,digitalSignature" \
-            -addext "extendedKeyUsage=serverAuth"
+            -addext "extendedKeyUsage=serverAuth" || exit 1
         openssl x509 -req -sha256 -days 3650 \
             -in "$pgbouncer_tls_dir/server.csr" \
             -CA "$pgbouncer_ca_dir/ca.crt" \
             -CAkey "$pgbouncer_ca_dir/ca.key" \
             -CAcreateserial \
             -copy_extensions copy \
-            -out "$pgbouncer_tls_dir/server.crt"
+            -out "$pgbouncer_tls_dir/server.crt" || exit 1
         rm "$pgbouncer_tls_dir/server.csr"
     fi
     chown -R 0:0 "$pgbouncer_ca_dir"

--- a/test/test_dojo_cli.py
+++ b/test/test_dojo_cli.py
@@ -1192,6 +1192,9 @@ def test_workspace_egress_policy(cli_user):
 def test_init_rerun_preserves_secrets_and_host_keys(admin_session):
     before = dojo_run("cat", "/data/config.env").stdout
     fingerprint = dojo_run("ssh-keygen", "-lf", "/data/ssh_host_keys/ssh_host_ed25519_key.pub").stdout.split()[1]
+    pgbouncer_certificate = dojo_run(
+        "openssl", "x509", "-in", "/data/pgbouncer-tls/server.crt", "-noout", "-fingerprint", "-sha256"
+    ).stdout
 
     result = _rerun_dojo_init()
     assert result.returncode == 0, (result.stdout + result.stderr)[-2000:]
@@ -1200,6 +1203,9 @@ def test_init_rerun_preserves_secrets_and_host_keys(admin_session):
     assert after == before, "dojo-init rewrote config.env, rotating generated secrets"
     assert dojo_run("ssh-keygen", "-lf", "/data/ssh_host_keys/ssh_host_ed25519_key.pub").stdout.split()[1] == \
         fingerprint, "dojo-init regenerated the ssh host keys"
+    assert dojo_run(
+        "openssl", "x509", "-in", "/data/pgbouncer-tls/server.crt", "-noout", "-fingerprint", "-sha256"
+    ).stdout == pgbouncer_certificate, "dojo-init regenerated the PgBouncer certificate"
     assert admin_session.get(f"{DOJO_URL}/dojos").status_code == 200, "an existing session broke across dojo-init"
 
 

--- a/test/test_dojo_cli.py
+++ b/test/test_dojo_cli.py
@@ -1193,7 +1193,7 @@ def test_init_rerun_preserves_secrets_and_host_keys(admin_session):
     before = dojo_run("cat", "/data/config.env").stdout
     fingerprint = dojo_run("ssh-keygen", "-lf", "/data/ssh_host_keys/ssh_host_ed25519_key.pub").stdout.split()[1]
     pgbouncer_certificate = dojo_run(
-        "openssl", "x509", "-in", "/data/pgbouncer-tls/server.crt", "-noout", "-fingerprint", "-sha256"
+        "openssl", "x509", "-in", "/data/pgbouncer/tls/server.crt", "-noout", "-fingerprint", "-sha256"
     ).stdout
 
     result = _rerun_dojo_init()
@@ -1204,7 +1204,7 @@ def test_init_rerun_preserves_secrets_and_host_keys(admin_session):
     assert dojo_run("ssh-keygen", "-lf", "/data/ssh_host_keys/ssh_host_ed25519_key.pub").stdout.split()[1] == \
         fingerprint, "dojo-init regenerated the ssh host keys"
     assert dojo_run(
-        "openssl", "x509", "-in", "/data/pgbouncer-tls/server.crt", "-noout", "-fingerprint", "-sha256"
+        "openssl", "x509", "-in", "/data/pgbouncer/tls/server.crt", "-noout", "-fingerprint", "-sha256"
     ).stdout == pgbouncer_certificate, "dojo-init regenerated the PgBouncer certificate"
     assert admin_session.get(f"{DOJO_URL}/dojos").status_code == 200, "an existing session broke across dojo-init"
 


### PR DESCRIPTION
## Summary

- provision persistent PgBouncer TLS certificates during initialization
- configure PgBouncer to accept TLS connections
- preserve the certificate across repeated initialization

## Testing

- `sh -n dojo/dojo-init`
- `docker compose --profile main config`
- verified the generated certificate chain with OpenSSL
- started PgBouncer with the generated certificate and TLS settings