### PR TITLE
Workspace: include hicolor fallback icon theme

### DIFF
--- a/workspace/services/desktop.nix
+++ b/workspace/services/desktop.nix
@@ -72,6 +72,7 @@ let
       dconf
       dejavu_fonts
       blackbird
+      hicolor-icon-theme
     ];
   };
 


### PR DESCRIPTION
The workspace desktop shows missing icons for Firefox, Binary Ninja, Ghidra, and Wireshark because their images are installed under `share/icons/hicolor`, but the theme's `index.theme` is absent from the desktop's search paths.

Include `hicolor-icon-theme` explicitly in the XFCE bundle so the desktop service installs the fallback theme metadata in both core and full workspaces.

Validation:
- Built the desktop-service derivation using the workspace's pinned Nixpkgs and verified its output contains `share/icons/hicolor/index.theme`.
- In an isolated GTK lookup test against the affected workspace, all four application icons failed with the current search paths and resolved when the hicolor theme directory was added.
- `git diff --check` passed.
