### PR TITLE
Compare user emails case-insensitively

### DIFF
--- a/ctfd/patches/04-case-insensitive-user-emails.patch
+++ b/ctfd/patches/04-case-insensitive-user-emails.patch
@@ -1,0 +1,87 @@
+diff --git a/CTFd/models/__init__.py b/CTFd/models/__init__.py
+index 86538bf..7766a76 100644
+--- a/CTFd/models/__init__.py
++++ b/CTFd/models/__init__.py
+@@ -6,6 +6,8 @@ from flask_sqlalchemy import SQLAlchemy
+ from sqlalchemy.ext.compiler import compiles
+ from sqlalchemy.ext.hybrid import hybrid_property
+ from sqlalchemy.orm import column_property, validates
++from sqlalchemy.sql import operators
++from sqlalchemy.types import TypeDecorator
+
+ from CTFd.cache import cache
+
+@@ -13,6 +15,18 @@ db = SQLAlchemy()
+ ma = Marshmallow()
+
+
++class EmailAddress(TypeDecorator):
++    impl = db.String
++    python_type = str
++    cache_ok = True
++
++    class comparator_factory(db.String.Comparator):
++        def operate(self, op, other, **kwargs):
++            if op in (operators.eq, operators.ne) and other is not None:
++                return op(db.func.lower(self.expr), db.func.lower(other), **kwargs)
++            return super().operate(op, other, **kwargs)
++
++
+ def get_class_by_tablename(tablename):
+     """Return class reference mapped to table.
+     https://stackoverflow.com/a/66666783
+@@ -324,14 +338,13 @@ class Flags(db.Model):
+
+ class Users(db.Model):
+     __tablename__ = "users"
+-    __table_args__ = (db.UniqueConstraint("id", "oauth_id"), {})
+     # Core attributes
+     id = db.Column(db.Integer, primary_key=True)
+     oauth_id = db.Column(db.Integer, unique=True)
+     # User names are not constrained to be unique to allow for official/unofficial teams.
+     name = db.Column(db.String(128))
+     password = db.Column(db.String(128))
+-    email = db.Column(db.String(128), unique=True)
++    email = db.Column(EmailAddress(128), unique=True)
+     type = db.Column(db.String(80))
+     secret = db.Column(db.String(128))
+
+@@ -357,6 +370,11 @@ class Users(db.Model):
+
+     created = db.Column(db.DateTime, default=datetime.datetime.utcnow)
+
++    __table_args__ = (
++        db.UniqueConstraint("id", "oauth_id"),
++        db.Index("users_email_lower_key", db.func.lower(email), unique=True),
++    )
++
+     __mapper_args__ = {"polymorphic_identity": "user", "polymorphic_on": type}
+
+     def __init__(self, **kwargs):
+diff --git a/CTFd/schemas/users.py b/CTFd/schemas/users.py
+index a398c37..61c46d1 100644
+--- a/CTFd/schemas/users.py
++++ b/CTFd/schemas/users.py
+@@ -127,7 +127,7 @@ class UserSchema(ma.ModelSchema):
+                             "Email address has already been used", field_names=["email"]
+                         )
+         else:
+-            if email == current_user.email:
++            if current_user.email and email.lower() == current_user.email.lower():
+                 return data
+             else:
+                 confirm = data.get("confirm")
+diff --git a/migrations/versions/8369118943a1_initial_revision.py b/migrations/versions/8369118943a1_initial_revision.py
+index 649d717..444bd36 100644
+--- a/migrations/versions/8369118943a1_initial_revision.py
++++ b/migrations/versions/8369118943a1_initial_revision.py
+@@ -142,6 +142,9 @@ def upgrade():
+         sa.UniqueConstraint("id", "oauth_id"),
+         sa.UniqueConstraint("oauth_id"),
+     )
++    op.create_index(
++        "users_email_lower_key", "users", [sa.text("lower(email)")], unique=True
++    )
+     op.create_table(
+         "awards",
+         sa.Column("id", sa.Integer(), nullable=False),

--- a/dojo_plugin/api/v1/scoreboard.py
+++ b/dojo_plugin/api/v1/scoreboard.py
@@ -19,6 +19,7 @@ CREW_MODE_RANK_FIELDS = {"unique": "unique_rank", "mastery": "mastery_rank"}
 
 
 def email_symbol_asset(email):
+    email = email.lower()
     if email.endswith("@asu.edu"):
         group = "fork.png"
     elif ".edu" in email.split("@")[1]:

--- a/test/test_accounts.py
+++ b/test/test_accounts.py
@@ -143,6 +143,84 @@ def second_user():
     yield name, login(name, name, register=True)
 
 
+@pytest.fixture
+def mixed_case_email_user(random_user, admin_session):
+    name, session = random_user
+    email = f"{name.upper()}@Example.COM"
+    response = admin_session.patch(
+        f"{DOJO_URL}/api/v1/users/{get_user_id(name)}", json={"email": email, "verified": True}
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["email"] == email
+    return name, session, email
+
+
+@pytest.mark.parametrize("email_case", [str.lower, str.upper])
+def test_email_login_case_insensitive(mixed_case_email_user, email_case):
+    name, _, email = mixed_case_email_user
+    session = login(email_case(email), name)
+    assert session.get(f"{DOJO_URL}/api/v1/users/me").json()["data"]["name"] == name
+
+    response = api_login(anon_session(), name=email_case(email), password=name)
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["username"] == name
+
+
+def test_email_unique_index():
+    assert db_sql(
+        "SELECT indisunique AND indisready AND indisvalid FROM pg_index "
+        "WHERE indexrelid = to_regclass('users_email_lower_key')"
+    ).strip() == "t"
+
+
+def test_email_comparison_does_not_change_credentials(mixed_case_email_user):
+    name, _, email = mixed_case_email_user
+    login(name.upper(), name, success=False)
+    login(email.lower(), name.upper(), success=False)
+    assert api_login(anon_session(), name=name.upper(), password=name).status_code == 401
+    assert api_login(anon_session(), name=email.lower(), password=name.upper()).status_code == 401
+
+
+def test_registration_rejects_email_case_duplicate(mixed_case_email_user, admin_session):
+    _, _, email = mixed_case_email_user
+    name = rand_name()
+    login(name, name, register=True, email=email.lower(), success=False)
+    assert count_users(name) == 0
+
+    response = api_register(anon_session(), **registration_payload(name, email=email.lower()))
+    assert response.status_code == 400, response.text
+    assert "That email is already registered" in response.json()["errors"]
+    assert count_users(name) == 0
+
+    response = admin_session.post(
+        f"{DOJO_URL}/api/v1/users", json=registration_payload(name, email=email.lower())
+    )
+    assert response.status_code == 400, response.text
+    assert "email" in response.json()["errors"]
+    assert count_users(name) == 0
+
+
+def test_self_email_case_edit(mixed_case_email_user):
+    name, session, email = mixed_case_email_user
+    response = session.patch(f"{DOJO_URL}/api/v1/users/me", json={"email": email.lower()})
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["email"] == email.lower()
+    assert db_sql(f"SELECT verified FROM users WHERE name = '{name}'").strip() == "t"
+
+
+@pytest.mark.parametrize("as_admin", [False, True])
+def test_email_edit_rejects_case_duplicate(mixed_case_email_user, second_user, admin_session, as_admin):
+    _, _, email = mixed_case_email_user
+    name, session = second_user
+    endpoint = f"/api/v1/users/{get_user_id(name)}" if as_admin else "/api/v1/users/me"
+    response = (admin_session if as_admin else session).patch(
+        f"{DOJO_URL}{endpoint}", json={"email": email.lower(), "confirm": name}
+    )
+    assert response.status_code == 400, response.text
+    assert "email" in response.json()["errors"]
+    assert db_sql(f"SELECT email FROM users WHERE name = '{name}'").strip() == f"{name}@example.com"
+
+
 def test_api_register_creates_user_and_session():
     name = rand_name()
     session = anon_session()

--- a/test/test_scoreboard_api.py
+++ b/test/test_scoreboard_api.py
@@ -440,6 +440,26 @@ def test_scoreboard_symbol_by_email_domain(sb_main):
         assert "email" not in entry, "the email used to pick the symbol must not be returned"
 
 
+def test_scoreboard_symbol_email_case_insensitive():
+    expected = {
+        "student@asu.edu": "fork.png",
+        "Student@ASU.EDU": "fork.png",
+        "student@mit.edu": "student.png",
+        "Student@MIT.EDU": "student.png",
+        "student@example.edu.au": "student.png",
+        "Student@Example.EDU.AU": "student.png",
+        "Hacker@Example.COM": "hacker.png",
+    }
+    result = json.loads(sb_flask_exec(
+        "import json\n"
+        "from flask import current_app\n"
+        "from CTFd.plugins.dojo_plugin.api.v1.scoreboard import email_symbol_asset\n"
+        "with current_app.test_request_context():\n"
+        f"    print(json.dumps({{email: email_symbol_asset(email) for email in {list(expected)!r}}}))\n"
+    ))
+    assert {email: asset_name(url) for email, url in result.items()} == expected
+
+
 def test_scoreboard_me_entry(sb_main):
     session = sb_main["sessions"][sb_main["alice"]]
     result = board(session, sb_main["dojo"])


### PR DESCRIPTION
Make user email comparisons case-insensitive while preserving stored capitalization.

- Apply case-insensitive equality through the `Users.email` type so existing lookups and uniqueness checks agree.
- Allow case-only edits to a user's own email address.
- Add a unique `lower(email)` index to the model and initial schema migration for fresh installations.
- Make ASU/student badge selection case-insensitive.

Existing PostgreSQL installations need the index applied manually after resolving any case-insensitive duplicates. Email-domain allowlist behavior is unchanged.

Validation: 18 focused local checks passed using patched CTFd and an isolated PostgreSQL instance, covering email comparisons, registration and edits, index enforcement, fresh/existing database behavior, and badge selection. The full dojo test suite was not run locally.
