### PR TITLE
Fix workspace description scrolling

### DIFF
--- a/dojo_theme/templates/workspace.html
+++ b/dojo_theme/templates/workspace.html
@@ -24,6 +24,7 @@
 
     main {
         flex: auto;
+        min-height: 0;
         margin: 0;
         display: flex;
         flex-direction: column;
@@ -37,6 +38,7 @@
 
     .challenge-workspace {
         flex: auto;
+        min-height: 0;
         display:flex;
         flex-direction: column;
     }


### PR DESCRIPTION
Long descriptions on `/workspace` can be clipped instead of scrolling because the parent flex items retain their automatic minimum height. Add `min-height: 0` to `main` and `.challenge-workspace` in the workspace template so they can shrink to the available viewport height and the description's existing `overflow: auto` can take effect.

Validation: `git diff --check` passed. Browser verification is still needed for a long description (for example, Linux Luminarium's Listing Processes), Terminal, Code, Desktop, SSH, and fullscreen mode; these views share the affected parent containers.
